### PR TITLE
chore(ffi): Remove all unnecessary derives

### DIFF
--- a/crates/iota-sdk-ffi/src/error.rs
+++ b/crates/iota-sdk-ffi/src/error.rs
@@ -3,11 +3,9 @@
 
 use std::fmt;
 
-use uniffi::Error;
-
 pub type Result<T, E = SdkFfiError> = std::result::Result<T, E>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, uniffi::Error)]
 #[uniffi(flat_error)]
 pub enum SdkFfiError {
     Generic(String),

--- a/crates/iota-sdk-ffi/src/faucet.rs
+++ b/crates/iota-sdk-ffi/src/faucet.rs
@@ -81,8 +81,8 @@ impl FaucetClient {
     }
 }
 
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct FaucetReceipt(pub iota_graphql_client::faucet::FaucetReceipt);
 
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct BatchSendStatus(pub iota_graphql_client::faucet::BatchSendStatus);

--- a/crates/iota-sdk-ffi/src/types/address.rs
+++ b/crates/iota-sdk-ffi/src/types/address.rs
@@ -56,7 +56,7 @@ use crate::error::Result;
 /// ```text
 /// address = 32OCTET
 /// ```
-#[derive(Copy, Clone, Debug, derive_more::From, derive_more::Deref, uniffi::Object)]
+#[derive(derive_more::From, derive_more::Deref, uniffi::Object)]
 pub struct Address(pub iota_types::Address);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/checkpoint.rs
+++ b/crates/iota-sdk-ffi/src/types/checkpoint.rs
@@ -55,7 +55,7 @@ pub type ProtocolVersion = u64;
 ///                      (option end-of-epoch-data)     ; end_of_epoch_data
 ///                      bytes                          ; version_specific_data
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct CheckpointSummary {
     /// Epoch that this checkpoint belongs to.
     pub epoch: u64,
@@ -144,7 +144,7 @@ impl From<CheckpointSummary> for iota_types::CheckpointSummary {
 /// checkpoint-commitment = ecmh-live-object-set
 /// ecmh-live-object-set = %x00 digest
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct CheckpointCommitment(pub iota_types::CheckpointCommitment);
 
 #[uniffi::export]
@@ -158,7 +158,7 @@ impl CheckpointCommitment {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct EndOfEpochData {
     pub next_epoch_committee: Vec<ValidatorCommitteeMember>,
     pub next_epoch_protocol_version: u64,

--- a/crates/iota-sdk-ffi/src/types/coin.rs
+++ b/crates/iota-sdk-ffi/src/types/coin.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Coin(pub iota_types::framework::Coin);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/crypto/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/crypto/mod.rs
@@ -13,7 +13,7 @@ use crate::{error::Result, types::signature::SimpleSignature};
 macro_rules! impl_crypto_object {
     ($(#[$meta:meta])* $t:ident) => {
         $(#[$meta])*
-        #[derive(Copy, Clone, Debug, derive_more::From, derive_more::Deref, uniffi::Object)]
+        #[derive(derive_more::From, derive_more::Deref, uniffi::Object)]
         pub struct $t(pub iota_types::$t);
 
         #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/crypto/multisig.rs
+++ b/crates/iota-sdk-ffi/src/types/crypto/multisig.rs
@@ -28,7 +28,7 @@ use crate::types::crypto::{
 /// secp256r1-multisig-member-signature = %x02 secp256r1-signature
 /// zklogin-multisig-member-signature   = %x03 zklogin-authenticator
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MultisigMemberSignature(pub iota_types::MultisigMemberSignature);
 
 #[uniffi::export]
@@ -126,7 +126,7 @@ impl MultisigMemberSignature {
 ///                     (secp256k1-flag secp256k1-public-key) /
 ///                     (secp256r1-flag secp256r1-public-key)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MultisigMemberPublicKey(pub iota_types::MultisigMemberPublicKey);
 
 #[uniffi::export]
@@ -221,7 +221,7 @@ impl MultisigMemberPublicKey {
 ///
 /// See [here](https://github.com/RoaringBitmap/RoaringFormatSpec) for the specification for the
 /// serialized format of RoaringBitmaps.
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MultisigAggregatedSignature(pub iota_types::MultisigAggregatedSignature);
 
 #[uniffi::export]
@@ -290,7 +290,7 @@ impl MultisigAggregatedSignature {
 /// legacy-multisig-committee = (vector legacy-multisig-member)
 ///                             u16     ; threshold
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MultisigCommittee(pub iota_types::MultisigCommittee);
 
 #[uniffi::export]
@@ -362,7 +362,7 @@ impl MultisigCommittee {
 /// legacy-multisig-member = legacy-multisig-member-public-key
 ///                          u8     ; weight
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MultisigMember(pub iota_types::MultisigMember);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/crypto/passkey.rs
+++ b/crates/iota-sdk-ffi/src/types/crypto/passkey.rs
@@ -32,7 +32,7 @@ use crate::{error::Result, types::signature::SimpleSignature};
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct PasskeyAuthenticator(pub iota_types::PasskeyAuthenticator);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/crypto/validator.rs
+++ b/crates/iota-sdk-ffi/src/types/crypto/validator.rs
@@ -15,7 +15,7 @@ use crate::types::crypto::Bls12381PublicKey;
 /// validator-committee-member = bls-public-key
 ///                              u64 ; stake
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ValidatorCommitteeMember {
     pub public_key: Arc<Bls12381PublicKey>,
     pub stake: u64,

--- a/crates/iota-sdk-ffi/src/types/crypto/zklogin.rs
+++ b/crates/iota-sdk-ffi/src/types/crypto/zklogin.rs
@@ -29,7 +29,7 @@ use crate::{
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ZkLoginAuthenticator(pub iota_types::ZkLoginAuthenticator);
 
 #[uniffi::export]
@@ -108,7 +108,7 @@ impl ZkLoginAuthenticator {
 /// ```
 ///
 /// [`Address`]: crate::Address
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ZkLoginPublicIdentifier(pub iota_types::ZkLoginPublicIdentifier);
 
 #[uniffi::export]
@@ -142,7 +142,7 @@ impl ZkLoginPublicIdentifier {
 ///                  string              ; base64url-unpadded encoded JwtHeader
 ///                  bn254-field-element ; address_seed
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ZkLoginInputs(pub iota_types::ZkLoginInputs);
 
 #[uniffi::export]
@@ -188,7 +188,7 @@ impl ZkLoginInputs {
 /// ```text
 /// zklogin-proof = circom-g1 circom-g2 circom-g1
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ZkLoginProof(pub iota_types::ZkLoginProof);
 
 #[uniffi::export]
@@ -242,7 +242,7 @@ pub struct ZkLoginClaim {
 /// ```text
 /// circom-g1 = %x03 3(bn254-field-element)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct CircomG1(pub iota_types::CircomG1);
 
 #[uniffi::export]
@@ -273,7 +273,7 @@ impl CircomG1 {
 /// ```text
 /// circom-g2 = %x03 3(%x02 2(bn254-field-element))
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct CircomG2(pub iota_types::CircomG2);
 
 #[uniffi::export]
@@ -308,7 +308,7 @@ impl CircomG2 {
 /// ```text
 /// bn254-field-element = *DIGIT ; which is then interpreted as a radix10 encoded 32-byte value
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Bn254FieldElement(pub iota_types::Bn254FieldElement);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/digest.rs
+++ b/crates/iota-sdk-ffi/src/types/digest.rs
@@ -7,15 +7,6 @@ macro_rules! impl_digest_wrapper {
     ($(#[$meta:meta])* $t:ident) => {
         $(#[$meta])*
         #[derive(
-            Copy,
-            Clone,
-            Debug,
-            Default,
-            Hash,
-            PartialEq,
-            Eq,
-            PartialOrd,
-            Ord,
             derive_more::From,
             derive_more::Deref,
             uniffi::Object,

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -16,7 +16,7 @@ use crate::types::{address::Address, object::ObjectId};
 /// ```text
 /// event = object-id identifier address struct-tag bytes
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct Event {
     /// Package id of the top-level function invoked by a MoveCall command which
     /// triggered this event to be emitted.

--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -18,7 +18,7 @@ use crate::types::{address::Address, digest::Digest, object::ObjectId};
 /// success = %x00
 /// failure = %x01 execution-error (option u64)
 /// ```xx
-#[derive(Debug, Clone, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum ExecutionStatus {
     /// The Transaction successfully executed.
     Success,
@@ -144,7 +144,7 @@ impl From<ExecutionStatus> for iota_types::ExecutionStatus {
 /// coin-type-global-pause                              = %x23 string
 /// execution-cancelled-due-to-randomness-unavailable   = %x24
 /// ```
-#[derive(Debug, Clone, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum ExecutionError {
     // General transaction errors
     /// Insufficient Gas
@@ -530,7 +530,7 @@ impl From<ExecutionError> for iota_types::ExecutionError {
 /// ```text
 /// move-location = object-id identifier u16 u16 (option identifier)
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MoveLocation {
     /// The package id
     pub package: Arc<ObjectId>,
@@ -662,7 +662,7 @@ pub enum CommandArgumentError {
 /// unknown-upgrade-policy      = %x04 u8
 /// package-id-does-not-match   = %x05 object-id object-id
 /// ```
-#[derive(Debug, Clone, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum PackageUpgradeError {
     /// Unable to fetch package
     UnableToFetchPackage { package_id: Arc<ObjectId> },

--- a/crates/iota-sdk-ffi/src/types/graphql.rs
+++ b/crates/iota-sdk-ffi/src/types/graphql.rs
@@ -24,7 +24,7 @@ use crate::types::{
     type_tag::TypeTag,
 };
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct TransactionMetadata {
     #[uniffi(default = None)]
     pub gas_budget: Option<u64>,
@@ -66,7 +66,7 @@ impl From<TransactionMetadata> for iota_graphql_client::query_types::Transaction
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct TransactionDataEffects {
     pub tx: SignedTransaction,
     pub effects: Arc<TransactionEffects>,
@@ -90,7 +90,7 @@ impl From<TransactionDataEffects> for iota_graphql_client::TransactionDataEffect
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct TransactionsFilter {
     #[uniffi(default = None)]
     pub function: Option<String>,
@@ -157,7 +157,7 @@ impl From<TransactionsFilter> for iota_graphql_client::query_types::Transactions
 
 /// The result of a dry run, which includes the effects of the transaction and
 /// any errors that may have occurred.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct DryRunResult {
     pub effects: Option<Arc<TransactionEffects>>,
     pub error: Option<String>,
@@ -181,7 +181,7 @@ impl From<DryRunResult> for iota_graphql_client::DryRunResult {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ObjectRef {
     pub address: Arc<ObjectId>,
     pub digest: String,
@@ -208,10 +208,10 @@ impl From<ObjectRef> for iota_graphql_client::query_types::ObjectRef {
     }
 }
 
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Epoch(pub iota_graphql_client::query_types::Epoch);
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct EventFilter {
     #[uniffi(default = None)]
     pub emitting_module: Option<String>,
@@ -245,7 +245,7 @@ impl From<EventFilter> for iota_graphql_client::query_types::EventFilter {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ObjectFilter {
     pub type_tag: Option<String>,
     pub owner: Option<Arc<Address>>,
@@ -278,7 +278,7 @@ impl From<ObjectFilter> for iota_graphql_client::query_types::ObjectFilter {
 
 /// The output of a dynamic field query, that includes the name, value, and
 /// value's json representation.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct DynamicFieldOutput {
     /// The name of the dynamic field
     pub name: DynamicFieldName,
@@ -310,7 +310,7 @@ impl From<DynamicFieldOutput> for iota_graphql_client::DynamicFieldOutput {
 
 /// The name part of a dynamic field, including its type, bcs, and json
 /// representation.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct DynamicFieldName {
     /// The type name of this dynamic field name
     pub type_tag: Arc<TypeTag>,
@@ -341,7 +341,7 @@ impl From<DynamicFieldName> for iota_graphql_client::DynamicFieldName {
 }
 
 /// The value part of a dynamic field.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct DynamicFieldValue {
     pub type_tag: Arc<TypeTag>,
     pub bcs: Vec<u8>,
@@ -366,7 +366,7 @@ impl From<DynamicFieldValue> for iota_graphql_client::DynamicFieldValue {
 }
 
 /// Represents a validator in the system.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct Validator {
     /// The APY of this validator in basis points.
     /// To get the APY in percentage, divide by 100.
@@ -568,7 +568,7 @@ pub enum Direction {
     Backward,
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ValidatorSet {
     pub active_validators: ValidatorConnection,
 }
@@ -589,7 +589,7 @@ impl From<ValidatorSet> for iota_graphql_client::query_types::ValidatorSet {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ValidatorConnection {
     pub page_info: PageInfo,
     pub nodes: Vec<Validator>,
@@ -613,7 +613,7 @@ impl From<ValidatorConnection> for iota_graphql_client::query_types::ValidatorCo
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct GQLAddress {
     pub address: Arc<Address>,
 }
@@ -742,7 +742,7 @@ pub struct OpenMoveType {
     pub repr: String,
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MoveModule {
     pub file_format_version: i32,
     #[uniffi(default = None)]
@@ -778,7 +778,7 @@ impl From<MoveModule> for iota_graphql_client::query_types::MoveModule {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MoveModuleConnection {
     pub nodes: Vec<MoveModuleQuery>,
     pub page_info: PageInfo,
@@ -802,7 +802,7 @@ impl From<MoveModuleConnection> for iota_graphql_client::query_types::MoveModule
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MovePackageQuery {
     pub address: Arc<Address>,
     pub bcs: Option<Base64>,
@@ -826,7 +826,7 @@ impl From<MovePackageQuery> for iota_graphql_client::query_types::MovePackageQue
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MoveModuleQuery {
     pub package: MovePackageQuery,
     pub name: String,

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -36,9 +36,7 @@ use crate::{
 /// ```text
 /// object-id = 32*OCTET
 /// ```
-#[derive(
-    Clone, Debug, PartialEq, Eq, Hash, derive_more::From, derive_more::Deref, uniffi::Object,
-)]
+#[derive(PartialEq, Eq, Hash, derive_more::From, derive_more::Deref, uniffi::Object)]
 #[uniffi::export(Hash)]
 pub struct ObjectId(pub iota_types::ObjectId);
 
@@ -80,7 +78,7 @@ impl ObjectId {
 /// ```text
 /// object-ref = object-id u64 digest
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ObjectReference {
     object_id: Arc<ObjectId>,
     version: u64,
@@ -112,7 +110,7 @@ impl From<ObjectReference> for iota_types::ObjectReference {
 /// ```text
 /// object = object-data owner digest u64
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Object(pub iota_types::Object);
 
 #[uniffi::export]
@@ -188,7 +186,7 @@ impl Object {
 /// object-data-struct  = %x00 object-move-struct
 /// object-data-package = %x01 object-move-package
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ObjectData(pub iota_types::ObjectData);
 
 #[uniffi::export]
@@ -239,7 +237,7 @@ impl ObjectData {
 /// ```text
 /// type-origin = identifier identifier object-id
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct TypeOrigin {
     pub module_name: Arc<Identifier>,
     pub struct_name: Arc<Identifier>,
@@ -275,7 +273,7 @@ impl From<TypeOrigin> for iota_types::TypeOrigin {
 /// ```text
 /// upgrade-info = object-id u64
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct UpgradeInfo {
     /// Id of the upgraded packages
     pub upgraded_id: Arc<ObjectId>,
@@ -314,7 +312,7 @@ impl From<UpgradeInfo> for iota_types::UpgradeInfo {
 /// type-origin-table = vector type-origin
 /// linkage-table = map (object-id upgrade-info)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MovePackage(pub iota_types::MovePackage);
 
 #[uniffi::export]
@@ -361,7 +359,7 @@ impl MovePackage {
 /// ; first 32 bytes of the contents are the object's object-id
 /// object-contents = uleb128 (object-id *OCTET) ; length followed by contents
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct MoveStruct {
     /// The type of this object
     pub struct_type: Arc<StructTag>,
@@ -407,7 +405,7 @@ impl From<MoveStruct> for iota_types::MoveStruct {
 /// owner-shared    = %x02 u64
 /// owner-immutable = %x03
 /// ```
-#[derive(Copy, Clone, Debug, derive_more::From, derive_more::Deref, uniffi::Object)]
+#[derive(derive_more::From, derive_more::Deref, uniffi::Object)]
 pub struct Owner(pub iota_types::Owner);
 
 #[uniffi::export]
@@ -470,7 +468,7 @@ impl Owner {
 }
 
 /// Type of an IOTA object
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ObjectType(pub iota_types::ObjectType);
 
 #[uniffi::export]
@@ -514,7 +512,7 @@ impl ObjectType {
 /// ```text
 /// genesis-object = object-data owner
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct GenesisObject(pub iota_types::GenesisObject);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/signature.rs
+++ b/crates/iota-sdk-ffi/src/types/signature.rs
@@ -61,7 +61,7 @@ pub enum SignatureScheme {
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct UserSignature(pub iota_types::UserSignature);
 
 #[uniffi::export]
@@ -198,7 +198,7 @@ impl UserSignature {
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct SimpleSignature(pub iota_types::SimpleSignature);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/struct_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/struct_tag.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// UNDERSCORE = %x95
 /// ```
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, derive_more::From, uniffi::Object)]
+#[derive(PartialEq, Eq, Hash, derive_more::From, uniffi::Object)]
 #[uniffi::export(Hash)]
 pub struct Identifier(pub iota_types::Identifier);
 
@@ -49,7 +49,7 @@ impl Identifier {
 ///              identifier         ; name of the type
 ///              (vector type-tag)  ; type parameters
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct StructTag(pub iota_types::StructTag);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -35,7 +35,7 @@ pub mod v1;
 ///
 /// transaction-v1 = transaction-kind address gas-payment transaction-expiration
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Transaction(pub iota_types::Transaction);
 
 #[uniffi::export]
@@ -72,7 +72,7 @@ impl Transaction {
     }
 }
 
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct SignedTransaction {
     pub transaction: Arc<Transaction>,
     pub signatures: Vec<Arc<UserSignature>>,
@@ -118,7 +118,7 @@ impl From<SignedTransaction> for iota_types::SignedTransaction {
 ///                     =/ %x07 consensus-commit-prologue-v2
 ///                     =/ %x08 consensus-commit-prologue-v3
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct TransactionKind(pub iota_types::TransactionKind);
 
 #[uniffi::export]
@@ -176,7 +176,7 @@ impl TransactionKind {
 /// ```text
 /// ptb = (vector input) (vector command)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ProgrammableTransaction(pub iota_types::ProgrammableTransaction);
 
 #[uniffi::export]
@@ -235,7 +235,7 @@ impl ProgrammableTransaction {
 /// input-shared                = %x02 object-id u64 bool
 /// input-receiving             = %x04 object-ref
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Input(pub iota_types::Input);
 
 #[uniffi::export]
@@ -292,7 +292,7 @@ impl Input {
 /// command-make-move-vector    = %x05 make-move-vector
 /// command-upgrade             = %x06 upgrade
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Command(pub iota_types::Command);
 
 #[uniffi::export]
@@ -364,7 +364,7 @@ impl Command {
 /// ```text
 /// transfer-objects = (vector argument) argument
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct TransferObjects(pub iota_types::TransferObjects);
 
 #[uniffi::export]
@@ -403,7 +403,7 @@ impl TransferObjects {
 /// ```text
 /// split-coins = argument (vector argument)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct SplitCoins(pub iota_types::SplitCoins);
 
 #[uniffi::export]
@@ -442,7 +442,7 @@ impl SplitCoins {
 /// ```text
 /// merge-coins = argument (vector argument)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MergeCoins(pub iota_types::MergeCoins);
 
 #[uniffi::export]
@@ -484,7 +484,7 @@ impl MergeCoins {
 /// publish = (vector bytes)        ; the serialized move modules
 ///           (vector object-id)    ; the set of package dependencies
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Publish(pub iota_types::Publish);
 
 #[uniffi::export]
@@ -523,7 +523,7 @@ impl Publish {
 /// ```text
 /// make-move-vector = (option type-tag) (vector argument)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MakeMoveVector(pub iota_types::MakeMoveVector);
 
 #[uniffi::export]
@@ -568,7 +568,7 @@ impl MakeMoveVector {
 ///           object-id             ; package-id of the package
 ///           argument              ; upgrade ticket
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct Upgrade(pub iota_types::Upgrade);
 
 #[uniffi::export]
@@ -625,7 +625,7 @@ impl Upgrade {
 /// consensus-commit-prologue-v1 = u64 u64 (option u64) u64 digest
 ///                                consensus-determined-version-assignments
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ConsensusCommitPrologueV1(pub iota_types::ConsensusCommitPrologueV1);
 
 #[uniffi::export]
@@ -688,7 +688,7 @@ impl ConsensusCommitPrologueV1 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ConsensusDeterminedVersionAssignments(
     pub iota_types::ConsensusDeterminedVersionAssignments,
 );
@@ -733,7 +733,7 @@ impl ConsensusDeterminedVersionAssignments {
 /// ```text
 /// cancelled-transaction = digest (vector version-assignment)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct CancelledTransaction(pub iota_types::CancelledTransaction);
 
 #[uniffi::export]
@@ -776,7 +776,7 @@ impl CancelledTransaction {
 /// ```text
 /// version-assignment = object-id u64
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct VersionAssignment(iota_types::VersionAssignment);
 
 #[uniffi::export]
@@ -807,7 +807,7 @@ impl VersionAssignment {
 /// ```text
 /// genesis-transaction = (vector genesis-object)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct GenesisTransaction(iota_types::GenesisTransaction);
 
 #[uniffi::export]
@@ -816,7 +816,7 @@ impl GenesisTransaction {
     pub fn new(objects: Vec<Arc<GenesisObject>>, events: Vec<Event>) -> Self {
         Self(iota_types::GenesisTransaction {
             objects: objects.iter().map(|object| object.0.clone()).collect(),
-            events: events.iter().cloned().map(Into::into).collect(),
+            events: events.into_iter().map(Into::into).collect(),
         })
     }
 
@@ -851,7 +851,7 @@ impl GenesisTransaction {
 ///                u64  ; epoch start timestamp
 ///                (vector system-package)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ChangeEpoch(pub iota_types::ChangeEpoch);
 
 #[uniffi::export]
@@ -942,7 +942,7 @@ impl ChangeEpoch {
 ///                  (vector bytes)     ; modules
 ///                  (vector object-id) ; dependencies
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct SystemPackage(pub iota_types::SystemPackage);
 
 #[uniffi::export]
@@ -992,7 +992,7 @@ impl SystemPackage {
 ///                u64  ; epoch start timestamp
 ///                (vector system-package)
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ChangeEpochV2(pub iota_types::ChangeEpochV2);
 
 #[uniffi::export]
@@ -1152,7 +1152,7 @@ pub struct ActiveJwk {
 ///                                          (vec execution-time-observation)
 ///                                         )
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ExecutionTimeObservations(pub iota_types::ExecutionTimeObservations);
 
 #[uniffi::export]
@@ -1168,7 +1168,7 @@ impl ExecutionTimeObservations {
     }
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ExecutionTimeObservation(pub iota_types::ExecutionTimeObservation);
 
 #[uniffi::export]
@@ -1210,7 +1210,7 @@ impl ExecutionTimeObservation {
 /// duration =  u64 ; seconds
 ///             u32 ; subsecond nanoseconds
 /// ```
-#[derive(Debug, Hash, PartialEq, Eq, Clone, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ValidatorExecutionTimeObservation(iota_types::ValidatorExecutionTimeObservation);
 
 #[uniffi::export]
@@ -1249,7 +1249,7 @@ impl ValidatorExecutionTimeObservation {
 ///
 /// move-entry-point = object-id string string (vec type-tag)
 /// ```
-#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct ExecutionTimeObservationKey(iota_types::ExecutionTimeObservationKey);
 
 #[uniffi::export]
@@ -1349,7 +1349,7 @@ pub struct RandomnessStateUpdate {
 /// eoe-bridge-committee-init       = %x06 u64
 /// eoe-store-execution-time-observations = %x07 stored-execution-time-observations
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct EndOfEpochTransactionKind(pub iota_types::EndOfEpochTransactionKind);
 
 #[uniffi::export]
@@ -1391,7 +1391,7 @@ impl EndOfEpochTransactionKind {
 ///               u64                 ; price
 ///               u64                 ; budget
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct GasPayment {
     pub objects: Vec<ObjectReference>,
     /// Owner of the gas objects, either the transaction sender or a sponsor
@@ -1437,7 +1437,7 @@ impl From<GasPayment> for iota_types::GasPayment {
 /// transaction-effects =  %x00 effects-v1
 ///                     =/ %x01 effects-v2
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct TransactionEffects(pub iota_types::TransactionEffects);
 
 #[uniffi::export]
@@ -1492,9 +1492,7 @@ pub enum TransactionExpiration {
 /// argument-result         = %x02 u16
 /// argument-nested-result  = %x03 u16 u16
 /// ```
-#[derive(
-    Copy, Clone, Debug, PartialEq, Eq, derive_more::Deref, derive_more::From, uniffi::Object,
-)]
+#[derive(derive_more::Deref, derive_more::From, uniffi::Object)]
 pub struct Argument(iota_types::Argument);
 
 #[uniffi::export]
@@ -1555,7 +1553,7 @@ impl Argument {
 ///             (vector type-tag)   ; type arguments, if any
 ///             (vector argument)   ; input arguments
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct MoveCall(iota_types::MoveCall);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/types/transaction/v1.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/v1.rs
@@ -32,7 +32,7 @@ use crate::types::{
 ///              (vector unchanged-shared-object)
 ///              (option digest)                    ; auxiliary data digest
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct TransactionEffectsV1 {
     /// The status of the execution
     pub status: ExecutionStatus,
@@ -126,7 +126,7 @@ impl From<TransactionEffectsV1> for iota_types::TransactionEffectsV1 {
 /// ```text
 /// changed-object = object-id object-in object-out id-operation
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct ChangedObject {
     /// Id of the object
     pub object_id: Arc<ObjectId>,
@@ -171,7 +171,7 @@ impl From<ChangedObject> for iota_types::ChangedObject {
 /// ```text
 /// unchanged-shared-object = object-id unchanged-shared-object-kind
 /// ```
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(uniffi::Record)]
 pub struct UnchangedSharedObject {
     pub object_id: Arc<ObjectId>,
     pub kind: UnchangedSharedKind,
@@ -214,7 +214,7 @@ impl From<UnchangedSharedObject> for iota_types::UnchangedSharedObject {
 /// cancelled           = %x03 u64
 /// per-epoch-config    = %x04
 /// ```
-#[derive(Clone, Debug, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum UnchangedSharedKind {
     /// Read-only shared objects from the input. We don't really need
     /// ObjectDigest for protocol correctness, but it will make it easier to
@@ -287,7 +287,7 @@ impl From<UnchangedSharedKind> for iota_types::UnchangedSharedKind {
 /// object-in-missing = %x00
 /// object-in-data    = %x01 u64 digest owner
 /// ```
-#[derive(Clone, Debug, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum ObjectIn {
     Missing,
     /// The old version, digest and owner.
@@ -348,7 +348,7 @@ impl From<ObjectIn> for iota_types::ObjectIn {
 /// object-out-object-write   = %x01 digest owner
 /// object-out-package-write  = %x02 version digest
 /// ```
-#[derive(Clone, Debug, uniffi::Enum)]
+#[derive(uniffi::Enum)]
 pub enum ObjectOut {
     /// Same definition as in ObjectIn.
     Missing,

--- a/crates/iota-sdk-ffi/src/types/type_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/type_tag.rs
@@ -36,7 +36,7 @@ use crate::types::struct_tag::StructTag;
 /// type-tag-vector = %x06 type-tag
 /// type-tag-struct = %x07 struct-tag
 /// ```
-#[derive(Clone, Debug, derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, uniffi::Object)]
 pub struct TypeTag(pub iota_types::TypeTag);
 
 #[uniffi::export]

--- a/crates/iota-sdk-ffi/src/uniffi_helpers.rs
+++ b/crates/iota-sdk-ffi/src/uniffi_helpers.rs
@@ -16,7 +16,7 @@ use crate::types::{
 macro_rules! define_paged_record {
     ($id:ident, $type_:ty) => {
         /// A page of items returned by the GraphQL server.
-        #[derive(Debug, Clone, uniffi::Record)]
+        #[derive(uniffi::Record)]
         pub struct $id {
             /// Information about the page, such as the cursor and whether there are
             /// more pages.
@@ -46,7 +46,7 @@ define_paged_record!(ValidatorPage, Validator);
 macro_rules! define_paged_object {
     ($id:ident, $type_:ty) => {
         /// A page of items returned by the GraphQL server.
-        #[derive(Debug, Clone, uniffi::Record)]
+        #[derive(uniffi::Record)]
         pub struct $id {
             /// Information about the page, such as the cursor and whether there are
             /// more pages.


### PR DESCRIPTION
## Description

Removes the derives which aren't needed for the generated bindings.

Closes #114