### PR TITLE
upstream(types): Add new execution status

### DIFF
--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -278,6 +278,10 @@ pub enum ExecutionError {
     /// Certificate is cancelled because randomness could not be generated this
     /// epoch
     ExecutionCancelledDueToRandomnessUnavailable,
+
+    /// A valid linkage was unable to be determined for the transaction or one
+    /// of its commands.
+    InvalidLinkage,
 }
 
 /// Location in move bytecode where an error occurred
@@ -689,6 +693,8 @@ mod serialization {
             congested_objects: Vec<ObjectId>,
             suggested_gas_price: u64,
         },
+
+        InvalidLinkage,
     }
 
     #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
@@ -777,6 +783,8 @@ mod serialization {
             congested_objects: Vec<ObjectId>,
             suggested_gas_price: u64,
         },
+
+        InvalidLinkage,
     }
 
     impl Serialize for ExecutionError {
@@ -902,6 +910,7 @@ mod serialization {
                         congested_objects,
                         suggested_gas_price,
                     },
+                    Self::InvalidLinkage => ReadableExecutionError::InvalidLinkage,
                 };
                 readable.serialize(serializer)
             } else {
@@ -1018,6 +1027,7 @@ mod serialization {
                         congested_objects,
                         suggested_gas_price,
                     },
+                    Self::InvalidLinkage => BinaryExecutionError::InvalidLinkage,
                 };
                 binary.serialize(serializer)
             }
@@ -1145,6 +1155,7 @@ mod serialization {
                         congested_objects,
                         suggested_gas_price,
                     },
+                    ReadableExecutionError::InvalidLinkage => Self::InvalidLinkage,
                 })
             } else {
                 BinaryExecutionError::deserialize(deserializer).map(|binary| match binary {
@@ -1258,6 +1269,7 @@ mod serialization {
                         congested_objects,
                         suggested_gas_price,
                     },
+                    BinaryExecutionError::InvalidLinkage => Self::InvalidLinkage,
                 })
             }
         }


### PR DESCRIPTION
## Description

Adds the `InvalidLinkage` variant to execution errors.

See https://github.com/iotaledger/iota/pull/8046

Upstream https://github.com/MystenLabs/sui-rust-sdk/pull/111