### PR TITLE
feat: add objects_by_type example

### DIFF
--- a/bindings/go/examples/objects_by_type/main.go
+++ b/bindings/go/examples/objects_by_type/main.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	sdk "bindings/iota_sdk_ffi"
+)
+
+func main() {
+	client := sdk.GraphQlClientNewDevnet()
+
+	stakedIotaType := "0x3::staking_pool::StakedIota"
+	stakedIotas, err := client.Objects(&sdk.ObjectFilter{TypeTag: &stakedIotaType}, nil)
+	if err.(*sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to get staked iota: %v", err)
+	}
+
+	if len(stakedIotas.Data) == 0 {
+		fmt.Println("No StakedIota objects found")
+	} else {
+		fmt.Println("StakedIota object IDs:")
+		for _, stakedIota := range stakedIotas.Data {
+			fmt.Printf("%s\n", stakedIota.ObjectId().ToHex())
+		}
+	}
+}

--- a/bindings/kotlin/examples/ObjectsByType.kt
+++ b/bindings/kotlin/examples/ObjectsByType.kt
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.GraphQlClient
+import iota_sdk.ObjectFilter
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+
+        val stakedIotas = client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota"))
+
+        if (stakedIotas.data.isEmpty()) {
+            println("No StakedIota objects found")
+        } else {
+            println("StakedIota object IDs:")
+            for (stakedIota in stakedIotas.data) {
+                println(stakedIota.objectId().toHex())
+            }
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/bindings/python/examples/objects_by_type.py
+++ b/bindings/python/examples/objects_by_type.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from lib.iota_sdk_ffi import *
+
+
+async def main():
+    try:
+        client = GraphQlClient.new_devnet()
+
+        staked_iotas = await client.objects(
+            filter=ObjectFilter(type_tag="0x3::staking_pool::StakedIota")
+        )
+
+        if len(staked_iotas.data) == 0:
+            print("No StakedIota objects found")
+        else:
+            print("StakedIota object IDs:")
+            for staked_iota in staked_iotas.data:
+                print(staked_iota.object_id().to_hex())
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-graphql-client/examples/objects_by_type.rs
+++ b/crates/iota-graphql-client/examples/objects_by_type.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_graphql_client::{Client, error::Result, query_types::ObjectFilter};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let staked_iotas = client
+        .objects(
+            ObjectFilter {
+                type_: "0x3::staking_pool::StakedIota".to_owned().into(),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?;
+
+    if staked_iotas.data.is_empty() {
+        println!("No StakedIota objects found");
+    } else {
+        println!("StakedIota object IDs:");
+        for staked_iota in staked_iotas.data {
+            println!("{}", staked_iota.object_id());
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-rust-sdk/issues/193

Tested by running `cargo run --example objects_by_type ` and
```
make bindings-example objects_by_type
make[1]: Verzeichnis „/home/t/Desktop/iota-rust-sdk“ wird betreten

Running Go example "objects_by_type"
StakedIota object IDs:
0x00030af99878926cd11f8bdf4d2f67c4aa753a4afc249d776c8ed2cc88d7b8d5
0x0051c048da6d905b125473292e1d7edfc28b226d9b1a06d66e520b281fb2146b
0x00604cd51bf17de33652d9b453c526eca4605492df7ebc032daaa5df536396b7
0x0063430ee810f767f5015aa2468ba704276ea4a327f9aa8d6991c28dc893394e
0x006d3af89ba10adf19f242486bbe020126caab8dc35dfa5ebdfabb161e41684e
...
```