### PR TITLE
chore(cleanup): make graphql and faucet client api consistent

### DIFF
--- a/bindings/go/examples/faucet/main.go
+++ b/bindings/go/examples/faucet/main.go
@@ -16,7 +16,7 @@ func main() {
 		log.Fatalf("Failed to create address: %v", err)
 	}
 
-	faucetClient := sdk.FaucetClientNewLocal()
+	faucetClient := sdk.FaucetClientNewLocalnet()
 
 	faucetReceipt, err := faucetClient.RequestAndWait(address)
 	if err.(*sdk.SdkFfiError) != nil {

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -4898,25 +4898,25 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet()
 	})
-	if checksum != 60053 {
+	if checksum != 41429 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet: UniFFI API checksum mismatch")
 	}
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-		return C.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local()
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet()
 	})
-	if checksum != 12434 {
+	if checksum != 53173 {
 		// If this happens try cleaning and rebuilding your project
-		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local: UniFFI API checksum mismatch")
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet: UniFFI API checksum mismatch")
 	}
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet()
 	})
-	if checksum != 14673 {
+	if checksum != 11124 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet: UniFFI API checksum mismatch")
 	}
@@ -10744,21 +10744,21 @@ func NewFaucetClient(faucetUrl string) *FaucetClient {
 }
 
 
-// Set to devnet faucet.
+// Create a new Faucet client connected to the `devnet` faucet.
 func FaucetClientNewDevnet() *FaucetClient {
 	return FfiConverterFaucetClientINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_devnet(_uniffiStatus)
 	}))
 }
 
-// Set to local faucet.
-func FaucetClientNewLocal() *FaucetClient {
+// Create a new Faucet client connected to a `localnet` faucet.
+func FaucetClientNewLocalnet() *FaucetClient {
 	return FfiConverterFaucetClientINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local(_uniffiStatus)
+		return C.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet(_uniffiStatus)
 	}))
 }
 
-// Set to testnet faucet.
+// Create a new Faucet client connected to the `testnet` faucet.
 func FaucetClientNewTestnet() *FaucetClient {
 	return FfiConverterFaucetClientINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_testnet(_uniffiStatus)

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -4959,11 +4959,11 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-		return C.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost()
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet()
 	})
-	if checksum != 5570 {
+	if checksum != 2330 {
 		// If this happens try cleaning and rebuilding your project
-		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost: UniFFI API checksum mismatch")
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -11410,9 +11410,9 @@ func GraphQlClientNewDevnet() *GraphQlClient {
 
 // Create a new GraphQL client connected to the `localhost` GraphQL server:
 // {DEFAULT_LOCAL_HOST}.
-func GraphQlClientNewLocalhost() *GraphQlClient {
+func GraphQlClientNewLocalnet() *GraphQlClient {
 	return FfiConverterGraphQlClientINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost(_uniffiStatus)
+		return C.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet(_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -1470,9 +1470,9 @@ void* uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_devnet(RustCallStatus 
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCAL
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCAL
-void* uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local(RustCallStatus *out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCALNET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCALNET
+void* uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet(RustCallStatus *out_status
     
 );
 #endif
@@ -7973,9 +7973,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCAL
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCAL
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCALNET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_FAUCETCLIENT_NEW_LOCALNET
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet(void
     
 );
 #endif

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -1583,9 +1583,9 @@ void* uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_devnet(RustCallStatus
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALHOST
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALHOST
-void* uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost(RustCallStatus *out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALNET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALNET
+void* uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet(RustCallStatus *out_status
     
 );
 #endif
@@ -8009,9 +8009,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALHOST
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALHOST
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALNET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_GRAPHQLCLIENT_NEW_LOCALNET
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet(void
     
 );
 #endif

--- a/bindings/kotlin/examples/Faucet.kt
+++ b/bindings/kotlin/examples/Faucet.kt
@@ -11,7 +11,7 @@ fun main() = runBlocking {
                 Address.fromHex(
                         "0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900"
                 )
-        val faucetClient = FaucetClient.newLocal()
+        val faucetClient = FaucetClient.newLocalnet()
         val faucetReceipt = faucetClient.requestAndWait(address)
         if (faucetReceipt != null) {
             println("Faucet receipt:")

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -3235,7 +3235,7 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet(
 ): Short
-fun uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local(
+fun uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet(
 ): Short
@@ -3992,7 +3992,7 @@ fun uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new(`faucetUrl`: RustBuffer.
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_devnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local(uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_testnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -6894,13 +6894,13 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new() != 13557.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet() != 60053.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet() != 41429.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local() != 12434.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet() != 53173.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet() != 14673.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet() != 11124.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_genesisobject_new() != 35390.toShort()) {
@@ -17766,7 +17766,7 @@ open class FaucetClient: Disposable, AutoCloseable, FaucetClientInterface
     companion object {
         
     /**
-     * Set to devnet faucet.
+     * Create a new Faucet client connected to the `devnet` faucet.
      */ fun `newDevnet`(): FaucetClient {
             return FfiConverterTypeFaucetClient.lift(
     uniffiRustCall() { _status ->
@@ -17779,11 +17779,11 @@ open class FaucetClient: Disposable, AutoCloseable, FaucetClientInterface
 
         
     /**
-     * Set to local faucet.
-     */ fun `newLocal`(): FaucetClient {
+     * Create a new Faucet client connected to a `localnet` faucet.
+     */ fun `newLocalnet`(): FaucetClient {
             return FfiConverterTypeFaucetClient.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local(
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet(
         _status)
 }
     )
@@ -17792,7 +17792,7 @@ open class FaucetClient: Disposable, AutoCloseable, FaucetClientInterface
 
         
     /**
-     * Set to testnet faucet.
+     * Create a new Faucet client connected to the `testnet` faucet.
      */ fun `newTestnet`(): FaucetClient {
             return FfiConverterTypeFaucetClient.lift(
     uniffiRustCall() { _status ->

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -3247,7 +3247,7 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet(
 ): Short
-fun uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost(
+fun uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_mainnet(
 ): Short
@@ -4036,7 +4036,7 @@ fun uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new(`server`: RustBuffer.By
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_devnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost(uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_mainnet(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -6915,7 +6915,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet() != 6494.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost() != 5570.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet() != 2330.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_mainnet() != 3613.toShort()) {
@@ -20210,10 +20210,10 @@ open class GraphQlClient: Disposable, AutoCloseable, GraphQlClientInterface
     /**
      * Create a new GraphQL client connected to the `localhost` GraphQL server:
      * {DEFAULT_LOCAL_HOST}.
-     */ fun `newLocalhost`(): GraphQlClient {
+     */ fun `newLocalnet`(): GraphQlClient {
             return FfiConverterTypeGraphQLClient.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost(
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet(
         _status)
 }
     )

--- a/bindings/python/examples/faucet.py
+++ b/bindings/python/examples/faucet.py
@@ -7,13 +7,17 @@ import asyncio
 
 
 async def main():
-    address = Address.from_hex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
-    faucet_client = FaucetClient.new_local()
+    address = Address.from_hex(
+        "0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900"
+    )
+    faucet_client = FaucetClient.new_localnet()
     faucet_receipt = await faucet_client.request_and_wait(address)
     if faucet_receipt:
         print("Faucet receipt:")
         for coin in faucet_receipt.sent:
-            print(f"  Coin ID: {coin.id.to_hex()}, Amount: {coin.amount}, Digest: {coin.transfer_tx_digest.to_base58()}")
+            print(
+                f"  Coin ID: {coin.id.to_hex()}, Amount: {coin.amount}, Digest: {coin.transfer_tx_digest.to_base58()}"
+            )
     else:
         print("Faucet receipt: None")
 

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1483,7 +1483,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet() != 6494:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost() != 5570:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet() != 2330:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_mainnet() != 3613:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -3080,10 +3080,10 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_devnet.argtypes 
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_devnet.restype = ctypes.c_void_p
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_mainnet.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
@@ -8075,9 +8075,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new.restype = 
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_devnet.restype = ctypes.c_uint16
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet.argtypes = (
 )
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localhost.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_localnet.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_mainnet.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_mainnet.restype = ctypes.c_uint16
@@ -26723,14 +26723,14 @@ class GraphQlClient():
         return cls._make_instance_(pointer)
 
     @classmethod
-    def new_localhost(cls, ):
+    def new_localnet(cls, ):
         """
         Create a new GraphQL client connected to the `localhost` GraphQL server:
         {DEFAULT_LOCAL_HOST}.
         """
 
         # Call the (fallible) function before creating any half-baked object instances.
-        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localhost,)
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_graphqlclient_new_localnet,)
         return cls._make_instance_(pointer)
 
     @classmethod

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1469,11 +1469,11 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new() != 13557:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet() != 60053:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet() != 41429:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local() != 12434:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet() != 53173:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet() != 14673:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet() != 11124:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_genesisobject_new() != 35390:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -2971,10 +2971,10 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_devnet.argtypes =
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_devnet.restype = ctypes.c_void_p
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_testnet.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
@@ -8057,9 +8057,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new.restype = c
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_devnet.restype = ctypes.c_uint16
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet.argtypes = (
 )
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_local.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_localnet.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_faucetclient_new_testnet.restype = ctypes.c_uint16
@@ -25890,7 +25890,7 @@ class FaucetClient():
     @classmethod
     def new_devnet(cls, ):
         """
-        Set to devnet faucet.
+        Create a new Faucet client connected to the `devnet` faucet.
         """
 
         # Call the (fallible) function before creating any half-baked object instances.
@@ -25898,19 +25898,19 @@ class FaucetClient():
         return cls._make_instance_(pointer)
 
     @classmethod
-    def new_local(cls, ):
+    def new_localnet(cls, ):
         """
-        Set to local faucet.
+        Create a new Faucet client connected to a `localnet` faucet.
         """
 
         # Call the (fallible) function before creating any half-baked object instances.
-        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_local,)
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_faucetclient_new_localnet,)
         return cls._make_instance_(pointer)
 
     @classmethod
     def new_testnet(cls, ):
         """
-        Set to testnet faucet.
+        Create a new Faucet client connected to the `testnet` faucet.
         """
 
         # Call the (fallible) function before creating any half-baked object instances.

--- a/crates/iota-graphql-client/README.md
+++ b/crates/iota-graphql-client/README.md
@@ -55,7 +55,7 @@ async fn main() -> Result<()> {
     let address = Address::from_str("IOTA_ADDRESS_HERE")?;
     // Request gas from the faucet and wait until a coin is received
     // As the client is set to devnet, faucet will use the devnet faucet.
-    let faucet = FaucetClient::devnet().request_and_wait(address).await?;
+    let faucet = FaucetClient::new_devnet().request_and_wait(address).await?;
     if let Some(resp) = faucet {
         let coins = resp.sent;
         for coin in coins {
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
     }
 
     // Request gas from the testnet faucet by explicitly setting the faucet to testnet
-    let faucet_testnet = FaucetClient::testnet().request_and_wait(address).await?;
+    let faucet_testnet = FaucetClient::new_testnet().request_and_wait(address).await?;
     Ok(())
 }
 ```

--- a/crates/iota-graphql-client/examples/faucet.rs
+++ b/crates/iota-graphql-client/examples/faucet.rs
@@ -9,7 +9,9 @@ use iota_types::Address;
 async fn main() -> Result<()> {
     let address =
         Address::from_hex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
-    let faucet_receipt = FaucetClient::local().request_and_wait(address).await?;
+    let faucet_receipt = FaucetClient::new_localnet()
+        .request_and_wait(address)
+        .await?;
     if let Some(receipt) = faucet_receipt {
         println!("Faucet receipt:");
         for coin in &receipt.sent {

--- a/crates/iota-graphql-client/src/faucet.rs
+++ b/crates/iota-graphql-client/src/faucet.rs
@@ -77,19 +77,19 @@ impl FaucetClient {
         FaucetClient { faucet_url, inner }
     }
 
-    /// Set to local faucet.
-    pub fn local() -> Self {
-        Self::new(FAUCET_LOCAL_HOST)
+    /// Create a new Faucet client connected to the `testnet` faucet.
+    pub fn new_testnet() -> Self {
+        Self::new(FAUCET_TESTNET_HOST)
     }
 
-    /// Set to devnet faucet.
-    pub fn devnet() -> Self {
+    /// Create a new Faucet client connected to the `devnet` faucet.
+    pub fn new_devnet() -> Self {
         Self::new(FAUCET_DEVNET_HOST)
     }
 
-    /// Set to testnet faucet.
-    pub fn testnet() -> Self {
-        Self::new(FAUCET_TESTNET_HOST)
+    /// Create a new Faucet client connected to a `localnet` faucet.
+    pub fn new_localnet() -> Self {
+        Self::new(FAUCET_LOCAL_HOST)
     }
 
     /// Request gas from the faucet. Note that this will return the UUID of the

--- a/crates/iota-graphql-client/src/lib.rs
+++ b/crates/iota-graphql-client/src/lib.rs
@@ -416,9 +416,9 @@ impl Client {
         Self::new(DEVNET_HOST).expect("Invalid devnet URL")
     }
 
-    /// Create a new GraphQL client connected to the `localhost` GraphQL server:
+    /// Create a new GraphQL client connected to a `localnet` GraphQL server:
     /// {DEFAULT_LOCAL_HOST}.
-    pub fn new_localhost() -> Self {
+    pub fn new_localnet() -> Self {
         Self::new(LOCAL_HOST).expect("Invalid localhost URL")
     }
 
@@ -1718,7 +1718,7 @@ mod tests {
             "mainnet" => Client::new_mainnet(),
             "testnet" => Client::new_testnet(),
             "devnet" => Client::new_devnet(),
-            "local" => Client::new_localhost(),
+            "local" => Client::new_localnet(),
             _ => Client::new(&network).expect("Invalid network URL: {network}"),
         }
     }
@@ -2070,9 +2070,9 @@ mod tests {
     async fn test_coins_stream() {
         let client = test_client();
         let faucet = match client.rpc_server().as_str() {
-            LOCAL_HOST => FaucetClient::local(),
-            TESTNET_HOST => FaucetClient::testnet(),
-            DEVNET_HOST => FaucetClient::devnet(),
+            LOCAL_HOST => FaucetClient::new_localnet(),
+            TESTNET_HOST => FaucetClient::new_testnet(),
+            DEVNET_HOST => FaucetClient::new_devnet(),
             _ => return,
         };
         let key = Ed25519PublicKey::generate(rand::thread_rng());

--- a/crates/iota-sdk-ffi/src/faucet.rs
+++ b/crates/iota-sdk-ffi/src/faucet.rs
@@ -28,19 +28,19 @@ impl FaucetClient {
     /// Set to local faucet.
     #[uniffi::constructor]
     pub fn new_local() -> Self {
-        Self(iota_graphql_client::faucet::FaucetClient::local())
+        Self(iota_graphql_client::faucet::FaucetClient::new_localnet())
     }
 
     /// Set to devnet faucet.
     #[uniffi::constructor]
     pub fn new_devnet() -> Self {
-        Self(iota_graphql_client::faucet::FaucetClient::devnet())
+        Self(iota_graphql_client::faucet::FaucetClient::new_devnet())
     }
 
     /// Set to testnet faucet.
     #[uniffi::constructor]
     pub fn new_testnet() -> Self {
-        Self(iota_graphql_client::faucet::FaucetClient::testnet())
+        Self(iota_graphql_client::faucet::FaucetClient::new_testnet())
     }
 
     /// Request gas from the faucet. Note that this will return the UUID of the

--- a/crates/iota-sdk-ffi/src/faucet.rs
+++ b/crates/iota-sdk-ffi/src/faucet.rs
@@ -25,22 +25,22 @@ impl FaucetClient {
         Self(iota_graphql_client::faucet::FaucetClient::new(&faucet_url))
     }
 
-    /// Set to local faucet.
+    /// Create a new Faucet client connected to the `testnet` faucet.
     #[uniffi::constructor]
-    pub fn new_local() -> Self {
-        Self(iota_graphql_client::faucet::FaucetClient::new_localnet())
+    pub fn new_testnet() -> Self {
+        Self(iota_graphql_client::faucet::FaucetClient::new_testnet())
     }
 
-    /// Set to devnet faucet.
+    /// Create a new Faucet client connected to the `devnet` faucet.
     #[uniffi::constructor]
     pub fn new_devnet() -> Self {
         Self(iota_graphql_client::faucet::FaucetClient::new_devnet())
     }
 
-    /// Set to testnet faucet.
+    /// Create a new Faucet client connected to a `localnet` faucet.
     #[uniffi::constructor]
-    pub fn new_testnet() -> Self {
-        Self(iota_graphql_client::faucet::FaucetClient::new_testnet())
+    pub fn new_localnet() -> Self {
+        Self(iota_graphql_client::faucet::FaucetClient::new_localnet())
     }
 
     /// Request gas from the faucet. Note that this will return the UUID of the

--- a/crates/iota-sdk-ffi/src/graphql.rs
+++ b/crates/iota-sdk-ffi/src/graphql.rs
@@ -81,8 +81,8 @@ impl GraphQLClient {
     /// Create a new GraphQL client connected to the `localhost` GraphQL server:
     /// {DEFAULT_LOCAL_HOST}.
     #[uniffi::constructor]
-    pub fn new_localhost() -> Self {
-        Self(RwLock::new(iota_graphql_client::Client::new_localhost()))
+    pub fn new_localnet() -> Self {
+        Self(RwLock::new(iota_graphql_client::Client::new_localnet()))
     }
 
     /// Get the chain identifier.

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -82,9 +82,9 @@ mod tests {
         Vec<CoinInfo>,
     ) {
         let (address, pk) = helper_address_pk();
-        let client = Client::new_localhost();
+        let client = Client::new_localnet();
         let mut tx = TransactionBuilder::new(address).with_client(client.clone());
-        let coins = FaucetClient::local()
+        let coins = FaucetClient::new_localnet()
             .request_and_wait(address)
             .await
             .unwrap()
@@ -160,7 +160,7 @@ mod tests {
         let (mut tx, _, pk, coins) = helper_setup().await;
 
         // get the object information from the client
-        let client = Client::new_localhost();
+        let client = Client::new_localnet();
         let coin = coins.first().unwrap().id;
         let recipient = Address::generate(rand::thread_rng());
         tx.transfer_objects(recipient, coin);
@@ -192,7 +192,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_split_transfer() {
-        let client = Client::new_localhost();
+        let client = Client::new_localnet();
         let (mut tx, _, pk, _) = helper_setup().await;
 
         // transfer 1 IOTA from Gas coin
@@ -312,7 +312,7 @@ mod tests {
         }
         wait_for_tx_and_check_effects_status_success(effects).await;
 
-        let client = Client::new_localhost();
+        let client = Client::new_localnet();
         let mut tx = TransactionBuilder::new(address).with_client(client.clone());
         let mut upgrade_cap = None;
         for o in created_objs {


### PR DESCRIPTION
I wanted to make both the graphql client and the faucet client constructor API consistent, so usage feels more similar to the user.