### PR TITLE
rename: fix capitalization (`Iota` to `IOTA`)

### DIFF
--- a/crates/iota-rust-sdk/src/hash.rs
+++ b/crates/iota-rust-sdk/src/hash.rs
@@ -225,7 +225,7 @@ mod type_digest {
     }
 }
 
-/// A 1-byte domain separator for hashing Object ID in Iota. It is starting from
+/// A 1-byte domain separator for hashing Object ID in IOTA. It is starting from
 /// 0xf0 to ensure no hashing collision for any ObjectId vs Address which is
 /// derived as the hash of `flag || pubkey`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]

--- a/crates/iota-rust-sdk/src/types/address.rs
+++ b/crates/iota-rust-sdk/src/types/address.rs
@@ -207,7 +207,7 @@ impl schemars::JsonSchema for Address {
         SchemaObject {
             metadata: Some(Box::new(Metadata {
                 title: Some(Self::schema_name()),
-                description: Some("A 32-byte Iota address, encoded as a hex string.".to_owned()),
+                description: Some("A 32-byte IOTA address, encoded as a hex string.".to_owned()),
                 examples: vec![serde_json::to_value(Address::TWO).unwrap()],
                 ..Default::default()
             })),

--- a/crates/iota-rust-sdk/src/types/crypto/passkey.rs
+++ b/crates/iota-rust-sdk/src/types/crypto/passkey.rs
@@ -262,7 +262,7 @@ mod serialization {
     pub enum ClientDataType {
         /// Serializes to the string `"webauthn.get"`
         ///
-        /// Passkey's in Iota only support the value `"webauthn.get"`, other
+        /// Passkey's in IOTA only support the value `"webauthn.get"`, other
         /// values will be rejected.
         #[serde(rename = "webauthn.get")]
         Get,

--- a/crates/iota-rust-sdk/src/types/digest.rs
+++ b/crates/iota-rust-sdk/src/types/digest.rs
@@ -133,7 +133,7 @@ impl std::fmt::LowerHex for Digest {
     }
 }
 
-// Unfortunately iota's binary representation of digests is prefixed with its
+// Unfortunately IOTA's binary representation of digests is prefixed with its
 // length meaning its serialized binary form is 33 bytes long (in bcs) vs a more
 // compact 32 bytes.
 #[cfg(feature = "serde")]

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -64,7 +64,7 @@ pub enum ExecutionError {
     /// The modules in the package must have their self-addresses set to zero.
     PublishErrorNonZeroAddress,
 
-    /// Iota Move Bytecode Verification Error.
+    /// IOTA Move Bytecode Verification Error.
     IotaMoveVerificationError,
 
     // MoveVm Errors
@@ -146,7 +146,7 @@ pub enum ExecutionError {
     /// Certificate is on the deny list
     CertificateDenied,
 
-    /// Iota Move Bytecode verification timed out.
+    /// IOTA Move Bytecode verification timed out.
     IotaMoveVerificationTimeout,
 
     /// The requested shared object operation is not allowed

--- a/crates/iota-rust-sdk/src/types/object.rs
+++ b/crates/iota-rust-sdk/src/types/object.rs
@@ -92,7 +92,7 @@ pub enum ObjectData {
     Struct(MoveStruct),
     /// Map from each module name to raw serialized Move module bytes
     Package(MovePackage),
-    // ... Iota "native" types go here
+    // ... IOTA "native" types go here
 }
 
 // serde_bytes::ByteBuf is an analog of Vec<u8> with built-in fast
@@ -204,7 +204,7 @@ pub struct MoveStruct {
     pub contents: Vec<u8>,
 }
 
-/// Type of a Iota object
+/// Type of an IOTA object
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum ObjectType {
     /// Move package containing one or more bytecode modules
@@ -352,7 +352,7 @@ mod serialization {
     enum MoveStructType {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(StructTag),
-        /// A IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
+        /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
         GasCoin,
         /// A record of a staked IOTA coin (i.e.,
         /// `0x3::staking_pool::StakedIota`)
@@ -370,7 +370,7 @@ mod serialization {
     enum MoveStructTypeRef<'a> {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(&'a StructTag),
-        /// A IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
+        /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
         GasCoin,
         /// A record of a staked IOTA coin (i.e.,
         /// `0x3::staking_pool::StakedIota`)


### PR DESCRIPTION
Same as in the `iota` repository. We need this change, otherwise the auto-generated API specs still contain the wrong capitalization.