### PR TITLE
feat: remove the `DenyListStateCreate` transaction

### DIFF
--- a/crates/iota-rust-sdk/src/types/transaction/mod.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/mod.rs
@@ -135,7 +135,6 @@ pub enum EndOfEpochTransactionKind {
     ChangeEpoch(ChangeEpoch),
     AuthenticatorStateCreate,
     AuthenticatorStateExpire(AuthenticatorStateExpire),
-    DenyListStateCreate,
     BridgeStateCreate {
         chain_id: super::CheckpointDigest,
     },

--- a/crates/iota-rust-sdk/src/types/transaction/serialization.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/serialization.rs
@@ -290,7 +290,6 @@ mod end_of_epoch {
         ChangeEpoch(&'a ChangeEpoch),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
-        DenyListStateCreate,
         BridgeStateCreate {
             chain_id: &'a CheckpointDigest,
         },
@@ -306,7 +305,6 @@ mod end_of_epoch {
         ChangeEpoch(ChangeEpoch),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(AuthenticatorStateExpire),
-        DenyListStateCreate,
         BridgeStateCreate {
             chain_id: CheckpointDigest,
         },
@@ -321,7 +319,6 @@ mod end_of_epoch {
         ChangeEpoch(&'a ChangeEpoch),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
-        DenyListStateCreate,
         BridgeStateCreate { chain_id: &'a CheckpointDigest },
         BridgeCommitteeInit { bridge_object_version: u64 },
     }
@@ -331,7 +328,6 @@ mod end_of_epoch {
         ChangeEpoch(ChangeEpoch),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(AuthenticatorStateExpire),
-        DenyListStateCreate,
         BridgeStateCreate { chain_id: CheckpointDigest },
         BridgeCommitteeInit { bridge_object_version: u64 },
     }
@@ -349,9 +345,6 @@ mod end_of_epoch {
                     }
                     Self::AuthenticatorStateExpire(k) => {
                         ReadableEndOfEpochTransactionKindRef::AuthenticatorStateExpire(k)
-                    }
-                    Self::DenyListStateCreate => {
-                        ReadableEndOfEpochTransactionKindRef::DenyListStateCreate
                     }
                     Self::BridgeStateCreate { chain_id } => {
                         ReadableEndOfEpochTransactionKindRef::BridgeStateCreate { chain_id }
@@ -371,9 +364,6 @@ mod end_of_epoch {
                     }
                     Self::AuthenticatorStateExpire(k) => {
                         BinaryEndOfEpochTransactionKindRef::AuthenticatorStateExpire(k)
-                    }
-                    Self::DenyListStateCreate => {
-                        BinaryEndOfEpochTransactionKindRef::DenyListStateCreate
                     }
                     Self::BridgeStateCreate { chain_id } => {
                         BinaryEndOfEpochTransactionKindRef::BridgeStateCreate { chain_id }
@@ -404,9 +394,6 @@ mod end_of_epoch {
                         ReadableEndOfEpochTransactionKind::AuthenticatorStateExpire(k) => {
                             Self::AuthenticatorStateExpire(k)
                         }
-                        ReadableEndOfEpochTransactionKind::DenyListStateCreate => {
-                            Self::DenyListStateCreate
-                        }
                         ReadableEndOfEpochTransactionKind::BridgeStateCreate { chain_id } => {
                             Self::BridgeStateCreate { chain_id }
                         }
@@ -426,9 +413,6 @@ mod end_of_epoch {
                         }
                         BinaryEndOfEpochTransactionKind::AuthenticatorStateExpire(k) => {
                             Self::AuthenticatorStateExpire(k)
-                        }
-                        BinaryEndOfEpochTransactionKind::DenyListStateCreate => {
-                            Self::DenyListStateCreate
                         }
                         BinaryEndOfEpochTransactionKind::BridgeStateCreate { chain_id } => {
                             Self::BridgeStateCreate { chain_id }


### PR DESCRIPTION
The transaction kind was removed since it is outdated.