### PR TITLE
fix: add missing Event fields

### DIFF
--- a/bindings/go/examples/package_events/main.go
+++ b/bindings/go/examples/package_events/main.go
@@ -35,5 +35,6 @@ func main() {
 		fmt.Println("Type: ", event.Type)
 		fmt.Println("Sender: ", event.Sender.ToHex())
 		fmt.Println("Module: ", event.Module)
+		fmt.Println("JSON: ", event.Json)
 	}
 }

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -24206,6 +24206,12 @@ type Event struct {
 	Type string
 	// BCS serialized bytes of the event
 	Contents []byte
+	// UTC timestamp in milliseconds since epoch (1/1/1970)
+	Timestamp string
+	// Structured contents of a Move value
+	Data string
+	// Representation of a Move value in JSON
+	Json string
 }
 
 func (r *Event) Destroy() {
@@ -24214,6 +24220,9 @@ func (r *Event) Destroy() {
 		FfiDestroyerAddress{}.Destroy(r.Sender);
 		FfiDestroyerString{}.Destroy(r.Type);
 		FfiDestroyerBytes{}.Destroy(r.Contents);
+		FfiDestroyerString{}.Destroy(r.Timestamp);
+		FfiDestroyerString{}.Destroy(r.Data);
+		FfiDestroyerString{}.Destroy(r.Json);
 }
 
 type FfiConverterEvent struct {}
@@ -24231,6 +24240,9 @@ func (c FfiConverterEvent) Read(reader io.Reader) Event {
 			FfiConverterAddressINSTANCE.Read(reader),
 			FfiConverterStringINSTANCE.Read(reader),
 			FfiConverterBytesINSTANCE.Read(reader),
+			FfiConverterStringINSTANCE.Read(reader),
+			FfiConverterStringINSTANCE.Read(reader),
+			FfiConverterStringINSTANCE.Read(reader),
 	}
 }
 
@@ -24244,6 +24256,9 @@ func (c FfiConverterEvent) Write(writer io.Writer, value Event) {
 		FfiConverterAddressINSTANCE.Write(writer, value.Sender);
 		FfiConverterStringINSTANCE.Write(writer, value.Type);
 		FfiConverterBytesINSTANCE.Write(writer, value.Contents);
+		FfiConverterStringINSTANCE.Write(writer, value.Timestamp);
+		FfiConverterStringINSTANCE.Write(writer, value.Data);
+		FfiConverterStringINSTANCE.Write(writer, value.Json);
 }
 
 type FfiDestroyerEvent struct {}

--- a/bindings/kotlin/examples/PackageEvents.kt
+++ b/bindings/kotlin/examples/PackageEvents.kt
@@ -26,6 +26,7 @@ fun main() = runBlocking {
             println("Type: ${event.type}")
             println("Sender: ${event.sender}")
             println("Module: ${event.module}")
+            println("JSON: ${event.json}")
         }
     } catch (e: Exception) {
         e.printStackTrace()

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -44043,7 +44043,19 @@ data class Event (
     /**
      * BCS serialized bytes of the event
      */
-    var `contents`: kotlin.ByteArray
+    var `contents`: kotlin.ByteArray, 
+    /**
+     * UTC timestamp in milliseconds since epoch (1/1/1970)
+     */
+    var `timestamp`: kotlin.String, 
+    /**
+     * Structured contents of a Move value
+     */
+    var `data`: kotlin.String, 
+    /**
+     * Representation of a Move value in JSON
+     */
+    var `json`: kotlin.String
 ) : Disposable {
     
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -44054,7 +44066,10 @@ data class Event (
         this.`module`,
         this.`sender`,
         this.`type`,
-        this.`contents`
+        this.`contents`,
+        this.`timestamp`,
+        this.`data`,
+        this.`json`
     )
     }
     
@@ -44072,6 +44087,9 @@ public object FfiConverterTypeEvent: FfiConverterRustBuffer<Event> {
             FfiConverterTypeAddress.read(buf),
             FfiConverterString.read(buf),
             FfiConverterByteArray.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
         )
     }
 
@@ -44080,7 +44098,10 @@ public object FfiConverterTypeEvent: FfiConverterRustBuffer<Event> {
             FfiConverterString.allocationSize(value.`module`) +
             FfiConverterTypeAddress.allocationSize(value.`sender`) +
             FfiConverterString.allocationSize(value.`type`) +
-            FfiConverterByteArray.allocationSize(value.`contents`)
+            FfiConverterByteArray.allocationSize(value.`contents`) +
+            FfiConverterString.allocationSize(value.`timestamp`) +
+            FfiConverterString.allocationSize(value.`data`) +
+            FfiConverterString.allocationSize(value.`json`)
     )
 
     override fun write(value: Event, buf: ByteBuffer) {
@@ -44089,6 +44110,9 @@ public object FfiConverterTypeEvent: FfiConverterRustBuffer<Event> {
             FfiConverterTypeAddress.write(value.`sender`, buf)
             FfiConverterString.write(value.`type`, buf)
             FfiConverterByteArray.write(value.`contents`, buf)
+            FfiConverterString.write(value.`timestamp`, buf)
+            FfiConverterString.write(value.`data`, buf)
+            FfiConverterString.write(value.`json`, buf)
     }
 }
 

--- a/bindings/python/examples/package_events.py
+++ b/bindings/python/examples/package_events.py
@@ -20,6 +20,7 @@ async def main():
         print(f"Type: {event.type}")
         print(f"Sender: {event.sender.to_hex()}")
         print(f"Module: {event.module}")
+        print(f"JSON: {event.json}")
 
 
 if __name__ == "__main__":

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -10064,15 +10064,33 @@ class Event:
     BCS serialized bytes of the event
     """
 
-    def __init__(self, *, package_id: "ObjectId", module: "str", sender: "Address", type: "str", contents: "bytes"):
+    timestamp: "str"
+    """
+    UTC timestamp in milliseconds since epoch (1/1/1970)
+    """
+
+    data: "str"
+    """
+    Structured contents of a Move value
+    """
+
+    json: "str"
+    """
+    Representation of a Move value in JSON
+    """
+
+    def __init__(self, *, package_id: "ObjectId", module: "str", sender: "Address", type: "str", contents: "bytes", timestamp: "str", data: "str", json: "str"):
         self.package_id = package_id
         self.module = module
         self.sender = sender
         self.type = type
         self.contents = contents
+        self.timestamp = timestamp
+        self.data = data
+        self.json = json
 
     def __str__(self):
-        return "Event(package_id={}, module={}, sender={}, type={}, contents={})".format(self.package_id, self.module, self.sender, self.type, self.contents)
+        return "Event(package_id={}, module={}, sender={}, type={}, contents={}, timestamp={}, data={}, json={})".format(self.package_id, self.module, self.sender, self.type, self.contents, self.timestamp, self.data, self.json)
 
     def __eq__(self, other):
         if self.package_id != other.package_id:
@@ -10085,6 +10103,12 @@ class Event:
             return False
         if self.contents != other.contents:
             return False
+        if self.timestamp != other.timestamp:
+            return False
+        if self.data != other.data:
+            return False
+        if self.json != other.json:
+            return False
         return True
 
 class _UniffiConverterTypeEvent(_UniffiConverterRustBuffer):
@@ -10096,6 +10120,9 @@ class _UniffiConverterTypeEvent(_UniffiConverterRustBuffer):
             sender=_UniffiConverterTypeAddress.read(buf),
             type=_UniffiConverterString.read(buf),
             contents=_UniffiConverterBytes.read(buf),
+            timestamp=_UniffiConverterString.read(buf),
+            data=_UniffiConverterString.read(buf),
+            json=_UniffiConverterString.read(buf),
         )
 
     @staticmethod
@@ -10105,6 +10132,9 @@ class _UniffiConverterTypeEvent(_UniffiConverterRustBuffer):
         _UniffiConverterTypeAddress.check_lower(value.sender)
         _UniffiConverterString.check_lower(value.type)
         _UniffiConverterBytes.check_lower(value.contents)
+        _UniffiConverterString.check_lower(value.timestamp)
+        _UniffiConverterString.check_lower(value.data)
+        _UniffiConverterString.check_lower(value.json)
 
     @staticmethod
     def write(value, buf):
@@ -10113,6 +10143,9 @@ class _UniffiConverterTypeEvent(_UniffiConverterRustBuffer):
         _UniffiConverterTypeAddress.write(value.sender, buf)
         _UniffiConverterString.write(value.type, buf)
         _UniffiConverterBytes.write(value.contents, buf)
+        _UniffiConverterString.write(value.timestamp, buf)
+        _UniffiConverterString.write(value.data, buf)
+        _UniffiConverterString.write(value.json, buf)
 
 
 class EventFilter:

--- a/crates/iota-graphql-client/examples/package_events.rs
+++ b/crates/iota-graphql-client/examples/package_events.rs
@@ -29,6 +29,7 @@ async fn main() -> Result<()> {
         println!("Type: {}", event.type_);
         println!("Sender: {}", event.sender);
         println!("Module: {}", event.module);
+        println!("JSON: {}", event.json);
     }
 
     Ok(())

--- a/crates/iota-graphql-client/examples/package_events.rs
+++ b/crates/iota-graphql-client/examples/package_events.rs
@@ -26,9 +26,9 @@ async fn main() -> Result<()> {
         .await?;
 
     for event in events.data() {
-        println!("Type: {}", event.type_);
-        println!("Sender: {}", event.sender);
-        println!("Module: {}", event.module);
+        println!("Type: {}", event.type_.repr);
+        println!("Sender: {}", event.sender.as_ref().unwrap().address);
+        println!("Module: {}", event.sending_module.as_ref().unwrap().name);
         println!("JSON: {}", event.json);
     }
 

--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -15,16 +15,16 @@ use cynic::{GraphQlResponse, MutationBuilder, Operation, QueryBuilder, serde};
 use error::Error;
 use futures::Stream;
 use iota_types::{
-    Address, CheckpointSequenceNumber, CheckpointSummary, Digest, Event, Identifier, MovePackage,
-    Object, ObjectId, SignedTransaction, Transaction, TransactionEffects, TransactionKind, TypeTag,
-    UserSignature, framework::Coin,
+    Address, CheckpointSequenceNumber, CheckpointSummary, Digest, MovePackage, Object, ObjectId,
+    SignedTransaction, Transaction, TransactionEffects, TransactionKind, TypeTag, UserSignature,
+    framework::Coin,
 };
 use query_types::{
     ActiveValidatorsArgs, ActiveValidatorsQuery, BalanceArgs, BalanceQuery, ChainIdentifierQuery,
     CheckpointArgs, CheckpointId, CheckpointQuery, CheckpointsArgs, CheckpointsQuery, CoinMetadata,
     CoinMetadataArgs, CoinMetadataQuery, DryRunArgs, DryRunQuery, DynamicFieldArgs,
     DynamicFieldConnectionArgs, DynamicFieldQuery, DynamicFieldsOwnerQuery,
-    DynamicObjectFieldQuery, Epoch, EpochArgs, EpochQuery, EpochSummaryQuery, EventFilter,
+    DynamicObjectFieldQuery, Epoch, EpochArgs, EpochQuery, EpochSummaryQuery, Event, EventFilter,
     EventsQuery, EventsQueryArgs, ExecuteTransactionArgs, ExecuteTransactionQuery,
     LatestPackageQuery, MoveFunction, MoveModule, MovePackageVersionFilter,
     NormalizedMoveFunctionQuery, NormalizedMoveFunctionQueryArgs, NormalizedMoveModuleQuery,
@@ -890,28 +890,7 @@ impl Client {
             let ec = events.events;
             let page_info = ec.page_info;
 
-            let events = ec
-                .nodes
-                .into_iter()
-                .map(|node| {
-                    let module = node.sending_module.ok_or_else(|| {
-                        Error::from_error(
-                            Kind::Deserialization,
-                            "Expected a sending module for this event, but it is missing.",
-                        )
-                    })?;
-                    Ok(Event {
-                        package_id: module.package.address.into(),
-                        module: Identifier::new(module.name)?,
-                        sender: node.sender.map(|s| s.address).unwrap_or(Address::ZERO),
-                        type_: node.type_.repr.parse()?,
-                        contents: base64ct::Base64::decode_vec(&node.bcs.0)?,
-                        timestamp: node.timestamp.map(|t| t.0).unwrap_or_default(),
-                        data: node.data.0.to_string(),
-                        json: node.json.to_string(),
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
+            let events = ec.nodes;
 
             Ok(Page::new(page_info, events))
         } else {

--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -906,6 +906,9 @@ impl Client {
                         sender: node.sender.map(|s| s.address).unwrap_or(Address::ZERO),
                         type_: node.type_.repr.parse()?,
                         contents: base64ct::Base64::decode_vec(&node.bcs.0)?,
+                        timestamp: node.timestamp.map(|t| t.0).unwrap_or_default(),
+                        data: node.data.0.to_string(),
+                        json: node.json.to_string(),
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/crates/iota-graphql-client/src/query_types/events.rs
+++ b/crates/iota-graphql-client/src/query_types/events.rs
@@ -51,7 +51,7 @@ pub struct EventFilter {
     pub transaction_digest: Option<String>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "Event")]
 pub struct Event {
     pub sending_module: Option<MoveModuleQuery>,

--- a/crates/iota-graphql-client/src/query_types/events.rs
+++ b/crates/iota-graphql-client/src/query_types/events.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{
-    Address, Base64, GQLAddress, MoveType, PageInfo, normalized_move::MoveModuleQuery, schema,
+    Address, Base64, DateTime, GQLAddress, JsonValue, MoveData, MoveType, PageInfo,
+    normalized_move::MoveModuleQuery, schema,
 };
 
 // ===========================================================================
@@ -57,4 +58,7 @@ pub struct Event {
     pub sender: Option<GQLAddress>,
     pub type_: MoveType,
     pub bcs: Base64,
+    pub timestamp: Option<DateTime>,
+    pub data: MoveData,
+    pub json: JsonValue,
 }

--- a/crates/iota-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-graphql-client/src/query_types/mod.rs
@@ -128,7 +128,7 @@ pub struct MoveValue {
     pub json: Option<JsonValue>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "MoveType")]
 pub struct MoveType {
     pub repr: String,

--- a/crates/iota-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-graphql-client/src/query_types/mod.rs
@@ -94,6 +94,10 @@ pub struct BigInt(pub String);
 #[cynic(graphql_type = "DateTime")]
 pub struct DateTime(pub String);
 
+#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
+#[cynic(graphql_type = "MoveData")]
+pub struct MoveData(pub serde_json::Value);
+
 // ===========================================================================
 // Types used in several queries
 // ===========================================================================
@@ -129,6 +133,7 @@ pub struct MoveValue {
 pub struct MoveType {
     pub repr: String,
 }
+
 // ===========================================================================
 // Utility Types
 // ===========================================================================

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -31,6 +31,12 @@ pub struct Event {
     pub type_: String,
     /// BCS serialized bytes of the event
     pub contents: Vec<u8>,
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    pub timestamp: String,
+    /// Structured contents of a Move value
+    pub data: String,
+    /// Representation of a Move value in JSON
+    pub json: String,
 }
 
 impl From<iota_types::Event> for Event {
@@ -41,6 +47,9 @@ impl From<iota_types::Event> for Event {
             sender: Arc::new(value.sender.into()),
             type_: value.type_.to_string(),
             contents: value.contents,
+            timestamp: value.timestamp.clone(),
+            data: value.data.clone(),
+            json: value.json.to_string(),
         }
     }
 }
@@ -53,6 +62,9 @@ impl From<Event> for iota_types::Event {
             sender: (**value.sender),
             type_: StructTag::from_str(&value.type_).unwrap(),
             contents: value.contents,
+            timestamp: value.timestamp.clone(),
+            data: value.data.clone(),
+            json: value.json.clone(),
         }
     }
 }

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -3,6 +3,10 @@
 
 use std::{str::FromStr, sync::Arc};
 
+use base64ct::Encoding;
+use iota_graphql_client::query_types::{
+    Base64, DateTime, GQLAddress, MoveData, MoveModuleQuery, MovePackageQuery, MoveType,
+};
 use iota_types::{Identifier, StructTag};
 
 use crate::types::{address::Address, digest::Digest, object::ObjectId};
@@ -39,16 +43,19 @@ pub struct Event {
     pub json: String,
 }
 
-impl From<iota_types::Event> for Event {
-    fn from(value: iota_types::Event) -> Self {
+impl From<iota_graphql_client::query_types::Event> for Event {
+    fn from(value: iota_graphql_client::query_types::Event) -> Self {
+        let sending_module = value.sending_module.as_ref().unwrap();
         Self {
-            package_id: Arc::new(value.package_id.into()),
-            module: value.module.to_string(),
-            sender: Arc::new(value.sender.into()),
-            type_: value.type_.to_string(),
-            contents: value.contents,
-            timestamp: value.timestamp.clone(),
-            data: value.data.clone(),
+            package_id: Arc::new(ObjectId(iota_types::ObjectId::from(
+                sending_module.package.address,
+            ))),
+            module: sending_module.name.clone(),
+            sender: Arc::new(Address(value.sender.as_ref().unwrap().address)),
+            type_: value.type_.repr.clone(),
+            contents: base64ct::Base64::decode_vec(&value.bcs.0).unwrap_or_default(),
+            timestamp: value.timestamp.as_ref().unwrap().0.clone(),
+            data: value.data.0.to_string(),
             json: value.json.to_string(),
         }
     }
@@ -62,9 +69,45 @@ impl From<Event> for iota_types::Event {
             sender: (**value.sender),
             type_: StructTag::from_str(&value.type_).unwrap(),
             contents: value.contents,
-            timestamp: value.timestamp.clone(),
-            data: value.data.clone(),
-            json: value.json.clone(),
+        }
+    }
+}
+
+impl From<Event> for iota_graphql_client::query_types::Event {
+    fn from(value: Event) -> Self {
+        Self {
+            sending_module: Some(MoveModuleQuery {
+                package: MovePackageQuery {
+                    address: iota_types::Address::from(**value.package_id),
+                    bcs: None,
+                },
+                name: value.module.clone(),
+            }),
+            sender: Some(GQLAddress {
+                address: (**value.sender),
+            }),
+            type_: MoveType {
+                repr: value.type_.clone(),
+            },
+            bcs: Base64(base64ct::Base64::encode_string(&value.contents)),
+            timestamp: Some(DateTime(value.timestamp.clone())),
+            data: MoveData(serde_json::from_str(&value.data).unwrap_or_default()),
+            json: serde_json::Value::from_str(&value.json).unwrap_or_default(),
+        }
+    }
+}
+
+impl From<iota_types::Event> for Event {
+    fn from(value: iota_types::Event) -> Self {
+        Self {
+            package_id: Arc::new(value.package_id.into()),
+            module: value.module.to_string(),
+            sender: Arc::new(value.sender.into()),
+            type_: value.type_.to_string(),
+            contents: value.contents,
+            timestamp: String::new(),
+            data: String::new(),
+            json: String::new(),
         }
     }
 }

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -62,15 +62,6 @@ pub struct Event {
     )]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::Base64"))]
     pub contents: Vec<u8>,
-
-    /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    pub timestamp: String,
-
-    /// Structured contents of a Move value
-    pub data: String,
-
-    /// Representation of a Move value in JSON
-    pub json: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -62,6 +62,15 @@ pub struct Event {
     )]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::Base64"))]
     pub contents: Vec<u8>,
+
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    pub timestamp: String,
+
+    /// Structured contents of a Move value
+    pub data: String,
+
+    /// Representation of a Move value in JSON
+    pub json: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-rust-sdk/issues/205

```
make bindings-example package_events
make[1]: Verzeichnis „/home/t/Desktop/iota-rust-sdk“ wird betreten

Running Go example "package_events"
Type:  0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba::registry::NameRecordAddedEvent
Sender:  0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900
Module:  payment
JSON:  {"name":{"labels":["iota","name"]},"name_record":{"data":{"contents":[]},"expiration_timestamp_ms":"1783692571549","nft_id":"0x422e07698806aad526cf983e574f9f013b4a14a6ea6e51604f53d1f6e7debf10","target_address":null}}
```