### PR TITLE
Introduce `ChangeEpochV3` with `eligible_active_validators` field

### DIFF
--- a/crates/iota-rust-sdk/src/types/transaction/fixtures/update-transaction-fixtures/src/main.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/fixtures/update-transaction-fixtures/src/main.rs
@@ -107,6 +107,15 @@ async fn main() -> Result<(), anyhow::Error> {
                                 got_epoch_change = true;
                             }
                         }
+                        IotaEndOfEpochTransactionKind::ChangeEpochV3(_change_epoch_v3) => {
+                            if !got_epoch_change {
+                                write_bs64_tx_to_file(
+                                    &raw_tx_bytes_to_transaction_data_bytes(&tx.raw_transaction)?,
+                                    "change-epoch-v3",
+                                )?;
+                                got_epoch_change = true;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/iota-rust-sdk/src/types/transaction/mod.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/mod.rs
@@ -134,6 +134,7 @@ pub enum TransactionKind {
 pub enum EndOfEpochTransactionKind {
     ChangeEpoch(ChangeEpoch),
     ChangeEpochV2(ChangeEpochV2),
+    ChangeEpochV3(ChangeEpochV3),
     AuthenticatorStateCreate,
     AuthenticatorStateExpire(AuthenticatorStateExpire),
 }
@@ -368,6 +369,60 @@ pub struct ChangeEpochV2 {
     /// their package ID), and a list of their transitive dependencies.
     #[cfg_attr(test, any(proptest::collection::size_range(0..=2).lift()))]
     pub system_packages: Vec<SystemPackage>,
+}
+
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub struct ChangeEpochV3 {
+    /// The next (to become) epoch ID.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub epoch: EpochId,
+    /// The protocol version in effect in the new epoch.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub protocol_version: ProtocolVersion,
+    /// The total amount of gas charged for storage during the epoch.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub storage_charge: u64,
+    /// The total amount of gas charged for computation during the epoch.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub computation_charge: u64,
+    /// The total amount of gas burned for computation during the epoch.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub computation_charge_burned: u64,
+    /// The amount of storage rebate refunded to the txn senders.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub storage_rebate: u64,
+    /// The non-refundable storage fee.
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub non_refundable_storage_fee: u64,
+    /// Unix timestamp when epoch started
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
+    pub epoch_start_timestamp_ms: u64,
+    /// System packages (specifically framework and move stdlib) that are
+    /// written before the new epoch starts. This tracks framework upgrades
+    /// on chain. When executing the ChangeEpoch txn, the validator must
+    /// write out the modules below.  Modules are provided with the version they
+    /// will be upgraded to, their modules in serialized form (which include
+    /// their package ID), and a list of their transitive dependencies.
+    #[cfg_attr(test, any(proptest::collection::size_range(0..=2).lift()))]
+    pub system_packages: Vec<SystemPackage>,
+    /// Vector of active validator indices eligible to take part in committee
+    /// selection because they support the new, target protocol version.
+    pub eligible_active_validators: Vec<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/iota-rust-sdk/src/types/transaction/mod.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/mod.rs
@@ -371,7 +371,6 @@ pub struct ChangeEpochV2 {
     pub system_packages: Vec<SystemPackage>,
 }
 
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",

--- a/crates/iota-rust-sdk/src/types/transaction/serialization.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/serialization.rs
@@ -280,7 +280,8 @@ mod transaction_kind {
 mod end_of_epoch {
     use super::*;
     use crate::types::transaction::{
-        AuthenticatorStateExpire, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, EndOfEpochTransactionKind,
+        AuthenticatorStateExpire, ChangeEpoch, ChangeEpochV2, ChangeEpochV3,
+        EndOfEpochTransactionKind,
     };
 
     #[derive(serde_derive::Serialize)]

--- a/crates/iota-rust-sdk/src/types/transaction/serialization.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/serialization.rs
@@ -280,7 +280,7 @@ mod transaction_kind {
 mod end_of_epoch {
     use super::*;
     use crate::types::transaction::{
-        AuthenticatorStateExpire, ChangeEpoch, ChangeEpochV2, EndOfEpochTransactionKind,
+        AuthenticatorStateExpire, ChangeEpoch, ChangeEpochV2, ChangeEpochV3, EndOfEpochTransactionKind,
     };
 
     #[derive(serde_derive::Serialize)]
@@ -288,6 +288,7 @@ mod end_of_epoch {
     enum ReadableEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
+        ChangeEpochV2(&'a ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
@@ -297,6 +298,7 @@ mod end_of_epoch {
     enum ReadableEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),
+        ChangeEpochV2(ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(AuthenticatorStateExpire),
     }
@@ -305,6 +307,7 @@ mod end_of_epoch {
     enum BinaryEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
+        ChangeEpochV2(&'a ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
@@ -313,6 +316,7 @@ mod end_of_epoch {
     enum BinaryEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),
+        ChangeEpochV3(ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(AuthenticatorStateExpire),
     }
@@ -328,6 +332,9 @@ mod end_of_epoch {
                     Self::ChangeEpochV2(k) => {
                         ReadableEndOfEpochTransactionKindRef::ChangeEpochV2(k)
                     }
+                    Self::ChangeEpochV3(k) => {
+                        ReadableEndOfEpochTransactionKindRef::ChangeEpochV3(k)
+                    }
                     Self::AuthenticatorStateCreate => {
                         ReadableEndOfEpochTransactionKindRef::AuthenticatorStateCreate
                     }
@@ -340,6 +347,8 @@ mod end_of_epoch {
                 let binary = match self {
                     Self::ChangeEpoch(k) => BinaryEndOfEpochTransactionKindRef::ChangeEpoch(k),
                     Self::ChangeEpochV2(k) => BinaryEndOfEpochTransactionKindRef::ChangeEpochV2(k),
+                    Self::ChangeEpochV3(k) => BinaryEndOfEpochTransactionKindRef::ChangeEpochV3(k),
+
                     Self::AuthenticatorStateCreate => {
                         BinaryEndOfEpochTransactionKindRef::AuthenticatorStateCreate
                     }
@@ -364,6 +373,9 @@ mod end_of_epoch {
                         ReadableEndOfEpochTransactionKind::ChangeEpochV2(k) => {
                             Self::ChangeEpochV2(k)
                         }
+                        ReadableEndOfEpochTransactionKind::ChangeEpochV3(k) => {
+                            Self::ChangeEpochV3(k)
+                        }
                         ReadableEndOfEpochTransactionKind::AuthenticatorStateCreate => {
                             Self::AuthenticatorStateCreate
                         }
@@ -377,6 +389,8 @@ mod end_of_epoch {
                     |binary| match binary {
                         BinaryEndOfEpochTransactionKind::ChangeEpoch(k) => Self::ChangeEpoch(k),
                         BinaryEndOfEpochTransactionKind::ChangeEpochV2(k) => Self::ChangeEpochV2(k),
+                        BinaryEndOfEpochTransactionKind::ChangeEpochV2(k) => Self::ChangeEpochV3(k),
+
                         BinaryEndOfEpochTransactionKind::AuthenticatorStateCreate => {
                             Self::AuthenticatorStateCreate
                         }

--- a/crates/iota-rust-sdk/src/types/transaction/serialization.rs
+++ b/crates/iota-rust-sdk/src/types/transaction/serialization.rs
@@ -288,7 +288,7 @@ mod end_of_epoch {
     enum ReadableEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
-        ChangeEpochV2(&'a ChangeEpochV3),
+        ChangeEpochV3(&'a ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
@@ -298,7 +298,7 @@ mod end_of_epoch {
     enum ReadableEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),
-        ChangeEpochV2(ChangeEpochV3),
+        ChangeEpochV3(ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(AuthenticatorStateExpire),
     }
@@ -307,7 +307,7 @@ mod end_of_epoch {
     enum BinaryEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
-        ChangeEpochV2(&'a ChangeEpochV3),
+        ChangeEpochV3(&'a ChangeEpochV3),
         AuthenticatorStateCreate,
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
@@ -389,7 +389,7 @@ mod end_of_epoch {
                     |binary| match binary {
                         BinaryEndOfEpochTransactionKind::ChangeEpoch(k) => Self::ChangeEpoch(k),
                         BinaryEndOfEpochTransactionKind::ChangeEpochV2(k) => Self::ChangeEpochV2(k),
-                        BinaryEndOfEpochTransactionKind::ChangeEpochV2(k) => Self::ChangeEpochV3(k),
+                        BinaryEndOfEpochTransactionKind::ChangeEpochV3(k) => Self::ChangeEpochV3(k),
 
                         BinaryEndOfEpochTransactionKind::AuthenticatorStateCreate => {
                             Self::AuthenticatorStateCreate


### PR DESCRIPTION
This PR adds `ChangeEpochV3` type necessary for changes in committee selection in https://github.com/iotaledger/iota/pull/8127