### PR TITLE
feat(transaction-builder): Refactor PTB args

### DIFF
--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -5312,7 +5312,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128()
 	})
-	if checksum != 39528 {
+	if checksum != 33699 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128: UniFFI API checksum mismatch")
 	}
@@ -5324,6 +5324,15 @@ func uniffiCheckChecksums() {
 	if checksum != 58656 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256()
+	})
+	if checksum != 46000 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -16178,15 +16187,21 @@ func PtbArgumentString(string string) *PtbArgument {
 	}))
 }
 
-func PtbArgumentU128(bytes []byte) *PtbArgument {
+func PtbArgumentU128(value string) *PtbArgument {
 	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(FfiConverterBytesINSTANCE.Lower(bytes),_uniffiStatus)
+		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(FfiConverterStringINSTANCE.Lower(value),_uniffiStatus)
 	}))
 }
 
 func PtbArgumentU16(value uint16) *PtbArgument {
 	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16(FfiConverterUint16INSTANCE.Lower(value),_uniffiStatus)
+	}))
+}
+
+func PtbArgumentU256(value string) *PtbArgument {
+	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256(FfiConverterStringINSTANCE.Lower(value),_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -5247,6 +5247,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas()
+	})
+	if checksum != 10767 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id()
 	})
 	if checksum != 41681 {
@@ -16124,6 +16133,12 @@ func PtbArgumentAddress(address *Address) *PtbArgument {
 func PtbArgumentDigest(digest *Digest) *PtbArgument {
 	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest(FfiConverterDigestINSTANCE.Lower(digest),_uniffiStatus)
+	}))
+}
+
+func PtbArgumentGas() *PtbArgument {
+	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas(_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -2717,12 +2717,17 @@ void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_string(RustBuffer string, R
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U128
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U128
-void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(RustBuffer bytes, RustCallStatus *out_status
+void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(RustBuffer value, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U16
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U16
 void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16(uint16_t value, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U256
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U256
+void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256(RustBuffer value, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_U32
@@ -8258,6 +8263,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_U16
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_U16
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_U256
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_U256
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256(void
     
 );
 #endif

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -2679,6 +2679,12 @@ void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_address(void* address, Rust
 void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest(void* digest, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_GAS
+void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas(RustCallStatus *out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_OBJECT_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_OBJECT_ID
 void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_object_id(void* id, RustCallStatus *out_status
@@ -8198,6 +8204,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_address(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_DIGEST
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_DIGEST
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_GAS
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas(void
     
 );
 #endif

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -2212,6 +2212,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -3330,6 +3332,8 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_string(
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16(
+): Short
+fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u32(
 ): Short
@@ -4490,9 +4494,11 @@ fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_shared_mut(`id`: Pointer,unif
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_string(`string`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(`bytes`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(`value`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16(`value`: Short,uniffi_out_err: UniffiRustCallStatus, 
+): Pointer
+fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256(`value`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u32(`value`: Int,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -7038,10 +7044,13 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_string() != 60971.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128() != 39528.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128() != 33699.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16() != 58656.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256() != 46000.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u32() != 13754.toShort()) {
@@ -27302,11 +27311,11 @@ open class PtbArgument: Disposable, AutoCloseable, PtbArgumentInterface
     }
     
 
-         fun `u128`(`bytes`: kotlin.ByteArray): PtbArgument {
+         fun `u128`(`value`: kotlin.String): PtbArgument {
             return FfiConverterTypePTBArgument.lift(
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128(
-        FfiConverterByteArray.lower(`bytes`),_status)
+        FfiConverterString.lower(`value`),_status)
 }
     )
     }
@@ -27317,6 +27326,16 @@ open class PtbArgument: Disposable, AutoCloseable, PtbArgumentInterface
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16(
         FfiConverterUShort.lower(`value`),_status)
+}
+    )
+    }
+    
+
+         fun `u256`(`value`: kotlin.String): PtbArgument {
+            return FfiConverterTypePTBArgument.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256(
+        FfiConverterString.lower(`value`),_status)
 }
     )
     }

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -2210,6 +2210,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -3310,6 +3312,8 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_owner_new_shared(
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_address(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest(
+): Short
+fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id(
 ): Short
@@ -4471,6 +4475,8 @@ fun uniffi_iota_sdk_ffi_fn_free_ptbargument(`ptr`: Pointer,uniffi_out_err: Uniff
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_address(`address`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest(`digest`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): Pointer
+fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_object_id(`id`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -7009,6 +7015,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest() != 54344.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas() != 10767.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id() != 41681.toShort()) {
@@ -27218,6 +27227,16 @@ open class PtbArgument: Disposable, AutoCloseable, PtbArgumentInterface
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest(
         FfiConverterTypeDigest.lower(`digest`),_status)
+}
+    )
+    }
+    
+
+         fun `gas`(): PtbArgument {
+            return FfiConverterTypePTBArgument.lift(
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas(
+        _status)
 }
     )
     }

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1561,9 +1561,11 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_string() != 60971:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128() != 39528:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128() != 33699:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16() != 58656:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256() != 46000:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u32() != 13754:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -4271,6 +4273,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u32.argtypes = (
     ctypes.c_uint32,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -8204,6 +8211,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u128.restype = c
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u16.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u256.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u32.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_u32.restype = ctypes.c_uint16
@@ -32334,12 +32344,12 @@ class PtbArgument():
         return cls._make_instance_(pointer)
 
     @classmethod
-    def u128(cls, bytes: "bytes"):
-        _UniffiConverterBytes.check_lower(bytes)
+    def u128(cls, value: "str"):
+        _UniffiConverterString.check_lower(value)
         
         # Call the (fallible) function before creating any half-baked object instances.
         pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u128,
-        _UniffiConverterBytes.lower(bytes))
+        _UniffiConverterString.lower(value))
         return cls._make_instance_(pointer)
 
     @classmethod
@@ -32349,6 +32359,15 @@ class PtbArgument():
         # Call the (fallible) function before creating any half-baked object instances.
         pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u16,
         _UniffiConverterUInt16.lower(value))
+        return cls._make_instance_(pointer)
+
+    @classmethod
+    def u256(cls, value: "str"):
+        _UniffiConverterString.check_lower(value)
+        
+        # Call the (fallible) function before creating any half-baked object instances.
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_u256,
+        _UniffiConverterString.lower(value))
         return cls._make_instance_(pointer)
 
     @classmethod

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1547,6 +1547,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest() != 54344:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas() != 10767:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id() != 41681:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving() != 50553:
@@ -4225,6 +4227,10 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas.argtypes = (
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_object_id.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -8171,6 +8177,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_address.restype 
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_digest.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_gas.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_object_id.restype = ctypes.c_uint16
@@ -32262,6 +32271,12 @@ class PtbArgument():
         # Call the (fallible) function before creating any half-baked object instances.
         pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_digest,
         _UniffiConverterTypeDigest.lower(digest))
+        return cls._make_instance_(pointer)
+
+    @classmethod
+    def gas(cls, ):
+        # Call the (fallible) function before creating any half-baked object instances.
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_gas,)
         return cls._make_instance_(pointer)
 
     @classmethod

--- a/crates/iota-graphql-client/examples/prepare_split_coins.rs
+++ b/crates/iota-graphql-client/examples/prepare_split_coins.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     builder
         .split_coins(coin, [1000, 2000, 3000])
         .name(("coin1", "coin2", "coin3"))
-        .transfer_objects(sender, [res("coin1"), res("coin2"), res("coin3")])
+        .transfer_objects(sender, (res("coin1"), res("coin2"), res("coin3")))
         .gas(coin)
         .gas_budget(1000000000);
 

--- a/crates/iota-sdk-ffi/Cargo.toml
+++ b/crates/iota-sdk-ffi/Cargo.toml
@@ -18,6 +18,7 @@ base64ct = { version = "1.6.0", features = ["alloc", "std"] }
 bcs = "0.1.6"
 derive_more = { version = "2.0", features = ["from", "deref", "display"] }
 hex = "0.4.3"
+primitive-types = { version = "0.14", features = ["impl-serde"] }
 rand = "0.8"
 roaring = { version = "0.11.2", default-features = false }
 serde = { version = "1.0.144" }

--- a/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use iota_transaction_builder::{MovePackageData, PTBArguments};
+use iota_transaction_builder::MovePackageData;
 use iota_types::Input;
 
 use crate::{

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -3,120 +3,162 @@
 
 use std::sync::Arc;
 
-use iota_transaction_builder::{Receiving, Shared, SharedMut, res, types::PureBytes};
+use iota_transaction_builder::{
+    PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::Res, res,
+};
 
 use crate::types::{address::Address, digest::Digest, object::ObjectId};
 
-type DynPTBArg = Box<dyn iota_transaction_builder::PTBArguments + Send + Sync>;
+#[derive(derive_more::From)]
+enum PTBArg {
+    ObjectId(iota_types::ObjectId),
+    Address(iota_types::Address),
+    Digest(iota_types::Digest),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    String(String),
+    Vector(Vec<PureBytes>),
+    Res(Res),
+    Shared(Shared<iota_types::ObjectId>),
+    SharedMut(SharedMut<iota_types::ObjectId>),
+    Receiving(Receiving<iota_types::ObjectId>),
+    Gas,
+}
 
 #[derive(uniffi::Object)]
-pub struct PTBArgument(DynPTBArg);
+pub struct PTBArgument(PTBArg);
 
 #[uniffi::export]
 impl PTBArgument {
     #[uniffi::constructor]
     pub fn res(name: String) -> Self {
-        Self(Box::new(res(name)))
+        Self(res(name).into())
     }
 
     #[uniffi::constructor]
     pub fn object_id(id: &ObjectId) -> Self {
-        Self(Box::new(**id))
+        Self((**id).into())
     }
 
     #[uniffi::constructor]
     pub fn address(address: &Address) -> Self {
-        Self(Box::new(**address))
+        Self((**address).into())
     }
 
     #[uniffi::constructor]
     pub fn shared(id: &ObjectId) -> Self {
-        Self(Box::new(Shared(**id)))
+        Self(Shared(**id).into())
     }
 
     #[uniffi::constructor]
     pub fn shared_mut(id: &ObjectId) -> Self {
-        Self(Box::new(SharedMut(**id)))
+        Self(SharedMut(**id).into())
     }
 
     #[uniffi::constructor]
     pub fn receiving(id: &ObjectId) -> Self {
-        Self(Box::new(Receiving(**id)))
+        Self(Receiving(**id).into())
     }
 
     #[uniffi::constructor]
     pub fn digest(digest: &Digest) -> Self {
-        Self(Box::new(**digest))
+        Self((**digest).into())
     }
 
     #[uniffi::constructor]
     pub fn u8(value: u8) -> Self {
-        Self(Box::new(value))
+        Self(value.into())
     }
 
     #[uniffi::constructor]
     pub fn u16(value: u16) -> Self {
-        Self(Box::new(value))
+        Self(value.into())
     }
 
     #[uniffi::constructor]
     pub fn u32(value: u32) -> Self {
-        Self(Box::new(value))
+        Self(value.into())
     }
 
     #[uniffi::constructor]
     pub fn u64(value: u64) -> Self {
-        Self(Box::new(value))
+        Self(value.into())
     }
 
     #[uniffi::constructor]
     pub fn u128(bytes: &[u8]) -> Self {
-        Self(Box::new(u128::from_le_bytes(
-            bytes.try_into().expect("invalid le bytes for u128"),
-        )))
+        Self(u128::from_le_bytes(bytes.try_into().expect("invalid le bytes for u128")).into())
     }
 
     #[uniffi::constructor]
     pub fn string(string: String) -> Self {
-        Self(Box::new(string))
+        Self(string.into())
     }
 
     #[uniffi::constructor]
     pub fn vector(vec: Vec<Vec<u8>>) -> Self {
-        Self(Box::new(vec.into_iter().map(PureBytes).collect::<Vec<_>>()))
+        Self(vec.into_iter().map(PureBytes).collect::<Vec<_>>().into())
+    }
+
+    #[uniffi::constructor]
+    pub fn gas() -> Self {
+        Self(PTBArg::Gas)
     }
 }
 
-impl iota_transaction_builder::PTBArguments for PTBArgument {
-    fn push_args(
-        &self,
+impl iota_transaction_builder::PTBArgument for PTBArgument {
+    fn arg(
+        self,
         ptb: &mut iota_transaction_builder::builder::TransactionBuildData,
-        args: &mut Vec<iota_transaction_builder::unresolved::Argument>,
-    ) {
-        self.0.push_args(ptb, args);
+    ) -> iota_transaction_builder::unresolved::Argument {
+        self.0.arg(ptb)
     }
 }
 
-impl iota_transaction_builder::PTBArguments for &PTBArgument {
-    fn push_args(
-        &self,
+impl iota_transaction_builder::PTBArgument for &PTBArgument {
+    fn arg(
+        self,
         ptb: &mut iota_transaction_builder::builder::TransactionBuildData,
-        args: &mut Vec<iota_transaction_builder::unresolved::Argument>,
-    ) {
-        self.0.push_args(ptb, args);
+    ) -> iota_transaction_builder::unresolved::Argument {
+        self.0.arg(ptb)
     }
 }
 
 pub struct PTBArgs(pub Vec<Arc<PTBArgument>>);
 
-impl iota_transaction_builder::PTBArguments for PTBArgs {
-    fn push_args(
-        &self,
+impl iota_transaction_builder::PTBArgument for PTBArgs {
+    fn arg(
+        self,
         ptb: &mut iota_transaction_builder::builder::TransactionBuildData,
-        args: &mut Vec<iota_transaction_builder::unresolved::Argument>,
-    ) {
-        for arg in &self.0 {
-            arg.push_args(ptb, args);
+    ) -> iota_transaction_builder::unresolved::Argument {
+        todo!()
+    }
+}
+
+impl iota_transaction_builder::PTBArgument for &PTBArg {
+    fn arg(
+        self,
+        ptb: &mut iota_transaction_builder::builder::TransactionBuildData,
+    ) -> iota_transaction_builder::unresolved::Argument {
+        match self {
+            PTBArg::ObjectId(object_id) => object_id.arg(ptb),
+            PTBArg::Address(address) => address.arg(ptb),
+            PTBArg::Digest(digest) => digest.arg(ptb),
+            PTBArg::U8(val) => val.arg(ptb),
+            PTBArg::U16(val) => val.arg(ptb),
+            PTBArg::U32(val) => val.arg(ptb),
+            PTBArg::U64(val) => val.arg(ptb),
+            PTBArg::U128(val) => val.arg(ptb),
+            PTBArg::String(val) => val.arg(ptb),
+            PTBArg::Vector(pure_bytes) => pure_bytes.clone().arg(ptb),
+            PTBArg::Res(res) => res.arg(ptb),
+            PTBArg::Shared(shared) => shared.arg(ptb),
+            PTBArg::SharedMut(shared_mut) => shared_mut.arg(ptb),
+            PTBArg::Receiving(receiving) => receiving.arg(ptb),
+            PTBArg::Gas => iota_transaction_builder::unresolved::Argument::Gas,
         }
     }
 }

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use iota_transaction_builder::{Receiving, Shared, SharedMut, res, types::ArgType};
+use iota_transaction_builder::{Receiving, Shared, SharedMut, res, types::PureBytes};
 
 use crate::types::{address::Address, digest::Digest, object::ObjectId};
 
@@ -83,9 +83,7 @@ impl PTBArgument {
 
     #[uniffi::constructor]
     pub fn vector(vec: Vec<Vec<u8>>) -> Self {
-        Self(Box::new(
-            vec.into_iter().map(ArgType::Pure).collect::<Vec<_>>(),
-        ))
+        Self(Box::new(vec.into_iter().map(PureBytes).collect::<Vec<_>>()))
     }
 }
 

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use iota_transaction_builder::{
     PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::Res, res,
 };
+use primitive_types::U256;
 
 use crate::types::{address::Address, digest::Digest, object::ObjectId};
 
@@ -19,6 +20,7 @@ enum PTBArg {
     U32(u32),
     U64(u64),
     U128(u128),
+    U256(U256),
     String(String),
     Vector(Vec<PureBytes>),
     Res(Res),
@@ -89,8 +91,17 @@ impl PTBArgument {
     }
 
     #[uniffi::constructor]
-    pub fn u128(bytes: &[u8]) -> Self {
-        Self(u128::from_le_bytes(bytes.try_into().expect("invalid le bytes for u128")).into())
+    pub fn u128(value: &str) -> Self {
+        Self(
+            u128::from_str_radix(value, 10)
+                .expect("invalid u128")
+                .into(),
+        )
+    }
+
+    #[uniffi::constructor]
+    pub fn u256(value: &str) -> Self {
+        Self(U256::from_dec_str(value).expect("invalid u256").into())
     }
 
     #[uniffi::constructor]
@@ -155,6 +166,7 @@ impl iota_transaction_builder::PTBArgument for &PTBArg {
             PTBArg::U32(val) => val.arg(ptb),
             PTBArg::U64(val) => val.arg(ptb),
             PTBArg::U128(val) => val.arg(ptb),
+            PTBArg::U256(val) => val.arg(ptb),
             PTBArg::String(val) => val.arg(ptb),
             PTBArg::Vector(pure_bytes) => pure_bytes.clone().arg(ptb),
             PTBArg::Res(res) => res.arg(ptb),

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -92,11 +92,7 @@ impl PTBArgument {
 
     #[uniffi::constructor]
     pub fn u128(value: &str) -> Self {
-        Self(
-            u128::from_str_radix(value, 10)
-                .expect("invalid u128")
-                .into(),
-        )
+        Self(value.parse::<u128>().expect("invalid u128").into())
     }
 
     #[uniffi::constructor]

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -129,12 +129,15 @@ impl iota_transaction_builder::PTBArgument for &PTBArgument {
 
 pub struct PTBArgs(pub Vec<Arc<PTBArgument>>);
 
-impl iota_transaction_builder::PTBArgument for PTBArgs {
-    fn arg(
+impl iota_transaction_builder::PTBArguments for PTBArgs {
+    fn push_args(
         self,
         ptb: &mut iota_transaction_builder::builder::TransactionBuildData,
-    ) -> iota_transaction_builder::unresolved::Argument {
-        todo!()
+        args: &mut Vec<iota_transaction_builder::unresolved::Argument>,
+    ) {
+        for arg in &self.0 {
+            args.push(iota_transaction_builder::PTBArgument::arg(&arg.0, ptb))
+        }
     }
 }
 

--- a/crates/iota-transaction-builder/Cargo.toml
+++ b/crates/iota-transaction-builder/Cargo.toml
@@ -13,7 +13,7 @@ derive_more = { version = "2.0", features = ["from"] }
 iota-crypto = { package = "iota-crypto", path = "../iota-crypto", features = ["ed25519"] }
 iota-graphql-client = { package = "iota-graphql-client", path = "../iota-graphql-client" }
 iota-types = { package = "iota-sdk-types", path = "../iota-sdk-types", features = ["serde", "hash"] }
-primitive-types = { version = "0.13", features = ["impl-serde"] }
+primitive-types = { version = "0.14", features = ["impl-serde"] }
 serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -17,6 +17,7 @@ use iota_types::{
 use serde::Serialize;
 
 use crate::{
+    PTBArgument,
     builder::{
         named_results::{NamedResult, NamedResults},
         ptb_arguments::PTBArguments,
@@ -191,6 +192,11 @@ impl TransactionBuilder {
 }
 
 impl<C, L> TransactionBuilder<C, L> {
+    /// Apply the given parameter and return the generated argument
+    pub fn apply_argument<P: PTBArgument>(&mut self, param: P) -> Argument {
+        param.arg(&mut self.data)
+    }
+
     /// Apply the given parameters and return the generated arguments
     pub fn apply_arguments<P: PTBArguments>(&mut self, param: P) -> Vec<Argument> {
         param.args(&mut self.data)
@@ -655,7 +661,7 @@ impl<L> TransactionBuilder<Client, L> {
     }
 
     /// Upgrade a move package.
-    pub fn upgrade<U: PTBArguments>(
+    pub fn upgrade<U: PTBArgument>(
         &mut self,
         package_id: ObjectId,
         upgrade_cap: U,
@@ -665,16 +671,12 @@ impl<L> TransactionBuilder<Client, L> {
             PublishType::Path(_path) => todo!("load the package from the path"),
             PublishType::Compiled(m) => m,
         };
-        let ticket = self.apply_arguments(upgrade_cap);
-        if ticket.len() != 1 {
-            // TODO: Maybe there's a better way
-            panic!("invalid upgrade cap");
-        }
+        let ticket = self.apply_argument(upgrade_cap);
         self.state_change(Upgrade {
             modules: module.modules,
             dependencies: module.dependencies,
             package: package_id,
-            ticket: ticket.into_iter().next().unwrap(),
+            ticket,
         })
     }
 

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -31,7 +31,8 @@ use crate::{
 };
 
 mod named_results;
-pub(crate) mod ptb_arguments;
+/// Argument types for PTBs
+pub mod ptb_arguments;
 
 /// A transaction builder which can be used to construct [`Transaction`]s.
 #[derive(Debug, Clone)]

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -136,6 +136,22 @@ impl<const N: usize> PTBArguments for [ObjectId; N] {
     }
 }
 
+impl PTBArguments for Vec<Res> {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            args.push(input.arg(ptb));
+        }
+    }
+}
+
+impl<const N: usize> PTBArguments for [Res; N] {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            args.push(input.arg(ptb));
+        }
+    }
+}
+
 impl<T> PTBArguments for &[T]
 where
     for<'a> &'a T: PTBArgument,

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -1,9 +1,11 @@
 // Copyright 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_types::ObjectId;
+
 use crate::{
     builder::TransactionBuildData,
-    types::{ArgType, MoveArg},
+    types::MoveArg,
     unresolved::{Argument, InputKind},
 };
 
@@ -39,21 +41,11 @@ variadics_please::all_tuples_enumerated!(impl_ptb_args_tuple, 2, 15, T);
 
 impl<T: MoveArg> PTBArguments for T {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        let arg = match self.arg_type() {
-            ArgType::Object(id) => ptb.set_input(InputKind::ImmutableOrOwned(id), false),
-            ArgType::Pure(v) => ptb.pure_bytes(v),
-        };
-        args.push(arg);
+        args.push(ptb.pure_bytes(self.pure_bytes()));
     }
 }
 
 impl<T: PTBArguments> PTBArguments for std::sync::Arc<T> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        self.as_ref().push_args(ptb, args);
-    }
-}
-
-impl PTBArguments for Box<dyn PTBArguments> {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         self.as_ref().push_args(ptb, args);
     }
@@ -65,6 +57,30 @@ impl PTBArguments for Argument {
     }
 }
 
+impl<const N: usize> PTBArguments for [Argument; N] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for [Argument] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for Vec<Argument> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
 impl PTBArguments for iota_types::Input {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         let arg = ptb.input(self.clone());
@@ -72,7 +88,53 @@ impl PTBArguments for iota_types::Input {
     }
 }
 
+impl<const N: usize> PTBArguments for [iota_types::Input; N] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for [iota_types::Input] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
 impl PTBArguments for Vec<iota_types::Input> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for ObjectId {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        args.push(ptb.set_input(InputKind::ImmutableOrOwned(*self), false))
+    }
+}
+
+impl<const N: usize> PTBArguments for [ObjectId; N] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for [ObjectId] {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            input.push_args(ptb, args);
+        }
+    }
+}
+
+impl PTBArguments for Vec<ObjectId> {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
             input.push_args(ptb, args);
@@ -85,17 +147,19 @@ pub struct Shared<T>(pub T);
 
 impl<T: MoveArg> PTBArguments for Shared<T> {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        let arg = match self.0.arg_type() {
-            ArgType::Object(id) => ptb.set_input(
-                InputKind::Shared {
-                    object_id: id,
-                    mutable: false,
-                },
-                false,
-            ),
-            ArgType::Pure(v) => ptb.pure_bytes(v),
-        };
-        args.push(arg);
+        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+    }
+}
+
+impl PTBArguments for Shared<ObjectId> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        args.push(ptb.set_input(
+            InputKind::Shared {
+                object_id: self.0,
+                mutable: false,
+            },
+            false,
+        ))
     }
 }
 
@@ -104,17 +168,19 @@ pub struct SharedMut<T>(pub T);
 
 impl<T: MoveArg> PTBArguments for SharedMut<T> {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        let arg = match self.0.arg_type() {
-            ArgType::Object(id) => ptb.set_input(
-                InputKind::Shared {
-                    object_id: id,
-                    mutable: true,
-                },
-                false,
-            ),
-            ArgType::Pure(v) => ptb.pure_bytes(v),
-        };
-        args.push(arg);
+        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+    }
+}
+
+impl PTBArguments for SharedMut<ObjectId> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        args.push(ptb.set_input(
+            InputKind::Shared {
+                object_id: self.0,
+                mutable: true,
+            },
+            false,
+        ))
     }
 }
 
@@ -123,11 +189,13 @@ pub struct Receiving<T>(pub T);
 
 impl<T: MoveArg> PTBArguments for Receiving<T> {
     fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        let arg = match self.0.arg_type() {
-            ArgType::Object(id) => ptb.set_input(InputKind::Receiving(id), false),
-            ArgType::Pure(v) => ptb.pure_bytes(v),
-        };
-        args.push(arg);
+        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+    }
+}
+
+impl PTBArguments for Receiving<ObjectId> {
+    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        args.push(ptb.set_input(InputKind::Receiving(self.0), false))
     }
 }
 

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -5,22 +5,56 @@ use iota_types::ObjectId;
 
 use crate::{
     builder::TransactionBuildData,
-    types::MoveArg,
+    types::{MoveArg, MoveArgCollection},
     unresolved::{Argument, InputKind},
 };
+
+/// A trait which defines an argument for a
+/// [`TransactionBuilder`](crate::TransactionBuilder).
+pub trait PTBArgument {
+    /// Get the argument.
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument;
+}
+
+impl PTBArgument for Argument {
+    fn arg(self, _ptb: &mut TransactionBuildData) -> Argument {
+        self
+    }
+}
+
+impl PTBArgument for iota_types::Input {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.input(self)
+    }
+}
+
+impl PTBArgument for ObjectId {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.set_input(InputKind::ImmutableOrOwned(self), false)
+    }
+}
+
+impl<T: MoveArgCollection> PTBArgument for T {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.pure_bytes(self.collection_bytes().0)
+    }
+}
 
 /// A trait which defines arguments for a
 /// [`TransactionBuilder`](crate::TransactionBuilder).
 pub trait PTBArguments {
     /// Get the arguments.
-    fn args(&self, ptb: &mut TransactionBuildData) -> Vec<Argument> {
+    fn args(self, ptb: &mut TransactionBuildData) -> Vec<Argument>
+    where
+        Self: Sized,
+    {
         let mut args = Vec::new();
         self.push_args(ptb, &mut args);
         args
     }
 
     /// Push the args onto the list.
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>);
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>);
 }
 
 macro_rules! impl_ptb_args_tuple {
@@ -28,7 +62,7 @@ macro_rules! impl_ptb_args_tuple {
         impl<$($T),+> PTBArguments for ($($T),+)
         where $($T: PTBArguments),+
         {
-            fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+            fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
                 $(
                     self.$n.push_args(ptb, args);
                 )+
@@ -39,105 +73,76 @@ macro_rules! impl_ptb_args_tuple {
 
 variadics_please::all_tuples_enumerated!(impl_ptb_args_tuple, 2, 15, T);
 
-impl<T: MoveArg> PTBArguments for T {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.pure_bytes(self.pure_bytes()));
-    }
-}
-
-impl<T: PTBArguments> PTBArguments for std::sync::Arc<T> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+impl<T> PTBArguments for std::sync::Arc<T>
+where
+    for<'a> &'a T: PTBArguments,
+{
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         self.as_ref().push_args(ptb, args);
     }
 }
 
-impl PTBArguments for Argument {
-    fn push_args(&self, _: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(*self);
-    }
-}
-
-impl<const N: usize> PTBArguments for [Argument; N] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
-impl PTBArguments for [Argument] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
-        }
+impl<T: PTBArgument> PTBArguments for T {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        args.push(self.arg(ptb))
     }
 }
 
 impl PTBArguments for Vec<Argument> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
-            input.push_args(ptb, args);
+            args.push(input.arg(ptb));
         }
     }
 }
 
-impl PTBArguments for iota_types::Input {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        let arg = ptb.input(self.clone());
-        args.push(arg);
-    }
-}
-
-impl<const N: usize> PTBArguments for [iota_types::Input; N] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+impl<const N: usize> PTBArguments for [Argument; N] {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
-impl PTBArguments for [iota_types::Input] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
+            args.push(input.arg(ptb));
         }
     }
 }
 
 impl PTBArguments for Vec<iota_types::Input> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
-            input.push_args(ptb, args);
+            args.push(input.arg(ptb));
         }
     }
 }
 
-impl PTBArguments for ObjectId {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.set_input(InputKind::ImmutableOrOwned(*self), false))
-    }
-}
-
-impl<const N: usize> PTBArguments for [ObjectId; N] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+impl<const N: usize> PTBArguments for [iota_types::Input; N] {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
-impl PTBArguments for [ObjectId] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
+            args.push(input.arg(ptb));
         }
     }
 }
 
 impl PTBArguments for Vec<ObjectId> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
         for input in self {
-            input.push_args(ptb, args);
+            args.push(input.arg(ptb));
+        }
+    }
+}
+
+impl<const N: usize> PTBArguments for [ObjectId; N] {
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            args.push(input.arg(ptb));
+        }
+    }
+}
+
+impl<T> PTBArguments for &[T]
+where
+    for<'a> &'a T: PTBArgument,
+{
+    fn push_args(self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+        for input in self {
+            args.push(input.arg(ptb));
         }
     }
 }
@@ -145,57 +150,75 @@ impl PTBArguments for Vec<ObjectId> {
 /// Allows specifying shared parameters.
 pub struct Shared<T>(pub T);
 
-impl<T: MoveArg> PTBArguments for Shared<T> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+impl<T: MoveArg> PTBArgument for Shared<T> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        self.0.arg(ptb)
     }
 }
 
-impl PTBArguments for Shared<ObjectId> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.set_input(
+impl PTBArgument for Shared<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        (&self).arg(ptb)
+    }
+}
+
+impl PTBArgument for &Shared<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.set_input(
             InputKind::Shared {
                 object_id: self.0,
                 mutable: false,
             },
             false,
-        ))
+        )
     }
 }
 
 /// Allows specifying shared mutable parameters.
 pub struct SharedMut<T>(pub T);
 
-impl<T: MoveArg> PTBArguments for SharedMut<T> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+impl<T: MoveArg> PTBArgument for SharedMut<T> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        self.0.arg(ptb)
     }
 }
 
-impl PTBArguments for SharedMut<ObjectId> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.set_input(
+impl PTBArgument for SharedMut<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        (&self).arg(ptb)
+    }
+}
+
+impl PTBArgument for &SharedMut<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.set_input(
             InputKind::Shared {
                 object_id: self.0,
                 mutable: true,
             },
             false,
-        ))
+        )
     }
 }
 
 /// Allows specifying receiving parameters.
 pub struct Receiving<T>(pub T);
 
-impl<T: MoveArg> PTBArguments for Receiving<T> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.pure_bytes(self.0.pure_bytes()));
+impl<T: MoveArg> PTBArgument for Receiving<T> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        self.0.arg(ptb)
     }
 }
 
-impl PTBArguments for Receiving<ObjectId> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        args.push(ptb.set_input(InputKind::Receiving(self.0), false))
+impl PTBArgument for Receiving<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        (&self).arg(ptb)
+    }
+}
+
+impl PTBArgument for &Receiving<ObjectId> {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        ptb.set_input(InputKind::Receiving(self.0), false)
     }
 }
 
@@ -207,10 +230,16 @@ pub fn res(name: impl Into<String>) -> Res {
     Res(name.into())
 }
 
-impl PTBArguments for Res {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
+impl PTBArgument for Res {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
+        (&self).arg(ptb)
+    }
+}
+
+impl PTBArgument for &Res {
+    fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
         if let Some(arg) = ptb.named_results.get(&self.0) {
-            args.push(*arg);
+            *arg
         } else {
             panic!("no command named `{}` exists", self.0)
         }

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -147,30 +147,6 @@ where
     }
 }
 
-impl PTBArguments for Vec<Res> {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
-impl<T: PTBArguments> PTBArguments for [T] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
-impl<const N: usize, T: PTBArguments> PTBArguments for [T; N] {
-    fn push_args(&self, ptb: &mut TransactionBuildData, args: &mut Vec<Argument>) {
-        for input in self {
-            input.push_args(ptb, args);
-        }
-    }
-}
-
 /// Allows specifying shared parameters.
 pub struct Shared<T>(pub T);
 

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -16,9 +16,10 @@ pub mod unresolved;
 pub use self::{
     builder::{
         TransactionBuilder,
-        ptb_arguments::{PTBArguments, Receiving, Shared, SharedMut, res},
+        ptb_arguments::{PTBArgument, Receiving, Shared, SharedMut, res},
     },
     publish_type::MovePackageData,
+    types::PureBytes,
 };
 
 #[cfg(test)]

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -16,7 +16,7 @@ pub mod unresolved;
 pub use self::{
     builder::{
         TransactionBuilder,
-        ptb_arguments::{PTBArgument, Receiving, Shared, SharedMut, res},
+        ptb_arguments::{PTBArgument, PTBArguments, Receiving, Shared, SharedMut, res},
     },
     publish_type::MovePackageData,
     types::PureBytes,

--- a/crates/iota-transaction-builder/src/types/mod.rs
+++ b/crates/iota-transaction-builder/src/types/mod.rs
@@ -8,7 +8,7 @@ use iota_types::{Address, TypeTag};
 mod move_arg;
 mod move_type;
 
-pub use move_arg::{MoveArg, PureBytes};
+pub use move_arg::{MoveArg, MoveArgCollection, PureBytes};
 pub use move_type::{MoveType, MoveTypes};
 use primitive_types::U256;
 
@@ -20,9 +20,15 @@ macro_rules! impl_simple_move_type {
             }
         }
 
+        impl MoveArg for &$rust_ty {
+            fn pure_bytes(self) -> PureBytes {
+                PureBytes(bcs::to_bytes(self).expect("bcs serialization failed"))
+            }
+        }
+
         impl MoveArg for $rust_ty {
-            fn pure_bytes(&self) -> Vec<u8> {
-                bcs::to_bytes(self).expect("bcs serialization failed")
+            fn pure_bytes(self) -> PureBytes {
+                PureBytes(bcs::to_bytes(&self).expect("bcs serialization failed"))
             }
         }
     };

--- a/crates/iota-transaction-builder/src/types/mod.rs
+++ b/crates/iota-transaction-builder/src/types/mod.rs
@@ -3,23 +3,14 @@
 
 //! Types for use with the transaction builder.
 
-use iota_types::{Address, ObjectId, TypeTag};
+use iota_types::{Address, TypeTag};
 
 mod move_arg;
 mod move_type;
 
-pub use move_arg::MoveArg;
+pub use move_arg::{MoveArg, PureBytes};
 pub use move_type::{MoveType, MoveTypes};
 use primitive_types::U256;
-
-/// A parameter type.
-#[derive(Clone, Debug)]
-pub enum ArgType {
-    /// An object, referenced by ID.
-    Object(ObjectId),
-    /// A bcs serialized value.
-    Pure(Vec<u8>),
-}
 
 macro_rules! impl_simple_move_type {
     ($rust_ty:ident, $move_ty:ident) => {
@@ -30,8 +21,8 @@ macro_rules! impl_simple_move_type {
         }
 
         impl MoveArg for $rust_ty {
-            fn arg_type(&self) -> ArgType {
-                ArgType::Pure(bcs::to_bytes(self).expect("bcs serialization failed"))
+            fn pure_bytes(&self) -> Vec<u8> {
+                bcs::to_bytes(self).expect("bcs serialization failed")
             }
         }
     };

--- a/crates/iota-transaction-builder/src/types/move_arg.rs
+++ b/crates/iota-transaction-builder/src/types/move_arg.rs
@@ -4,56 +4,98 @@
 use iota_types::Digest;
 
 /// Pure BCS bytes
+#[derive(Clone, Debug, Default)]
 pub struct PureBytes(pub Vec<u8>);
 
 /// A trait which defines how types are serialized for move calls.
 pub trait MoveArg {
     /// Get the pure BCS bytes.
-    fn pure_bytes(&self) -> Vec<u8>;
+    fn pure_bytes(self) -> PureBytes;
 }
 
 impl MoveArg for PureBytes {
-    fn pure_bytes(&self) -> Vec<u8> {
-        self.0.clone()
+    fn pure_bytes(self) -> PureBytes {
+        self
+    }
+}
+
+impl MoveArg for &Digest {
+    fn pure_bytes(self) -> PureBytes {
+        PureBytes(bcs::to_bytes(self).expect("bcs serialization failed"))
     }
 }
 
 impl MoveArg for Digest {
-    fn pure_bytes(&self) -> Vec<u8> {
-        bcs::to_bytes(self).expect("bcs serialization failed")
+    fn pure_bytes(self) -> PureBytes {
+        PureBytes(bcs::to_bytes(&self).expect("bcs serialization failed"))
     }
 }
 
 impl MoveArg for () {
-    fn pure_bytes(&self) -> Vec<u8> {
-        Vec::new()
-    }
-}
-
-impl MoveArg for str {
-    fn pure_bytes(&self) -> Vec<u8> {
-        bcs::to_bytes(self).expect("bcs serialization failed")
+    fn pure_bytes(self) -> PureBytes {
+        Default::default()
     }
 }
 
 impl MoveArg for &str {
-    fn pure_bytes(&self) -> Vec<u8> {
-        (*self).pure_bytes()
+    fn pure_bytes(self) -> PureBytes {
+        PureBytes(bcs::to_bytes(&self).expect("bcs serialization failed"))
     }
 }
 
-impl MoveArg for String {
-    fn pure_bytes(&self) -> Vec<u8> {
+impl MoveArg for &String {
+    fn pure_bytes(self) -> PureBytes {
         self.as_str().pure_bytes()
     }
 }
 
-impl<T: MoveArg> MoveArg for Vec<T> {
-    fn pure_bytes(&self) -> Vec<u8> {
-        u32_as_uleb128(self.len() as u32)
-            .into_iter()
-            .chain(self.iter().map(|val| val.pure_bytes()).flatten())
-            .collect()
+impl MoveArg for String {
+    fn pure_bytes(self) -> PureBytes {
+        self.as_str().pure_bytes()
+    }
+}
+
+/// A trait which defines how collections of move arg types are serialized for
+/// move calls.
+pub trait MoveArgCollection {
+    /// Get the pure BCS bytes.
+    fn collection_bytes(self) -> PureBytes;
+}
+
+impl<T: MoveArg> MoveArgCollection for T {
+    fn collection_bytes(self) -> PureBytes {
+        self.pure_bytes()
+    }
+}
+
+impl<const N: usize, T: MoveArg> MoveArgCollection for [T; N] {
+    fn collection_bytes(self) -> PureBytes {
+        PureBytes(
+            u32_as_uleb128(self.len() as u32)
+                .into_iter()
+                .chain(self.into_iter().map(|val| val.pure_bytes().0).flatten())
+                .collect(),
+        )
+    }
+}
+
+impl<T: MoveArg> MoveArgCollection for Vec<T> {
+    fn collection_bytes(self) -> PureBytes {
+        PureBytes(
+            u32_as_uleb128(self.len() as u32)
+                .into_iter()
+                .chain(self.into_iter().map(|val| val.pure_bytes().0).flatten())
+                .collect(),
+        )
+    }
+}
+
+impl<T: MoveArg> MoveArgCollection for Option<T> {
+    fn collection_bytes(self) -> PureBytes {
+        match self {
+            Some(value) => PureBytes([&[1], &value.pure_bytes().0[..]].concat()),
+            None => PureBytes(vec![0; 1]),
+        }
     }
 }
 
@@ -68,19 +110,4 @@ fn u32_as_uleb128(mut value: u32) -> Vec<u8> {
     // Write the remaining bits of data and set the highest bit to 0.
     res.push(value as u8);
     res
-}
-
-impl<T: MoveArg> MoveArg for Option<T> {
-    fn pure_bytes(&self) -> Vec<u8> {
-        match self {
-            Some(value) => [&[1], &value.pure_bytes()[..]].concat(),
-            None => vec![0; 1],
-        }
-    }
-}
-
-impl<T: MoveArg> MoveArg for &T {
-    fn pure_bytes(&self) -> Vec<u8> {
-        (*self).pure_bytes()
-    }
 }

--- a/crates/iota-transaction-builder/src/types/move_arg.rs
+++ b/crates/iota-transaction-builder/src/types/move_arg.rs
@@ -1,68 +1,59 @@
 // Copyright 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_types::{Digest, ObjectId};
+use iota_types::Digest;
 
-use crate::types::ArgType;
+/// Pure BCS bytes
+pub struct PureBytes(pub Vec<u8>);
 
 /// A trait which defines how types are serialized for move calls.
 pub trait MoveArg {
-    /// Get the param type.
-    fn arg_type(&self) -> ArgType;
+    /// Get the pure BCS bytes.
+    fn pure_bytes(&self) -> Vec<u8>;
 }
 
-impl MoveArg for ObjectId {
-    fn arg_type(&self) -> ArgType {
-        ArgType::Object(*self)
+impl MoveArg for PureBytes {
+    fn pure_bytes(&self) -> Vec<u8> {
+        self.0.clone()
     }
 }
 
 impl MoveArg for Digest {
-    fn arg_type(&self) -> ArgType {
-        ArgType::Pure(bcs::to_bytes(self).expect("bcs serialization failed"))
-    }
-}
-
-impl MoveArg for ArgType {
-    fn arg_type(&self) -> ArgType {
-        self.clone()
+    fn pure_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).expect("bcs serialization failed")
     }
 }
 
 impl MoveArg for () {
-    fn arg_type(&self) -> ArgType {
-        ArgType::Pure(Vec::new())
+    fn pure_bytes(&self) -> Vec<u8> {
+        Vec::new()
     }
 }
 
 impl MoveArg for str {
-    fn arg_type(&self) -> ArgType {
-        ArgType::Pure(bcs::to_bytes(self).expect("bcs serialization failed"))
+    fn pure_bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).expect("bcs serialization failed")
     }
 }
 
 impl MoveArg for &str {
-    fn arg_type(&self) -> ArgType {
-        (*self).arg_type()
+    fn pure_bytes(&self) -> Vec<u8> {
+        (*self).pure_bytes()
     }
 }
 
 impl MoveArg for String {
-    fn arg_type(&self) -> ArgType {
-        self.as_str().arg_type()
+    fn pure_bytes(&self) -> Vec<u8> {
+        self.as_str().pure_bytes()
     }
 }
 
 impl<T: MoveArg> MoveArg for Vec<T> {
-    fn arg_type(&self) -> ArgType {
-        let mut res = u32_as_uleb128(self.len() as u32);
-        for val in self {
-            match val.arg_type() {
-                ArgType::Object(object_id) => res.extend(object_id.as_bytes()),
-                ArgType::Pure(items) => res.extend(items),
-            }
-        }
-        ArgType::Pure(res)
+    fn pure_bytes(&self) -> Vec<u8> {
+        u32_as_uleb128(self.len() as u32)
+            .into_iter()
+            .chain(self.iter().map(|val| val.pure_bytes()).flatten())
+            .collect()
     }
 }
 
@@ -79,26 +70,17 @@ fn u32_as_uleb128(mut value: u32) -> Vec<u8> {
     res
 }
 
-impl<T: MoveArg> MoveArg for Box<T> {
-    fn arg_type(&self) -> ArgType {
-        self.as_ref().arg_type()
-    }
-}
-
 impl<T: MoveArg> MoveArg for Option<T> {
-    fn arg_type(&self) -> ArgType {
+    fn pure_bytes(&self) -> Vec<u8> {
         match self {
-            Some(value) => match value.arg_type() {
-                ArgType::Object(object_id) => ArgType::Pure([&[1], object_id.as_bytes()].concat()),
-                ArgType::Pure(items) => ArgType::Pure([&[1], &items[..]].concat()),
-            },
-            None => ArgType::Pure(vec![0; 1]),
+            Some(value) => [&[1], &value.pure_bytes()[..]].concat(),
+            None => vec![0; 1],
         }
     }
 }
 
 impl<T: MoveArg> MoveArg for &T {
-    fn arg_type(&self) -> ArgType {
-        (*self).arg_type()
+    fn pure_bytes(&self) -> Vec<u8> {
+        (*self).pure_bytes()
     }
 }

--- a/crates/iota-transaction-builder/src/types/move_arg.rs
+++ b/crates/iota-transaction-builder/src/types/move_arg.rs
@@ -73,7 +73,7 @@ impl<const N: usize, T: MoveArg> MoveArgCollection for [T; N] {
         PureBytes(
             u32_as_uleb128(self.len() as u32)
                 .into_iter()
-                .chain(self.into_iter().map(|val| val.pure_bytes().0).flatten())
+                .chain(self.into_iter().flat_map(|val| val.pure_bytes().0))
                 .collect(),
         )
     }
@@ -84,7 +84,7 @@ impl<T: MoveArg> MoveArgCollection for Vec<T> {
         PureBytes(
             u32_as_uleb128(self.len() as u32)
                 .into_iter()
-                .chain(self.into_iter().map(|val| val.pure_bytes().0).flatten())
+                .chain(self.into_iter().flat_map(|val| val.pure_bytes().0))
                 .collect(),
         )
     }


### PR DESCRIPTION
## Description

I did another pass over the traits and made some refactors:

1. Split `PTBArguments` into two traits which solves the `todo` in the upgrade fn.
2. Split `MoveArg` into `MoveArgCollection` to separate collections and single values (which also avoids weirdness with collections of collections). `MoveArg` is now explicitly a trait for serializing pure BCS bytes.
3. Changed all the traits so that they accept `self` instead of `&self` which reduces the amount of cloning needed under certain circumstances. This did require some additional implementations, notably to support both owned and referenced data there must now be explicit impls for both. 
4. I removed the `ArgType` enum and pushed `ObjectId` handling up to the `PTBArgument` traits.