### PR TITLE
Add `EndOfEpochData::epoch_supply_change` field

### DIFF
--- a/crates/iota-rust-sdk/src/types/checkpoint.rs
+++ b/crates/iota-rust-sdk/src/types/checkpoint.rs
@@ -48,7 +48,7 @@ pub struct EndOfEpochData {
 
     /// Commitments to epoch specific state (e.g. live object set)
     pub epoch_commitments: Vec<CheckpointCommitment>,
-    
+
     /// The number of tokens that were minted (if positive) or burnt (if
     /// negative) in this epoch.
     pub epoch_supply_change: i64,


### PR DESCRIPTION
# Description

Adds a missing field to `EndOfEpochData` to match the type in `iota-types`.
https://github.com/iotaledger/iota/blob/edfd8423db78e8318243f4ca23eef0d0d1f25990/crates/iota-types/src/messages_checkpoint.rs#L143