### PR TITLE
chore(transaction-builder): Fix leftover `named-result` reference

### DIFF
--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -176,7 +176,7 @@ impl TransactionBuildData {
         name.push_named_results(self);
     }
 
-    /// Get the value for the given string in the named results map
+    /// Get the value for the given string in the named commands map
     pub fn get_named_command(&self, name: &str) -> Option<Argument> {
         self.named_results.get(name).copied()
     }

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -177,7 +177,7 @@ impl TransactionBuildData {
     }
 
     /// Get the value for the given string in the named results map
-    pub fn get_named_result(&self, name: &str) -> Option<Argument> {
+    pub fn get_named_command(&self, name: &str) -> Option<Argument> {
         self.named_results.get(name).copied()
     }
 }
@@ -306,7 +306,7 @@ impl<C, L> TransactionBuilder<C, L> {
 
     /// Get the value for the given string in the named results map
     pub fn get_named_result(&self, name: &str) -> Option<Argument> {
-        self.data.get_named_result(name)
+        self.data.get_named_command(name)
     }
 
     /// Send IOTA to a recipient address.


### PR DESCRIPTION
## Description

I noticed that this method wasn't properly renamed.