### PR TITLE
feat: add generate_ed25519_address example

### DIFF
--- a/bindings/go/examples/generate_ed25519_address/main.go
+++ b/bindings/go/examples/generate_ed25519_address/main.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	sdk "bindings/iota_sdk_ffi"
+)
+
+func main() {
+	privateKey := sdk.Ed25519PrivateKeyGenerate()
+	publicKey := privateKey.PublicKey()
+	address := publicKey.DeriveAddress()
+	publicKeyBytes := publicKey.ToBytes()
+
+	flaggedPublicKey := append([]byte{byte(sdk.SignatureSchemeEd25519)}, publicKeyBytes...)
+	privateKeyDer, err := privateKey.ToDer()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Private Key:", base64.StdEncoding.EncodeToString(privateKeyDer))
+	fmt.Println("Public Key:", base64.StdEncoding.EncodeToString(publicKeyBytes))
+	fmt.Println("Public Key With Flag:", base64.StdEncoding.EncodeToString(flaggedPublicKey))
+	fmt.Println("Address:", address.ToHex())
+}

--- a/bindings/go/examples/generate_ed25519_address/main.go
+++ b/bindings/go/examples/generate_ed25519_address/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"fmt"
 
 	sdk "bindings/iota_sdk_ffi"
@@ -22,8 +21,8 @@ func main() {
 		panic(err)
 	}
 
-	fmt.Println("Private Key:", base64.StdEncoding.EncodeToString(privateKeyDer))
-	fmt.Println("Public Key:", base64.StdEncoding.EncodeToString(publicKeyBytes))
-	fmt.Println("Public Key With Flag:", base64.StdEncoding.EncodeToString(flaggedPublicKey))
+	fmt.Println("Private Key:", sdk.Base64Encode(privateKeyDer))
+	fmt.Println("Public Key:", sdk.Base64Encode(publicKeyBytes))
+	fmt.Println("Public Key With Flag:", sdk.Base64Encode(flaggedPublicKey))
 	fmt.Println("Address:", address.ToHex())
 }

--- a/bindings/kotlin/examples/GenerateEd25519Address.kt
+++ b/bindings/kotlin/examples/GenerateEd25519Address.kt
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import iota_sdk.Ed25519PrivateKey
-import java.util.Base64
+import iota_sdk.base64Encode
 import kotlin.io.println
 
 fun main() {
@@ -12,8 +12,8 @@ fun main() {
     val flaggedPublicKey = byteArrayOf((publicKey.scheme().ordinal + 1).toByte()) + publicKeyBytes
     val address = publicKey.deriveAddress()
 
-    println("Private Key: ${Base64.getEncoder().encodeToString(privateKey.toDer())}")
-    println("Public Key: ${Base64.getEncoder().encodeToString(publicKeyBytes)}")
-    println("Public Key With Flag: ${Base64.getEncoder().encodeToString(flaggedPublicKey)}")
+    println("Private Key: ${base64Encode(privateKey.toDer())}")
+    println("Public Key: ${base64Encode(publicKeyBytes)}")
+    println("Public Key With Flag: ${base64Encode(flaggedPublicKey)}")
     println("Address: ${address.toHex()}")
 }

--- a/bindings/kotlin/examples/GenerateEd25519Address.kt
+++ b/bindings/kotlin/examples/GenerateEd25519Address.kt
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.Ed25519PrivateKey
+import java.util.Base64
+import kotlin.io.println
+
+fun main() {
+    val privateKey = Ed25519PrivateKey.generate()
+    val publicKey = privateKey.publicKey()
+    val publicKeyBytes = publicKey.toBytes()
+    val flaggedPublicKey = byteArrayOf((publicKey.scheme().ordinal + 1).toByte()) + publicKeyBytes
+    val address = publicKey.deriveAddress()
+
+    println("Private Key: ${Base64.getEncoder().encodeToString(privateKey.toDer())}")
+    println("Public Key: ${Base64.getEncoder().encodeToString(publicKeyBytes)}")
+    println("Public Key With Flag: ${Base64.getEncoder().encodeToString(flaggedPublicKey)}")
+    println("Address: ${address.toHex()}")
+}

--- a/bindings/python/examples/generate_ed25519_address.py
+++ b/bindings/python/examples/generate_ed25519_address.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+from lib.iota_sdk_ffi import Ed25519PrivateKey
+
+
+def main():
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+    public_key_bytes = public_key.to_bytes()
+    flagged_public_key = bytes([public_key.scheme().value]) + public_key_bytes
+    address = public_key.derive_address()
+
+    print(f"Private Key: {base64.b64encode(private_key.to_der()).decode()}")
+    print(f"Public Key: {base64.b64encode(public_key_bytes).decode()}")
+    print(f"Public Key With Flag: {base64.b64encode(flagged_public_key).decode()}")
+    print(f"Address: {address.to_hex()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/examples/generate_ed25519_address.py
+++ b/bindings/python/examples/generate_ed25519_address.py
@@ -1,8 +1,7 @@
 # Copyright (c) 2025 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-import base64
-from lib.iota_sdk_ffi import Ed25519PrivateKey
+from lib.iota_sdk_ffi import Ed25519PrivateKey, base64_encode
 
 
 def main():
@@ -12,9 +11,9 @@ def main():
     flagged_public_key = bytes([public_key.scheme().value]) + public_key_bytes
     address = public_key.derive_address()
 
-    print(f"Private Key: {base64.b64encode(private_key.to_der()).decode()}")
-    print(f"Public Key: {base64.b64encode(public_key_bytes).decode()}")
-    print(f"Public Key With Flag: {base64.b64encode(flagged_public_key).decode()}")
+    print(f"Private Key: {base64_encode(private_key.to_der())}")
+    print(f"Public Key: {base64_encode(public_key_bytes)}")
+    print(f"Public Key With Flag: {base64_encode(flagged_public_key)}")
     print(f"Address: {address.to_hex()}")
 
 

--- a/crates/iota-graphql-client/Cargo.toml
+++ b/crates/iota-graphql-client/Cargo.toml
@@ -27,6 +27,7 @@ url = "2.5.3"
 
 [dev-dependencies]
 hex = "0.4.3"
+iota-crypto = { path = "../iota-crypto", features = ["ed25519", "pem"] }
 iota-transaction-builder = { path = "../iota-transaction-builder" }
 iota-types = { package = "iota-sdk-types", path = "../iota-sdk-types", features = ["serde", "rand", "hash"] }
 rand = "0.8.5"

--- a/crates/iota-graphql-client/examples/generate_ed25519_address.rs
+++ b/crates/iota-graphql-client/examples/generate_ed25519_address.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use base64ct::{Base64, Encoding};
+use iota_crypto::ed25519::Ed25519PrivateKey;
+use rand::rngs::OsRng;
+
+fn main() {
+    let mut rng = OsRng;
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let public_key = private_key.public_key();
+    let address = public_key.derive_address();
+
+    let mut flagged_public_key = vec![public_key.scheme().to_u8()];
+    flagged_public_key.extend_from_slice(public_key.as_bytes());
+    let encoded_public_key = Base64::encode_string(&flagged_public_key);
+
+    println!(
+        "Private Key: {}",
+        Base64::encode_string(&private_key.to_der().unwrap())
+    );
+    println!("Public Key: {public_key}");
+    println!("Public Key With Flag: {encoded_public_key}");
+    println!("Address: {address}");
+}

--- a/crates/iota-graphql-client/examples/generate_ed25519_address.rs
+++ b/crates/iota-graphql-client/examples/generate_ed25519_address.rs
@@ -6,8 +6,7 @@ use iota_crypto::ed25519::Ed25519PrivateKey;
 use rand::rngs::OsRng;
 
 fn main() {
-    let mut rng = OsRng;
-    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let private_key = Ed25519PrivateKey::generate(OsRng);
     let public_key = private_key.public_key();
     let address = public_key.derive_address();
 


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-rust-sdk/issues/208

Tested with ` cargo run --example generate_ed25519_address` and `make bindings-example generate_ed25519_address`