### PR TITLE
chore: Add `iota-sdk` crate for publishing

### DIFF
--- a/crates/iota-graphql-client-build/schema.graphql
+++ b/crates/iota-graphql-client-build/schema.graphql
@@ -2107,7 +2107,7 @@ type MoveModuleEdge {
 
 """
 The representation of an object as a Move Object, which exposes additional
-information (content, module that governs it, version, is transferrable,
+information (content, module that governs it, version, is transferable,
 etc.) about this object.
 """
 type MoveObject implements IMoveObject & IObject & IOwner {

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.0.0"
 authors = ["IOTA Foundation <info@iota.org>"]
 edition = "2021"
 license = "Apache-2.0"
-description = "The official SDK for IOTA Rebased"
+description = "The official SDK for IOTA"
 
 [features]
 default = ["types"]

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -7,7 +7,24 @@ license = "Apache-2.0"
 description = "The official SDK for IOTA"
 
 [features]
-default = ["types"]
+default = [
+  "crypto",
+  "ed25519",
+  "secp256r1",
+  "passkey",
+  "secp256k1",
+  "zklogin",
+  "pem",
+  "bls12381",
+  "graphql",
+  "txn-builder",
+  "types",
+  "serder",
+  "rand",
+  "hash",
+  "proptest",
+  "schemars",
+]
 
 # Crypto
 crypto = ["dep:iota-crypto"]

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -19,7 +19,7 @@ default = [
   "graphql",
   "txn-builder",
   "types",
-  "serder",
+  "serde",
   "rand",
   "hash",
   "proptest",
@@ -28,13 +28,13 @@ default = [
 
 # Crypto
 crypto = ["dep:iota-crypto"]
-ed25519 = ["iota-crypto?/ed25519"]
-secp256r1 = ["iota-crypto?/secp256r1"]
-passkey = ["iota-crypto?/passkey"]
-secp256k1 = ["iota-crypto?/secp256k1"]
-zklogin = ["iota-crypto?/zklogin"]
-pem = ["iota-crypto?/pem"]
-bls12381 = ["iota-crypto?/bls12381"]
+ed25519 = ["crypto", "iota-crypto/ed25519"]
+secp256r1 = ["crypto", "iota-crypto/secp256r1"]
+passkey = ["crypto", "iota-crypto/passkey"]
+secp256k1 = ["crypto", "iota-crypto/secp256k1"]
+zklogin = ["crypto", "iota-crypto/zklogin"]
+pem = ["crypto", "iota-crypto/pem"]
+bls12381 = ["crypto", "iota-crypto/bls12381"]
 
 # GraphQL
 graphql = ["dep:iota-graphql-client"]
@@ -44,10 +44,10 @@ txn-builder = ["dep:iota-transaction-builder"]
 
 # Types
 types = ["dep:iota-sdk-types"]
-serde = ["iota-sdk-types?/serde"]
-rand = ["iota-sdk-types?/rand"]
-hash = ["iota-sdk-types?/hash"]
-proptest = ["iota-sdk-types?/proptest"]
+serde = ["types", "iota-sdk-types/serde"]
+rand = ["types", "iota-sdk-types/rand"]
+hash = ["types", "iota-sdk-types/hash"]
+proptest = ["types", "iota-sdk-types/proptest"]
 
 schemars = ["iota-sdk-types?/schemars", "iota-transaction-builder?/schemars"]
 

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "The official SDK for IOTA Rebased"
 
 [features]
-default = []
+default = ["types"]
 
 # Crypto
 crypto = ["dep:iota-crypto"]

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "iota-sdk"
+version = "3.0.0"
+authors = ["IOTA Foundation <info@iota.org>"]
+edition = "2021"
+license = "Apache-2.0"
+description = "The official SDK for IOTA Rebased"
+
+[features]
+default = []
+
+# Crypto
+crypto = ["dep:iota-crypto"]
+ed25519 = ["iota-crypto?/ed25519"]
+secp256r1 = ["iota-crypto?/secp256r1"]
+passkey = ["iota-crypto?/passkey"]
+secp256k1 = ["iota-crypto?/secp256k1"]
+zklogin = ["iota-crypto?/zklogin"]
+pem = ["iota-crypto?/pem"]
+bls12381 = ["iota-crypto?/bls12381"]
+
+# GraphQL
+graphql = ["dep:iota-graphql-client"]
+
+# Transaction Builder
+txn-builder = ["dep:iota-transaction-builder"]
+
+# Types
+types = ["dep:iota-sdk-types"]
+serde = ["iota-sdk-types?/serde"]
+rand = ["iota-sdk-types?/rand"]
+hash = ["iota-sdk-types?/hash"]
+proptest = ["iota-sdk-types?/proptest"]
+
+schemars = ["iota-sdk-types?/schemars", "iota-transaction-builder?/schemars"]
+
+[dependencies]
+iota-crypto = { path = "../iota-crypto", features = ["ed25519"], optional = true }
+iota-graphql-client = { path = "../iota-graphql-client", optional = true }
+iota-sdk-types = { path = "../iota-sdk-types", features = ["rand"], optional = true }
+iota-transaction-builder = { path = "../iota-transaction-builder", optional = true }

--- a/crates/iota-sdk/src/lib.rs
+++ b/crates/iota-sdk/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! The IOTA Rust SDK
+
+#[cfg(feature = "crypto")]
+pub use iota_crypto as crypto;
+#[cfg(feature = "graphql")]
+pub use iota_graphql_client as graphql_client;
+#[cfg(feature = "types")]
+pub use iota_sdk_types as types;
+#[cfg(feature = "txn-builder")]
+pub use iota_transaction_builder as transaction_builder;


### PR DESCRIPTION
## Description

Adds a wrapper crate for the other crates in this repo, which can be published to use the SDK.

Closes #227 