### PR TITLE
chore(examples): Add `split_coins` example

### DIFF
--- a/bindings/go/examples/prepare_split_coins/main.go
+++ b/bindings/go/examples/prepare_split_coins/main.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log"
+
+	sdk "bindings/iota_sdk_ffi"
+)
+
+func main() {
+	client := sdk.GraphQlClientNewDevnet()
+
+	sender, _ := sdk.AddressFromHex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
+
+	coinObjId, _ := sdk.ObjectIdFromHex("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")
+
+	builder := sdk.TransactionBuilderInit(sender, client)
+	builder.SplitCoins(coinObjId, []uint64{1000, 2000, 3000}, []string{"coin1", "coin2", "coin3"})
+	builder.TransferObjects(
+		sender,
+		[]*sdk.PtbArgument{sdk.PtbArgumentRes("coin1"), sdk.PtbArgumentRes("coin2"), sdk.PtbArgumentRes("coin3")},
+	)
+	builder.Gas(coinObjId).GasBudget(1000000000)
+
+	txn, err := builder.Finish()
+	if err.(*sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to create transaction: %v", err)
+	}
+
+	txnBytes, err := txn.BcsSerialize()
+	if err != nil {
+		log.Fatalf("Failed to serialize transaction: %v", err)
+	}
+	log.Printf("Signing Digest: %v", sdk.HexEncode(txn.SigningDigest()))
+	log.Printf("Txn Bytes: %v", sdk.Base64Encode(txnBytes))
+
+	res, err := builder.DryRun(false)
+	if err.(*sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to split coins: %v", err)
+	}
+
+	if res.Error != nil {
+		log.Fatalf("Failed to split coins: %v", *res.Error)
+	}
+
+	log.Print("Split coins dry run was successful!")
+}

--- a/bindings/kotlin/examples/PrepareSplitCoins.kt
+++ b/bindings/kotlin/examples/PrepareSplitCoins.kt
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.*
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+
+        val sender =
+                Address.fromHex(
+                        "0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c"
+                )
+
+        val coinId =
+                ObjectId.fromHex(
+                        "0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab"
+                )
+
+        val builder = TransactionBuilder.init(sender, client)
+
+        builder.splitCoins(
+                        coinId,
+                        listOf(1000uL, 2000uL, 3000uL),
+                        listOf("coin1", "coin2", "coin3")
+                )
+                .transferObjects(
+                        sender,
+                        listOf(
+                                PtbArgument.res("coin1"),
+                                PtbArgument.res("coin2"),
+                                PtbArgument.res("coin3")
+                        )
+                )
+                .gas(coinId)
+                .gasBudget(1000000000uL)
+
+        val txn = builder.finish()
+
+        println("Signing Digest: ${hexEncode(txn.signingDigest())}")
+        println("Txn Bytes: ${base64Encode(txn.bcsSerialize())}")
+
+        val res = builder.dryRun()
+
+        if (res.error != null) {
+            throw Exception("Failed to split coins: ${res.error}")
+        }
+
+        println("Split coins dry run was successful!")
+    } catch (e: Exception) {
+        e.printStackTrace()
+    }
+}

--- a/bindings/python/examples/prepare_split_coins.py
+++ b/bindings/python/examples/prepare_split_coins.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk_ffi import *
+
+import asyncio
+
+
+async def main():
+    try:
+        client = GraphQlClient.new_devnet()
+
+        sender = Address.from_hex(
+            "0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c"
+        )
+
+        coin_id = ObjectId.from_hex(
+            "0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab"
+        )
+
+        builder = await TransactionBuilder.init(sender, client)
+
+        builder.split_coins(
+            coin_id, [1000, 2000, 3000], ["coin1", "coin2", "coin3"]
+        ).transfer_objects(
+            sender,
+            [
+                PtbArgument.res("coin1"),
+                PtbArgument.res("coin2"),
+                PtbArgument.res("coin3"),
+            ],
+        ).gas(
+            coin_id
+        ).gas_budget(
+            1000000000
+        )
+
+        txn = await builder.finish()
+
+        print("Signing Digest:", hex_encode(txn.signing_digest()))
+        print("Txn Bytes:", base64_encode(txn.bcs_serialize()))
+
+        res = await builder.dry_run()
+        if res.error is not None:
+            raise Exception("Failed to split coins:", res.error)
+
+        print("Split coins dry run was successful!")
+
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-graphql-client/examples/prepare_split_coins.rs
+++ b/crates/iota-graphql-client/examples/prepare_split_coins.rs
@@ -6,21 +6,26 @@ use std::str::FromStr;
 use base64ct::Encoding;
 use eyre::Result;
 use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
+use iota_transaction_builder::{TransactionBuilder, res};
 use iota_types::{Address, ObjectId};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_devnet();
 
-    let from_address =
+    let sender =
         Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
     let coin =
         ObjectId::from_str("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")?;
 
-    let mut builder = TransactionBuilder::new(from_address).with_client(client.clone());
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
 
-    builder.split_coins(coin, [1000, 2000, 3000]);
+    builder
+        .split_coins(coin, [1000, 2000, 3000])
+        .name(("coin1", "coin2", "coin3"))
+        .transfer_objects(sender, [res("coin1"), res("coin2"), res("coin3")])
+        .gas(coin)
+        .gas_budget(1000000000);
 
     let txn = builder.finish().await?;
 
@@ -30,7 +35,7 @@ async fn main() -> Result<()> {
         base64ct::Base64::encode_string(&bcs::to_bytes(&txn)?)
     );
 
-    let res = client.dry_run_tx(&txn, true).await?;
+    let res = client.dry_run_tx(&txn, false).await?;
 
     if let Some(err) = res.error {
         eyre::bail!("Failed to split coin: {err}");

--- a/crates/iota-graphql-client/examples/prepare_split_coins.rs
+++ b/crates/iota-graphql-client/examples/prepare_split_coins.rs
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use base64ct::Encoding;
+use eyre::Result;
+use iota_graphql_client::Client;
+use iota_transaction_builder::TransactionBuilder;
+use iota_types::{Address, ObjectId};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let from_address =
+        Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
+    let coin =
+        ObjectId::from_str("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")?;
+
+    let mut builder = TransactionBuilder::new(from_address).with_client(client.clone());
+
+    builder.split_coins(coin, [1000, 2000, 3000]);
+
+    let txn = builder.finish().await?;
+
+    println!("Signing Digest: {}", hex::encode(txn.signing_digest()));
+    println!(
+        "Txn Bytes: {}",
+        base64ct::Base64::encode_string(&bcs::to_bytes(&txn)?)
+    );
+
+    let res = client.dry_run_tx(&txn, true).await?;
+
+    if let Some(err) = res.error {
+        eyre::bail!("Failed to split coin: {err}");
+    }
+
+    println!("Split coin dry run was successful!");
+
+    Ok(())
+}

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -80,6 +80,30 @@ impl PTBArguments for Vec<iota_types::Input> {
     }
 }
 
+impl PTBArguments for Vec<Res> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl<T: PTBArguments> PTBArguments for [T] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl<const N: usize, T: PTBArguments> PTBArguments for [T; N] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
 /// Allows specifying shared parameters.
 pub struct Shared<T>(pub T);
 


### PR DESCRIPTION
## Description

Adds an example that prepares a transaction to split a coin.

Closes #230