### PR TITLE
feat(examples): add pagination example

### DIFF
--- a/bindings/go/examples/pagination/main.go
+++ b/bindings/go/examples/pagination/main.go
@@ -36,7 +36,7 @@ func main() {
 			break
 		}
 	}
-	fmt.Printf("Total objects fetched(%d):\n", len(allObjects))
+	fmt.Printf("%d objects fetched:\n", len(allObjects))
 	for _, obj := range allObjects {
 		fmt.Println(obj.ObjectId().ToHex())
 	}

--- a/bindings/go/examples/pagination/main.go
+++ b/bindings/go/examples/pagination/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+
+	sdk "bindings/iota_sdk_ffi"
+)
+
+func main() {
+	client := sdk.GraphQlClientNewDevnet()
+	address, err := sdk.AddressFromHex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
+	if err != nil {
+		panic(err)
+	}
+
+	// Limit to 1 to demonstrate pagination
+	limit := int32(1)
+	var allObjects []*sdk.Object
+	var nextCursor *string
+	for {
+		if nextCursor != nil {
+			fmt.Printf("Fetching page with cursor: %s\n", *nextCursor)
+		} else {
+			fmt.Printf("Fetching page with cursor: nil\n")
+		}
+		page, err := client.Objects(&sdk.ObjectFilter{Owner: &address}, &sdk.PaginationFilter{Direction: sdk.DirectionForward, Cursor: nextCursor, Limit: &limit})
+		if err.(*sdk.SdkFfiError) != nil {
+			panic(err)
+		}
+		for _, obj := range page.Data {
+			allObjects = append(allObjects, obj)
+		}
+		if page.PageInfo.HasNextPage {
+			nextCursor = page.PageInfo.EndCursor
+		} else {
+			break
+		}
+	}
+	fmt.Printf("Total objects fetched(%d):\n", len(allObjects))
+	for _, obj := range allObjects {
+		fmt.Println(obj.ObjectId().ToHex())
+	}
+}

--- a/bindings/go/examples/pagination/main.go
+++ b/bindings/go/examples/pagination/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	sdk "bindings/iota_sdk_ffi"
 )
@@ -10,7 +11,7 @@ func main() {
 	client := sdk.GraphQlClientNewDevnet()
 	address, err := sdk.AddressFromHex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to parse address: %v", err)
 	}
 
 	// Limit to 1 to demonstrate pagination
@@ -25,7 +26,7 @@ func main() {
 		}
 		page, err := client.Objects(&sdk.ObjectFilter{Owner: &address}, &sdk.PaginationFilter{Direction: sdk.DirectionForward, Cursor: nextCursor, Limit: &limit})
 		if err.(*sdk.SdkFfiError) != nil {
-			panic(err)
+			log.Fatalf("Failed to get owned objects: %v", err)
 		}
 		for _, obj := range page.Data {
 			allObjects = append(allObjects, obj)

--- a/bindings/kotlin/examples/Pagination.kt
+++ b/bindings/kotlin/examples/Pagination.kt
@@ -37,7 +37,7 @@ fun main() = runBlocking {
                 break
             }
         }
-        println("Total objects fetched(${allObjects.size}):")
+        println("${allObjects.size} objects fetched:")
         for (obj in allObjects) {
             println(obj.objectId().toHex())
         }

--- a/bindings/kotlin/examples/Pagination.kt
+++ b/bindings/kotlin/examples/Pagination.kt
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.Address
+import iota_sdk.Direction
+import iota_sdk.GraphQlClient
+import iota_sdk.Object
+import iota_sdk.ObjectFilter
+import iota_sdk.PaginationFilter
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+        val address =
+                Address.fromHex(
+                        "0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c"
+                )
+        val allObjects = mutableListOf<Object>()
+        var nextCursor: String? = null
+        while (true) {
+            println("Fetching page with cursor: $nextCursor")
+            val page =
+                    client.objects(
+                            ObjectFilter(owner = address),
+                            PaginationFilter(
+                                    direction = Direction.FORWARD,
+                                    cursor = nextCursor,
+                                    // Limit to 1 to demonstrate pagination
+                                    limit = 1
+                            )
+                    )
+            allObjects.addAll(page.data)
+            if (page.pageInfo.hasNextPage) {
+                nextCursor = page.pageInfo.endCursor
+            } else {
+                break
+            }
+        }
+        println("Total objects fetched(${allObjects.size}):")
+        for (obj in allObjects) {
+            println(obj.objectId().toHex())
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/bindings/python/examples/pagination.py
+++ b/bindings/python/examples/pagination.py
@@ -22,7 +22,7 @@ async def main():
             next_cursor = page.page_info.end_cursor
         else:
             break
-    print(f"Total objects fetched({len(all_objects)}):")
+    print(f"{len(all_objects)} objects fetched:")
     for obj_id in all_objects:
         print(obj_id.object_id().to_hex())
 

--- a/bindings/python/examples/pagination.py
+++ b/bindings/python/examples/pagination.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from lib.iota_sdk_ffi import Address, Direction, GraphQlClient, ObjectFilter, PaginationFilter
+
+async def main():
+    client = GraphQlClient.new_devnet()
+    address = Address.from_hex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
+
+    all_objects = []
+    next_cursor = None
+    while True:
+        print(f"Fetching page with cursor: {next_cursor}")
+        page = await client.objects(
+            ObjectFilter(owner=address),
+            # Limit to 1 to demonstrate pagination
+            PaginationFilter(direction=Direction.FORWARD, cursor=next_cursor, limit=1)
+        )
+        all_objects.extend(page.data)
+        if page.page_info.has_next_page:
+            next_cursor = page.page_info.end_cursor
+        else:
+            break
+    print(f"Total objects fetched({len(all_objects)}):")
+    for obj_id in all_objects:
+        print(obj_id.object_id().to_hex())
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-graphql-client/examples/pagination.rs
+++ b/crates/iota-graphql-client/examples/pagination.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
             break;
         }
     }
-    println!("Total objects fetched({}):", all_objects.len());
+    println!("{} objects fetched:", all_objects.len());
     for obj in &all_objects {
         println!("{}", obj.object_id());
     }

--- a/crates/iota-graphql-client/examples/pagination.rs
+++ b/crates/iota-graphql-client/examples/pagination.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use iota_graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter};
+use iota_types::Address;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let address =
+        Address::from_hex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
+
+    let mut all_objects = Vec::new();
+    let mut next_cursor = None;
+    while let Some(cursor) = Some(next_cursor.clone()) {
+        println!("Fetching page with cursor: {cursor:?}");
+        let owned_objects_page = client
+            .objects(
+                Some(ObjectFilter {
+                    owner: Some(address),
+                    ..Default::default()
+                }),
+                PaginationFilter {
+                    cursor,
+                    // Limit to 1 to demonstrate pagination
+                    limit: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        let (page_info, data) = owned_objects_page.into_parts();
+        all_objects.extend(data);
+        if page_info.has_next_page {
+            next_cursor = page_info.end_cursor.clone();
+        } else {
+            break;
+        }
+    }
+    println!("Total objects fetched({}):", all_objects.len());
+    for obj in &all_objects {
+        println!("{}", obj.object_id());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Add examples to show how to fetch all pages using the nextCursor of the pageInfo

Fixes https://github.com/iotaledger/iota-rust-sdk/issues/189

```
make bindings-example pagination
make[1]: Verzeichnis „/home/t/Desktop/iota-rust-sdk“ wird betreten

Running Go example "pagination"
Fetching page with cursor: nil
Fetching page with cursor: IAsCcO6dJ9oNsJZR5fczjfoyx+5kQczvofbjBXNbz8erj6o4BwAAAAA=
Fetching page with cursor: IC18jxuTcLkdf/Pb2BRKBdadf5d1jemMW7bDJXjNpiIUj6o4BwAAAAA=
3 objects fetched:
0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab
0x2d7c8f1b9370b91d7ff3dbd8144a05d69d7f97758de98c5bb6c32578cda62214
0xd04077fe3b6fad13b3d4ed0d535b7ca92afcac8f0f2a0e0925fb9f4f0b30c699
```