### PR TITLE
fix(graphql-client): Fix an issue that can cause the `test_total_transaction_blocks` to fail randomly

### DIFF
--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -2319,9 +2319,9 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(
-            total_transaction_blocks,
-            total_transaction_blocks_by_seq_num
+        assert!(
+            total_transaction_blocks_by_seq_num > total_transaction_blocks,
+            "expected at least {total_transaction_blocks} transaction blocks, found {total_transaction_blocks_by_seq_num}"
         );
 
         let chckp = client

--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -2320,7 +2320,7 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(
-            total_transaction_blocks_by_seq_num > total_transaction_blocks,
+            total_transaction_blocks_by_seq_num >= total_transaction_blocks,
             "expected at least {total_transaction_blocks} transaction blocks, found {total_transaction_blocks_by_seq_num}"
         );
 


### PR DESCRIPTION
## Description

This test can now fail randomly if the queries are not fast enough and return different checkpoints. This fixes the problem by changing the assert.