### PR TITLE
chore(ffi): Add Display impls for types used by `get_object` examples

### DIFF
--- a/bindings/go/examples/get_object/main.go
+++ b/bindings/go/examples/get_object/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/hex"
 	"fmt"
 	"log"
 
@@ -28,26 +27,12 @@ func main() {
 	}
 	obj := *objOpt
 
-	objType := "Package"
-	if obj.ObjectType().IsStruct() {
-		objType = obj.ObjectType().AsStruct().String()
-	}
-
-	objOwner := "Immutable"
-	if obj.Owner().IsAddress() {
-		objOwner = fmt.Sprintf("Address(%v)", obj.Owner().AsAddress().ToHex())
-	} else if obj.Owner().IsObject() {
-		objOwner = fmt.Sprintf("Object(%v)", obj.Owner().AsObject().ToHex())
-	} else if obj.Owner().IsShared() {
-		objOwner = fmt.Sprintf("Shared(%v)", obj.Owner().AsShared())
-	}
-
 	fmt.Println("Object ID:", obj.ObjectId().ToHex())
 	fmt.Println("Version:", obj.Version())
 	fmt.Println("Previous transaction:", obj.PreviousTransaction().ToBase58())
-	fmt.Println("Owner:", objOwner)
+	fmt.Println("Owner:", obj.Owner())
 	fmt.Println("Storage rebate:", obj.StorageRebate())
-	fmt.Println("Type:", objType)
-	fmt.Println("BCS bytes:", hex.EncodeToString(obj.AsStruct().Contents))
+	fmt.Println("Type:", obj.ObjectType())
+	fmt.Println("BCS bytes:", sdk.HexEncode(obj.AsStruct().Contents))
 
 }

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -15826,6 +15826,19 @@ func (_self *ObjectType) IsStruct() bool {
 		_pointer,_uniffiStatus)
 	}))
 }
+
+func (_self *ObjectType) String() string {
+	_pointer := _self.ffiObject.incrementPointer("*ObjectType")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer {
+		inner: C.uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display(
+		_pointer,_uniffiStatus),
+	}
+	}))
+}
+
+
 func (object *ObjectType) Destroy() {
 	runtime.SetFinalizer(object, nil)
 	object.ffiObject.destroy()
@@ -16044,6 +16057,19 @@ func (_self *Owner) IsShared() bool {
 		_pointer,_uniffiStatus)
 	}))
 }
+
+func (_self *Owner) String() string {
+	_pointer := _self.ffiObject.incrementPointer("*Owner")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer {
+		inner: C.uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display(
+		_pointer,_uniffiStatus),
+	}
+	}))
+}
+
+
 func (object *Owner) Destroy() {
 	runtime.SetFinalizer(object, nil)
 	object.ffiObject.destroy()

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -2573,6 +2573,11 @@ int8_t uniffi_iota_sdk_ffi_fn_method_objecttype_is_package(void* ptr, RustCallSt
 int8_t uniffi_iota_sdk_ffi_fn_method_objecttype_is_struct(void* ptr, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTTYPE_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTTYPE_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display(void* ptr, RustCallStatus *out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_OWNER
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_OWNER
 void* uniffi_iota_sdk_ffi_fn_clone_owner(void* ptr, RustCallStatus *out_status
@@ -2652,6 +2657,11 @@ int8_t uniffi_iota_sdk_ffi_fn_method_owner_is_object(void* ptr, RustCallStatus *
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_IS_SHARED
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_IS_SHARED
 int8_t uniffi_iota_sdk_ffi_fn_method_owner_is_shared(void* ptr, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_UNIFFI_TRAIT_DISPLAY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_UNIFFI_TRAIT_DISPLAY
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display(void* ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_PASSKEYAUTHENTICATOR

--- a/bindings/kotlin/examples/GetObject.kt
+++ b/bindings/kotlin/examples/GetObject.kt
@@ -3,6 +3,7 @@
 
 import iota_sdk.GraphQlClient
 import iota_sdk.ObjectId
+import iota_sdk.hexEncode
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
@@ -16,32 +17,14 @@ fun main() = runBlocking {
 
         val obj = client.`object`(objectId)!!
 
-        val objType =
-                if (obj.objectType().isPackage()) {
-                    "Package"
-                } else {
-                    obj.objectType().asStruct().toString()
-                }
-
-        val objOwner =
-                if (obj.owner().isAddress()) {
-                    "Address(${obj.owner().asAddress().toHex()})"
-                } else if (obj.owner().isObject()) {
-                    "Object(${obj.owner().asObject().toHex()})"
-                } else if (obj.owner().isShared()) {
-                    "Shared(${obj.owner().asShared()})"
-                } else {
-                    "Immutable"
-                }
-
         println("Object ID: ${obj.objectId().toHex()}")
         println("Version: ${obj.version()}")
         println("Previous transaction: ${obj.previousTransaction().toBase58()}")
-        println("Owner: $objOwner")
+        println("Owner: ${obj.owner().toString()}")
         println("Storage rebate: ${obj.storageRebate()}")
-        println("Type: $objType")
+        println("Type: ${obj.objectType().toString()}")
         @OptIn(kotlin.ExperimentalStdlibApi::class)
-        println("BCS bytes: ${obj.asStruct().contents.toHexString()}")
+        println("BCS bytes: ${hexEncode(obj.asStruct().contents)}")
     } catch (e: Exception) {
         e.printStackTrace()
     }

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -2204,6 +2204,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -4416,6 +4418,8 @@ fun uniffi_iota_sdk_ffi_fn_method_objecttype_is_package(`ptr`: Pointer,uniffi_ou
 ): Byte
 fun uniffi_iota_sdk_ffi_fn_method_objecttype_is_struct(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
+fun uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_clone_owner(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_free_owner(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -4448,6 +4452,8 @@ fun uniffi_iota_sdk_ffi_fn_method_owner_is_object(`ptr`: Pointer,uniffi_out_err:
 ): Byte
 fun uniffi_iota_sdk_ffi_fn_method_owner_is_shared(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Byte
+fun uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_clone_passkeyauthenticator(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_free_passkeyauthenticator(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -26835,6 +26841,17 @@ open class ObjectType: Disposable, AutoCloseable, ObjectTypeInterface
     
 
     
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display(
+        it, _status)
+}
+    }
+    )
+    }
+    
 
     
     companion object {
@@ -27249,6 +27266,17 @@ open class Owner: Disposable, AutoCloseable, OwnerInterface
     }
     
 
+    
+    override fun toString(): String {
+        return FfiConverterString.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display(
+        it, _status)
+}
+    }
+    )
+    }
     
 
     

--- a/bindings/python/examples/get_object.py
+++ b/bindings/python/examples/get_object.py
@@ -17,28 +17,13 @@ async def main():
     if obj is None:
         return
 
-    objType = (
-        "Package"
-        if obj.object_type().is_package()
-        else str(obj.object_type().as_struct())
-    )
-
-    if obj.owner().is_address():
-        objOwner = f"Address({obj.owner().as_address().to_hex()})"
-    elif obj.owner().is_object():
-        objOwner = f"Object({obj.owner().as_object().to_hex()})"
-    elif obj.owner().is_shared():
-        objOwner = f"Shared({obj.owner().as_shared()})"
-    else:
-        objOwner = "Immutable"
-
     print("Object ID:", obj.object_id().to_hex())
     print("Version:", obj.version())
     print("Previous transaction:", obj.previous_transaction().to_base58())
-    print("Owner:", objOwner)
+    print("Owner:", obj.owner())
     print("Storage rebate:", obj.storage_rebate())
-    print("Type:", objType)
-    print("BCS bytes:", obj.as_struct().contents.hex())
+    print("Type:", obj.object_type())
+    print("BCS bytes:", hex_encode(obj.as_struct().contents))
 
 
 if __name__ == "__main__":

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -4113,6 +4113,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_objecttype_is_struct.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_objecttype_is_struct.restype = ctypes.c_int8
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_iota_sdk_ffi_fn_clone_owner.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -4192,6 +4197,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_is_shared.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_is_shared.restype = ctypes.c_int8
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_iota_sdk_ffi_fn_clone_passkeyauthenticator.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -30659,6 +30669,15 @@ class ObjectType():
 
 
 
+    def __str__(self, ) -> "str":
+        return _UniffiConverterString.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_objecttype_uniffi_trait_display,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
 
 class _UniffiConverterTypeObjectType:
 
@@ -30885,6 +30904,15 @@ class Owner():
     def is_shared(self, ) -> "bool":
         return _UniffiConverterBool.lift(
             _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_is_shared,self._uniffi_clone_pointer(),)
+        )
+
+
+
+
+
+    def __str__(self, ) -> "str":
+        return _UniffiConverterString.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_uniffi_trait_display,self._uniffi_clone_pointer(),)
         )
 
 

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -481,7 +481,8 @@ impl From<MoveStruct> for iota_types::MoveStruct {
 /// owner-shared    = %x02 u64
 /// owner-immutable = %x03
 /// ```
-#[derive(derive_more::From, derive_more::Deref, uniffi::Object)]
+#[derive(derive_more::From, derive_more::Deref, derive_more::Display, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct Owner(pub iota_types::Owner);
 
 #[uniffi::export]
@@ -556,7 +557,8 @@ impl Owner {
 }
 
 /// Type of an IOTA object
-#[derive(derive_more::From, uniffi::Object)]
+#[derive(derive_more::From, derive_more::Display, uniffi::Object)]
+#[uniffi::export(Display)]
 pub struct ObjectType(pub iota_types::ObjectType);
 
 #[uniffi::export]

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -122,6 +122,17 @@ impl Owner {
     crate::def_is_as_into_opt!(Address, Object(ObjectId), Shared(Version));
 }
 
+impl std::fmt::Display for Owner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Owner::Address(address) => write!(f, "Address({address})"),
+            Owner::Object(object_id) => write!(f, "Object({object_id})"),
+            Owner::Shared(version) => write!(f, "Shared({version})"),
+            Owner::Immutable => write!(f, "Immutable"),
+        }
+    }
+}
+
 /// Object data, either a package or struct
 ///
 /// # BCS
@@ -325,6 +336,15 @@ impl ObjectType {
     crate::def_is!(Package);
 
     crate::def_is_as_into_opt!(Struct(StructTag));
+}
+
+impl std::fmt::Display for ObjectType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ObjectType::Package => write!(f, "Package"),
+            ObjectType::Struct(struct_tag) => write!(f, "Struct({struct_tag})"),
+        }
+    }
 }
 
 /// An object on the IOTA blockchain


### PR DESCRIPTION
## Description

Adds a few Display impls for types used by this example to simplify them.