### PR TITLE
fix(graphql): Fix transaction blocks test

### DIFF
--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -2336,7 +2336,10 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(total_transaction_blocks, total_transaction_blocks_by_digest);
+        assert_eq!(
+            total_transaction_blocks_by_seq_num,
+            total_transaction_blocks_by_digest
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

The test was still flaky because it was comparing the wrong vars.