### PR TITLE
feat: include gas price feedback in the execution error for transactions cancelled due to congestion

### DIFF
--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -42,7 +42,7 @@ bnum = "0.11.0"
 bs58 = "0.5.1"
 hex = "0.4.3"
 roaring = { version = "0.10.6", default-features = false }
-winnow = "0.6.26"
+winnow = "0.6.18"
 
 # Serialization and Deserialization support
 bcs = { version = "0.1.6", optional = true }

--- a/crates/iota-rust-sdk/Cargo.toml
+++ b/crates/iota-rust-sdk/Cargo.toml
@@ -42,7 +42,7 @@ bnum = "0.11.0"
 bs58 = "0.5.1"
 hex = "0.4.3"
 roaring = { version = "0.10.6", default-features = false }
-winnow = "0.6.18"
+winnow = "0.6.26"
 
 # Serialization and Deserialization support
 bcs = { version = "0.1.6", optional = true }

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -158,6 +158,13 @@ pub enum ExecutionError {
     /// Certificate is cancelled due to congestion on shared objects
     ExecutionCancelledDueToSharedObjectCongestion { congested_objects: Vec<ObjectId> },
 
+    /// Certificate is cancelled due to congestion on shared objects;
+    /// suggested gas price can be used to give this certificate more priority.
+    ExecutionCancelledDueToSharedObjectCongestionV2 {
+        congested_objects: Vec<ObjectId>,
+        suggested_gas_price: u64,
+    },
+
     /// Address is denied for this coin type
     AddressDeniedForCoin { address: Address, coin_type: String },
 
@@ -167,13 +174,6 @@ pub enum ExecutionError {
     /// Certificate is cancelled because randomness could not be generated this
     /// epoch
     ExecutionCancelledDueToRandomnessUnavailable,
-
-    /// Certificate is cancelled due to congestion on shared objects;
-    /// suggested gas price can be used to give this certificate more priority.
-    ExecutionCancelledDueToSharedObjectCongestionV2 {
-        congested_objects: Vec<ObjectId>,
-        suggested_gas_price: u64,
-    },
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -156,10 +156,10 @@ pub enum ExecutionError {
     InputObjectDeleted,
 
     /// Certificate is cancelled due to congestion on shared objects
-    ExecutionCancelledDueToSharedObjectCongestion {
-        congested_objects: Vec<ObjectId>,
-        suggested_gas_price: u64,
-    },
+    // NOTE: this error is obsolete but kept for backward compatibility;
+    // instead, use `ExecutionCancelledDueToSharedObjectCongestionV1`, which
+    // includes gas price feedback for transactions cancelled due to congestion
+    ExecutionCancelledDueToSharedObjectCongestion { congested_objects: Vec<ObjectId> },
 
     /// Address is denied for this coin type
     AddressDeniedForCoin { address: Address, coin_type: String },
@@ -170,6 +170,16 @@ pub enum ExecutionError {
     /// Certificate is cancelled because randomness could not be generated this
     /// epoch
     ExecutionCancelledDueToRandomnessUnavailable,
+
+    /// Certificate is cancelled due to congestion on shared objects.
+    /// Except congested shared objects, this error also contains gas
+    /// price feedback: the lowest gas price of a non-cancelled transaction
+    /// (that operates on at least one of these congested objects)
+    /// in the same consensus commit round
+    ExecutionCancelledDueToSharedObjectCongestionV1 {
+        congested_objects: Vec<ObjectId>,
+        lowest_gas_price_of_non_cancelled_transaction: u64,
+    },
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]
@@ -461,7 +471,6 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
-            suggested_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -474,6 +483,11 @@ mod serialization {
         },
 
         ExecutionCancelledDueToRandomnessUnavailable,
+
+        ExecutionCancelledDueToSharedObjectCongestionV1 {
+            congested_objects: Vec<ObjectId>,
+            lowest_gas_price_of_non_cancelled_transaction: u64,
+        },
     }
 
     #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
@@ -545,7 +559,6 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
-            suggested_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -558,6 +571,11 @@ mod serialization {
         },
 
         ExecutionCancelledDueToRandomnessUnavailable,
+
+        ExecutionCancelledDueToSharedObjectCongestionV1 {
+            congested_objects: Vec<ObjectId>,
+            lowest_gas_price_of_non_cancelled_transaction: u64,
+        },
     }
 
     impl Serialize for ExecutionError {
@@ -662,13 +680,11 @@ mod serialization {
                         ReadableExecutionError::SharedObjectOperationNotAllowed
                     }
                     Self::InputObjectDeleted => ReadableExecutionError::InputObjectDeleted,
-                    Self::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    },
+                    Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects } => {
+                        ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
+                            congested_objects,
+                        }
+                    }
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         ReadableExecutionError::AddressDeniedForCoin { address, coin_type }
                     }
@@ -678,6 +694,13 @@ mod serialization {
                     Self::ExecutionCancelledDueToRandomnessUnavailable => {
                         ReadableExecutionError::ExecutionCancelledDueToRandomnessUnavailable
                     }
+                    Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    },
                 };
                 readable.serialize(serializer)
             } else {
@@ -773,13 +796,11 @@ mod serialization {
                         BinaryExecutionError::SharedObjectOperationNotAllowed
                     }
                     Self::InputObjectDeleted => BinaryExecutionError::InputObjectDeleted,
-                    Self::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    },
+                    Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects } => {
+                        BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
+                            congested_objects,
+                        }
+                    }
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         BinaryExecutionError::AddressDeniedForCoin { address, coin_type }
                     }
@@ -789,6 +810,13 @@ mod serialization {
                     Self::ExecutionCancelledDueToRandomnessUnavailable => {
                         BinaryExecutionError::ExecutionCancelledDueToRandomnessUnavailable
                     }
+                    Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    },
                 };
                 binary.serialize(serializer)
             }
@@ -899,11 +927,7 @@ mod serialization {
                     ReadableExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        suggested_gas_price,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    },
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects },
                     ReadableExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }
                     }
@@ -913,6 +937,13 @@ mod serialization {
                     ReadableExecutionError::ExecutionCancelledDueToRandomnessUnavailable => {
                         Self::ExecutionCancelledDueToRandomnessUnavailable
                     }
+                    ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    },
                 })
             } else {
                 BinaryExecutionError::deserialize(deserializer).map(|binary| match binary {
@@ -1009,11 +1040,7 @@ mod serialization {
                     BinaryExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        suggested_gas_price,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestion {
-                        congested_objects,
-                        suggested_gas_price,
-                    },
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects },
                     BinaryExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }
                     }
@@ -1023,6 +1050,13 @@ mod serialization {
                     BinaryExecutionError::ExecutionCancelledDueToRandomnessUnavailable => {
                         Self::ExecutionCancelledDueToRandomnessUnavailable
                     }
+                    BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                        congested_objects,
+                        lowest_gas_price_of_non_cancelled_transaction,
+                    },
                 })
             }
         }

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -156,9 +156,6 @@ pub enum ExecutionError {
     InputObjectDeleted,
 
     /// Certificate is cancelled due to congestion on shared objects
-    // NOTE: this error is obsolete but kept for backward compatibility;
-    // instead, use `ExecutionCancelledDueToSharedObjectCongestionV1`, which
-    // includes gas price feedback for transactions cancelled due to congestion
     ExecutionCancelledDueToSharedObjectCongestion { congested_objects: Vec<ObjectId> },
 
     /// Address is denied for this coin type
@@ -173,7 +170,7 @@ pub enum ExecutionError {
 
     /// Certificate is cancelled due to congestion on shared objects;
     /// suggested gas price can be used to give this certificate more priority.
-    ExecutionCancelledDueToSharedObjectCongestionV1 {
+    ExecutionCancelledDueToSharedObjectCongestionV2 {
         congested_objects: Vec<ObjectId>,
         suggested_gas_price: u64,
     },
@@ -481,7 +478,7 @@ mod serialization {
 
         ExecutionCancelledDueToRandomnessUnavailable,
 
-        ExecutionCancelledDueToSharedObjectCongestionV1 {
+        ExecutionCancelledDueToSharedObjectCongestionV2 {
             congested_objects: Vec<ObjectId>,
             suggested_gas_price: u64,
         },
@@ -569,7 +566,7 @@ mod serialization {
 
         ExecutionCancelledDueToRandomnessUnavailable,
 
-        ExecutionCancelledDueToSharedObjectCongestionV1 {
+        ExecutionCancelledDueToSharedObjectCongestionV2 {
             congested_objects: Vec<ObjectId>,
             suggested_gas_price: u64,
         },
@@ -691,10 +688,10 @@ mod serialization {
                     Self::ExecutionCancelledDueToRandomnessUnavailable => {
                         ReadableExecutionError::ExecutionCancelledDueToRandomnessUnavailable
                     }
-                    Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    Self::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
-                    } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
                     },
@@ -807,10 +804,10 @@ mod serialization {
                     Self::ExecutionCancelledDueToRandomnessUnavailable => {
                         BinaryExecutionError::ExecutionCancelledDueToRandomnessUnavailable
                     }
-                    Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    Self::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
-                    } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
                     },
@@ -934,10 +931,10 @@ mod serialization {
                     ReadableExecutionError::ExecutionCancelledDueToRandomnessUnavailable => {
                         Self::ExecutionCancelledDueToRandomnessUnavailable
                     }
-                    ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
                     },
@@ -1047,10 +1044,10 @@ mod serialization {
                     BinaryExecutionError::ExecutionCancelledDueToRandomnessUnavailable => {
                         Self::ExecutionCancelledDueToRandomnessUnavailable
                     }
-                    BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestionV2 {
                         congested_objects,
                         suggested_gas_price,
                     },

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -156,7 +156,10 @@ pub enum ExecutionError {
     InputObjectDeleted,
 
     /// Certificate is cancelled due to congestion on shared objects
-    ExecutionCancelledDueToSharedObjectCongestion { congested_objects: Vec<ObjectId> },
+    ExecutionCancelledDueToSharedObjectCongestion {
+        congested_objects: Vec<ObjectId>,
+        recommended_gas_price: u64,
+    },
 
     /// Address is denied for this coin type
     AddressDeniedForCoin { address: Address, coin_type: String },
@@ -458,6 +461,7 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
+            recommended_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -541,6 +545,7 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
+            recommended_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -657,11 +662,13 @@ mod serialization {
                         ReadableExecutionError::SharedObjectOperationNotAllowed
                     }
                     Self::InputObjectDeleted => ReadableExecutionError::InputObjectDeleted,
-                    Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects } => {
-                        ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
-                            congested_objects,
-                        }
-                    }
+                    Self::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    },
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         ReadableExecutionError::AddressDeniedForCoin { address, coin_type }
                     }
@@ -766,11 +773,13 @@ mod serialization {
                         BinaryExecutionError::SharedObjectOperationNotAllowed
                     }
                     Self::InputObjectDeleted => BinaryExecutionError::InputObjectDeleted,
-                    Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects } => {
-                        BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
-                            congested_objects,
-                        }
-                    }
+                    Self::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    },
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         BinaryExecutionError::AddressDeniedForCoin { address, coin_type }
                     }
@@ -890,7 +899,11 @@ mod serialization {
                     ReadableExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects },
+                        recommended_gas_price,
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    },
                     ReadableExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }
                     }
@@ -996,7 +1009,11 @@ mod serialization {
                     BinaryExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                    } => Self::ExecutionCancelledDueToSharedObjectCongestion { congested_objects },
+                        recommended_gas_price,
+                    } => Self::ExecutionCancelledDueToSharedObjectCongestion {
+                        congested_objects,
+                        recommended_gas_price,
+                    },
                     BinaryExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }
                     }

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -171,14 +171,11 @@ pub enum ExecutionError {
     /// epoch
     ExecutionCancelledDueToRandomnessUnavailable,
 
-    // Except congested shared objects, this error also contains gas
-    // price feedback: the lowest gas price of a non-cancelled transaction
-    // (that operates on at least one of these congested objects)
-    // in the same consensus commit round
-    /// Certificate is cancelled due to congestion on shared objects.
+    /// Certificate is cancelled due to congestion on shared objects;
+    /// suggested gas price can be used to give this certificate more priority.
     ExecutionCancelledDueToSharedObjectCongestionV1 {
         congested_objects: Vec<ObjectId>,
-        lowest_gas_price_of_non_cancelled_transaction: u64,
+        suggested_gas_price: u64,
     },
 }
 
@@ -486,7 +483,7 @@ mod serialization {
 
         ExecutionCancelledDueToSharedObjectCongestionV1 {
             congested_objects: Vec<ObjectId>,
-            lowest_gas_price_of_non_cancelled_transaction: u64,
+            suggested_gas_price: u64,
         },
     }
 
@@ -574,7 +571,7 @@ mod serialization {
 
         ExecutionCancelledDueToSharedObjectCongestionV1 {
             congested_objects: Vec<ObjectId>,
-            lowest_gas_price_of_non_cancelled_transaction: u64,
+            suggested_gas_price: u64,
         },
     }
 
@@ -696,10 +693,10 @@ mod serialization {
                     }
                     Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     },
                 };
                 readable.serialize(serializer)
@@ -812,10 +809,10 @@ mod serialization {
                     }
                     Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     },
                 };
                 binary.serialize(serializer)
@@ -939,10 +936,10 @@ mod serialization {
                     }
                     ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     },
                 })
             } else {
@@ -1052,10 +1049,10 @@ mod serialization {
                     }
                     BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     } => Self::ExecutionCancelledDueToSharedObjectCongestionV1 {
                         congested_objects,
-                        lowest_gas_price_of_non_cancelled_transaction,
+                        suggested_gas_price,
                     },
                 })
             }

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -171,11 +171,11 @@ pub enum ExecutionError {
     /// epoch
     ExecutionCancelledDueToRandomnessUnavailable,
 
+    // Except congested shared objects, this error also contains gas
+    // price feedback: the lowest gas price of a non-cancelled transaction
+    // (that operates on at least one of these congested objects)
+    // in the same consensus commit round
     /// Certificate is cancelled due to congestion on shared objects.
-    /// Except congested shared objects, this error also contains gas
-    /// price feedback: the lowest gas price of a non-cancelled transaction
-    /// (that operates on at least one of these congested objects)
-    /// in the same consensus commit round
     ExecutionCancelledDueToSharedObjectCongestionV1 {
         congested_objects: Vec<ObjectId>,
         lowest_gas_price_of_non_cancelled_transaction: u64,

--- a/crates/iota-rust-sdk/src/types/execution_status.rs
+++ b/crates/iota-rust-sdk/src/types/execution_status.rs
@@ -158,7 +158,7 @@ pub enum ExecutionError {
     /// Certificate is cancelled due to congestion on shared objects
     ExecutionCancelledDueToSharedObjectCongestion {
         congested_objects: Vec<ObjectId>,
-        recommended_gas_price: u64,
+        suggested_gas_price: u64,
     },
 
     /// Address is denied for this coin type
@@ -461,7 +461,7 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
-            recommended_gas_price: u64,
+            suggested_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -545,7 +545,7 @@ mod serialization {
         InputObjectDeleted,
         ExecutionCancelledDueToSharedObjectCongestion {
             congested_objects: Vec<ObjectId>,
-            recommended_gas_price: u64,
+            suggested_gas_price: u64,
         },
 
         AddressDeniedForCoin {
@@ -664,10 +664,10 @@ mod serialization {
                     Self::InputObjectDeleted => ReadableExecutionError::InputObjectDeleted,
                     Self::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     } => ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     },
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         ReadableExecutionError::AddressDeniedForCoin { address, coin_type }
@@ -775,10 +775,10 @@ mod serialization {
                     Self::InputObjectDeleted => BinaryExecutionError::InputObjectDeleted,
                     Self::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     } => BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     },
                     Self::AddressDeniedForCoin { address, coin_type } => {
                         BinaryExecutionError::AddressDeniedForCoin { address, coin_type }
@@ -899,10 +899,10 @@ mod serialization {
                     ReadableExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     ReadableExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     } => Self::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     },
                     ReadableExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }
@@ -1009,10 +1009,10 @@ mod serialization {
                     BinaryExecutionError::InputObjectDeleted => Self::InputObjectDeleted,
                     BinaryExecutionError::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     } => Self::ExecutionCancelledDueToSharedObjectCongestion {
                         congested_objects,
-                        recommended_gas_price,
+                        suggested_gas_price,
                     },
                     BinaryExecutionError::AddressDeniedForCoin { address, coin_type } => {
                         Self::AddressDeniedForCoin { address, coin_type }

--- a/crates/iota-rust-sdk/src/types/object.rs
+++ b/crates/iota-rust-sdk/src/types/object.rs
@@ -645,7 +645,7 @@ mod serialization {
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
                         // check id matches in contents
-                        if !id_opt(&contents).is_some_and(|id| id == object_id) {
+                        if id_opt(&contents).is_none_or(|id| id != object_id) {
                             return Err(serde::de::Error::custom("id from contents doesn't match"));
                         }
 
@@ -799,7 +799,7 @@ mod serialization {
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
                         // check id matches in contents
-                        if !id_opt(&contents).is_some_and(|id| id == object_id) {
+                        if id_opt(&contents).is_none_or(|id| id != object_id) {
                             return Err(serde::de::Error::custom("id from contents doesn't match"));
                         }
 

--- a/crates/iota-rust-sdk/src/types/type_tag/parse.rs
+++ b/crates/iota-rust-sdk/src/types/type_tag/parse.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    PResult, Parser,
+    ModalResult, Parser,
     ascii::space0,
     combinator::{alt, delimited, eof, opt, separated},
     stream::AsChar,
@@ -12,11 +12,11 @@ use super::{Address, Identifier, StructTag, TypeTag};
 // r"(?:[a-zA-Z][a-zA-Z0-9_]*)|(?:_[a-zA-Z0-9_]+)";
 static MAX_IDENTIFIER_LENGTH: usize = 128;
 
-pub(super) fn parse_identifier(mut input: &str) -> PResult<&str> {
+pub(super) fn parse_identifier(mut input: &str) -> ModalResult<&str> {
     (identifier, eof).take().parse_next(&mut input)
 }
 
-fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
+fn identifier<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
     alt((
         (one_of(|c: char| c.is_alpha()), valid_remainder(0)),
         ('_', valid_remainder(1)),
@@ -38,17 +38,17 @@ fn valid_remainder<'a>(
     }
 }
 
-fn parse_address<'s>(input: &mut &'s str) -> PResult<&'s str> {
+fn parse_address<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
     ("0x", take_while(1..=64, AsChar::is_hex_digit))
         .take()
         .parse_next(input)
 }
 
-pub(super) fn parse_type_tag(mut input: &str) -> PResult<TypeTag> {
+pub(super) fn parse_type_tag(mut input: &str) -> ModalResult<TypeTag> {
     (type_tag, eof).parse_next(&mut input).map(|(t, _)| t)
 }
 
-fn type_tag(input: &mut &str) -> PResult<TypeTag> {
+fn type_tag(input: &mut &str) -> ModalResult<TypeTag> {
     alt((
         "u8".value(TypeTag::U8),
         "u16".value(TypeTag::U16),
@@ -65,11 +65,11 @@ fn type_tag(input: &mut &str) -> PResult<TypeTag> {
     .parse_next(input)
 }
 
-pub(super) fn parse_struct_tag(mut input: &str) -> PResult<StructTag> {
+pub(super) fn parse_struct_tag(mut input: &str) -> ModalResult<StructTag> {
     (struct_tag, eof).parse_next(&mut input).map(|(s, _)| s)
 }
 
-fn struct_tag(input: &mut &str) -> PResult<StructTag> {
+fn struct_tag(input: &mut &str) -> ModalResult<StructTag> {
     let (address, _, module, _, name) = (
         parse_address.try_map(|s| s.parse::<Address>()),
         "::",
@@ -92,7 +92,7 @@ fn struct_tag(input: &mut &str) -> PResult<StructTag> {
     })
 }
 
-fn generics(input: &mut &str) -> PResult<Vec<TypeTag>> {
+fn generics(input: &mut &str) -> ModalResult<Vec<TypeTag>> {
     separated(1.., delimited(space0, type_tag, space0), ",").parse_next(input)
 }
 

--- a/crates/iota-rust-sdk/src/types/type_tag/parse.rs
+++ b/crates/iota-rust-sdk/src/types/type_tag/parse.rs
@@ -1,5 +1,5 @@
 use winnow::{
-    ModalResult, Parser,
+    PResult, Parser,
     ascii::space0,
     combinator::{alt, delimited, eof, opt, separated},
     stream::AsChar,
@@ -12,11 +12,11 @@ use super::{Address, Identifier, StructTag, TypeTag};
 // r"(?:[a-zA-Z][a-zA-Z0-9_]*)|(?:_[a-zA-Z0-9_]+)";
 static MAX_IDENTIFIER_LENGTH: usize = 128;
 
-pub(super) fn parse_identifier(mut input: &str) -> ModalResult<&str> {
+pub(super) fn parse_identifier(mut input: &str) -> PResult<&str> {
     (identifier, eof).take().parse_next(&mut input)
 }
 
-fn identifier<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+fn identifier<'s>(input: &mut &'s str) -> PResult<&'s str> {
     alt((
         (one_of(|c: char| c.is_alpha()), valid_remainder(0)),
         ('_', valid_remainder(1)),
@@ -38,17 +38,17 @@ fn valid_remainder<'a>(
     }
 }
 
-fn parse_address<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+fn parse_address<'s>(input: &mut &'s str) -> PResult<&'s str> {
     ("0x", take_while(1..=64, AsChar::is_hex_digit))
         .take()
         .parse_next(input)
 }
 
-pub(super) fn parse_type_tag(mut input: &str) -> ModalResult<TypeTag> {
+pub(super) fn parse_type_tag(mut input: &str) -> PResult<TypeTag> {
     (type_tag, eof).parse_next(&mut input).map(|(t, _)| t)
 }
 
-fn type_tag(input: &mut &str) -> ModalResult<TypeTag> {
+fn type_tag(input: &mut &str) -> PResult<TypeTag> {
     alt((
         "u8".value(TypeTag::U8),
         "u16".value(TypeTag::U16),
@@ -65,11 +65,11 @@ fn type_tag(input: &mut &str) -> ModalResult<TypeTag> {
     .parse_next(input)
 }
 
-pub(super) fn parse_struct_tag(mut input: &str) -> ModalResult<StructTag> {
+pub(super) fn parse_struct_tag(mut input: &str) -> PResult<StructTag> {
     (struct_tag, eof).parse_next(&mut input).map(|(s, _)| s)
 }
 
-fn struct_tag(input: &mut &str) -> ModalResult<StructTag> {
+fn struct_tag(input: &mut &str) -> PResult<StructTag> {
     let (address, _, module, _, name) = (
         parse_address.try_map(|s| s.parse::<Address>()),
         "::",
@@ -92,7 +92,7 @@ fn struct_tag(input: &mut &str) -> ModalResult<StructTag> {
     })
 }
 
-fn generics(input: &mut &str) -> ModalResult<Vec<TypeTag>> {
+fn generics(input: &mut &str) -> PResult<Vec<TypeTag>> {
     separated(1.., delimited(space0, type_tag, space0), ",").parse_next(input)
 }
 


### PR DESCRIPTION
This PR extends `ExecutionCancelledDueToSharedObjectCongestion` to include gas price feedback in the execution error for transactions cancelled due to shared object congestion. It is needed for https://github.com/iotaledger/iota/issues/6206.

> [!IMPORTANT]
> This PR should only be merged after https://github.com/iotaledger/iota/pull/6280 is accepted.