### PR TITLE
chore(ffi): Improve dry run usage

### DIFF
--- a/bindings/go/examples/gas_sponsor/main.go
+++ b/bindings/go/examples/gas_sponsor/main.go
@@ -45,8 +45,7 @@ func main() {
 	log.Printf("Signing Digest: %v", sdk.HexEncode(txn.SigningDigest()))
 	log.Printf("Txn Bytes: %v", sdk.Base64Encode(txnBytes))
 
-	skipChecks := bool(false)
-	res, err := client.DryRunTx(txn, &skipChecks)
+	res, err := client.DryRunTx(txn, false)
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to send gas sponsor tx: %v", err)
 	}

--- a/bindings/go/examples/prepare_send_iota/main.go
+++ b/bindings/go/examples/prepare_send_iota/main.go
@@ -32,8 +32,7 @@ func main() {
 	log.Printf("Signing Digest: %v", sdk.HexEncode(txn.SigningDigest()))
 	log.Printf("Txn Bytes: %v", sdk.Base64Encode(txnBytes))
 
-	skipChecks := bool(false)
-	res, err := client.DryRunTx(txn, &skipChecks)
+	res, err := client.DryRunTx(txn, false)
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to send IOTA: %v", err)
 	}

--- a/bindings/go/examples/prepare_send_iota_multi/main.go
+++ b/bindings/go/examples/prepare_send_iota_multi/main.go
@@ -55,8 +55,7 @@ func main() {
 	log.Printf("Signing Digest: %v", sdk.HexEncode(txn.SigningDigest()))
 	log.Printf("Txn Bytes: %v", sdk.Base64Encode(txnBytes))
 
-	skipChecks := bool(false)
-	res, err := client.DryRunTx(txn, &skipChecks)
+	res, err := client.DryRunTx(txn, false)
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to dry run send IOTA: %v", err)
 	}

--- a/bindings/go/examples/prepare_transfer_objects/main.go
+++ b/bindings/go/examples/prepare_transfer_objects/main.go
@@ -45,8 +45,7 @@ func main() {
 	log.Printf("Signing Digest: %v", sdk.HexEncode(txn.SigningDigest()))
 	log.Printf("Txn Bytes: %v", sdk.Base64Encode(txnBytes))
 
-	skipChecks := bool(false)
-	res, err := client.DryRunTx(txn, &skipChecks)
+	res, err := client.DryRunTx(txn, false)
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to transfer objects: %v", err)
 	}

--- a/bindings/go/examples/sign_send_iota/main.go
+++ b/bindings/go/examples/sign_send_iota/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatalf("Failed to create transaction: %v", err)
 	}
 
-	dryRunResult, err := client.DryRunTx(txn, nil)
+	dryRunResult, err := client.DryRunTx(txn, false)
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to dry run: %v", err)
 	}

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -1334,7 +1334,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx()
 	})
-	if checksum != 12272 {
+	if checksum != 63702 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx: UniFFI API checksum mismatch")
 	}
@@ -1343,7 +1343,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind()
 	})
-	if checksum != 40594 {
+	if checksum != 1733 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind: UniFFI API checksum mismatch")
 	}
@@ -12068,7 +12068,7 @@ type GraphQlClientInterface interface {
 	// prevent access to objects that are owned by addresses other than the
 	// sender, and calling non-public, non-entry functions, and some other
 	// checks. Defaults to false.
-	DryRunTx(tx *Transaction, skipChecks *bool) (DryRunResult, error)
+	DryRunTx(tx *Transaction, skipChecks bool) (DryRunResult, error)
 	// Dry run a [`TransactionKind`] and return the transaction effects and dry
 	// run error (if any).
 	//
@@ -12078,7 +12078,7 @@ type GraphQlClientInterface interface {
 	// checks. Defaults to false.
 	//
 	// `tx_meta` is the transaction metadata.
-	DryRunTxKind(txKind *TransactionKind, txMeta TransactionMetadata, skipChecks *bool) (DryRunResult, error)
+	DryRunTxKind(txKind *TransactionKind, txMeta TransactionMetadata, skipChecks bool) (DryRunResult, error)
 	// Access a dynamic field on an object using its name. Names are arbitrary
 	// Move values whose type have copy, drop, and store, and are specified
 	// using their type, and their BCS contents, Base64 encoded.
@@ -12547,7 +12547,7 @@ func (_self *GraphQlClient) Coins(owner *Address, paginationFilter *PaginationFi
 // prevent access to objects that are owned by addresses other than the
 // sender, and calling non-public, non-entry functions, and some other
 // checks. Defaults to false.
-func (_self *GraphQlClient) DryRunTx(tx *Transaction, skipChecks *bool) (DryRunResult, error) {
+func (_self *GraphQlClient) DryRunTx(tx *Transaction, skipChecks bool) (DryRunResult, error) {
 	_pointer := _self.ffiObject.incrementPointer("*GraphQlClient")
 	defer _self.ffiObject.decrementPointer()
 	 res, err :=uniffiRustCallAsync[SdkFfiError](
@@ -12564,7 +12564,7 @@ func (_self *GraphQlClient) DryRunTx(tx *Transaction, skipChecks *bool) (DryRunR
 			return FfiConverterDryRunResultINSTANCE.Lift(ffi)
 		},
 		C.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(
-		_pointer,FfiConverterTransactionINSTANCE.Lower(tx), FfiConverterOptionalBoolINSTANCE.Lower(skipChecks)),
+		_pointer,FfiConverterTransactionINSTANCE.Lower(tx), FfiConverterBoolINSTANCE.Lower(skipChecks)),
 		// pollFn
 		func (handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer(handle, continuation, data)
@@ -12587,7 +12587,7 @@ func (_self *GraphQlClient) DryRunTx(tx *Transaction, skipChecks *bool) (DryRunR
 // checks. Defaults to false.
 //
 // `tx_meta` is the transaction metadata.
-func (_self *GraphQlClient) DryRunTxKind(txKind *TransactionKind, txMeta TransactionMetadata, skipChecks *bool) (DryRunResult, error) {
+func (_self *GraphQlClient) DryRunTxKind(txKind *TransactionKind, txMeta TransactionMetadata, skipChecks bool) (DryRunResult, error) {
 	_pointer := _self.ffiObject.incrementPointer("*GraphQlClient")
 	defer _self.ffiObject.decrementPointer()
 	 res, err :=uniffiRustCallAsync[SdkFfiError](
@@ -12604,7 +12604,7 @@ func (_self *GraphQlClient) DryRunTxKind(txKind *TransactionKind, txMeta Transac
 			return FfiConverterDryRunResultINSTANCE.Lift(ffi)
 		},
 		C.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(
-		_pointer,FfiConverterTransactionKindINSTANCE.Lower(txKind), FfiConverterTransactionMetadataINSTANCE.Lower(txMeta), FfiConverterOptionalBoolINSTANCE.Lower(skipChecks)),
+		_pointer,FfiConverterTransactionKindINSTANCE.Lower(txKind), FfiConverterTransactionMetadataINSTANCE.Lower(txMeta), FfiConverterBoolINSTANCE.Lower(skipChecks)),
 		// pollFn
 		func (handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer(handle, continuation, data)
@@ -31435,43 +31435,6 @@ type FfiDestroyerOptionalUint64 struct {}
 func (_ FfiDestroyerOptionalUint64) Destroy(value *uint64) {
 	if value != nil {
 		FfiDestroyerUint64{}.Destroy(*value)
-	}
-}
-
-type FfiConverterOptionalBool struct{}
-
-var FfiConverterOptionalBoolINSTANCE = FfiConverterOptionalBool{}
-
-func (c FfiConverterOptionalBool) Lift(rb RustBufferI) *bool {
-	return LiftFromRustBuffer[*bool](c, rb)
-}
-
-func (_ FfiConverterOptionalBool) Read(reader io.Reader) *bool {
-	if readInt8(reader) == 0 {
-		return nil
-	}
-	temp := FfiConverterBoolINSTANCE.Read(reader)
-	return &temp
-}
-
-func (c FfiConverterOptionalBool) Lower(value *bool) C.RustBuffer {
-	return LowerIntoRustBuffer[*bool](c, value)
-}
-
-func (_ FfiConverterOptionalBool) Write(writer io.Writer, value *bool) {
-	if value == nil {
-		writeInt8(writer, 0)
-	} else {
-		writeInt8(writer, 1)
-		FfiConverterBoolINSTANCE.Write(writer, *value)
-	}
-}
-
-type FfiDestroyerOptionalBool struct {}
-
-func (_ FfiDestroyerOptionalBool) Destroy(value *bool) {
-	if value != nil {
-		FfiDestroyerBool{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -1677,12 +1677,12 @@ uint64_t uniffi_iota_sdk_ffi_fn_method_graphqlclient_coins(void* ptr, void* owne
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GRAPHQLCLIENT_DRY_RUN_TX
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GRAPHQLCLIENT_DRY_RUN_TX
-uint64_t uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(void* ptr, void* tx, RustBuffer skip_checks
+uint64_t uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(void* ptr, void* tx, int8_t skip_checks
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GRAPHQLCLIENT_DRY_RUN_TX_KIND
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GRAPHQLCLIENT_DRY_RUN_TX_KIND
-uint64_t uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(void* ptr, void* tx_kind, RustBuffer tx_meta, RustBuffer skip_checks
+uint64_t uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(void* ptr, void* tx_kind, RustBuffer tx_meta, int8_t skip_checks
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GRAPHQLCLIENT_DYNAMIC_FIELD

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -4428,9 +4428,9 @@ fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_coin_metadata(`ptr`: Pointer,`co
 ): Long
 fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_coins(`ptr`: Pointer,`owner`: Pointer,`paginationFilter`: RustBuffer.ByValue,`coinType`: RustBuffer.ByValue,
 ): Long
-fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(`ptr`: Pointer,`tx`: Pointer,`skipChecks`: RustBuffer.ByValue,
+fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(`ptr`: Pointer,`tx`: Pointer,`skipChecks`: Byte,
 ): Long
-fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(`ptr`: Pointer,`txKind`: Pointer,`txMeta`: RustBuffer.ByValue,`skipChecks`: RustBuffer.ByValue,
+fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(`ptr`: Pointer,`txKind`: Pointer,`txMeta`: RustBuffer.ByValue,`skipChecks`: Byte,
 ): Long
 fun uniffi_iota_sdk_ffi_fn_method_graphqlclient_dynamic_field(`ptr`: Pointer,`address`: Pointer,`typeTag`: Pointer,`name`: RustBuffer.ByValue,
 ): Long
@@ -6252,10 +6252,10 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_coins() != 47450.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx() != 12272.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx() != 63702.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind() != 40594.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind() != 1733.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dynamic_field() != 17199.toShort()) {
@@ -19507,7 +19507,7 @@ public interface GraphQlClientInterface {
      * sender, and calling non-public, non-entry functions, and some other
      * checks. Defaults to false.
      */
-    suspend fun `dryRunTx`(`tx`: Transaction, `skipChecks`: kotlin.Boolean? = null): DryRunResult
+    suspend fun `dryRunTx`(`tx`: Transaction, `skipChecks`: kotlin.Boolean = false): DryRunResult
     
     /**
      * Dry run a [`TransactionKind`] and return the transaction effects and dry
@@ -19520,7 +19520,7 @@ public interface GraphQlClientInterface {
      *
      * `tx_meta` is the transaction metadata.
      */
-    suspend fun `dryRunTxKind`(`txKind`: TransactionKind, `txMeta`: TransactionMetadata, `skipChecks`: kotlin.Boolean? = null): DryRunResult
+    suspend fun `dryRunTxKind`(`txKind`: TransactionKind, `txMeta`: TransactionMetadata, `skipChecks`: kotlin.Boolean = false): DryRunResult
     
     /**
      * Access a dynamic field on an object using its name. Names are arbitrary
@@ -20104,12 +20104,12 @@ open class GraphQlClient: Disposable, AutoCloseable, GraphQlClientInterface
      */
     @Throws(SdkFfiException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `dryRunTx`(`tx`: Transaction, `skipChecks`: kotlin.Boolean?) : DryRunResult {
+    override suspend fun `dryRunTx`(`tx`: Transaction, `skipChecks`: kotlin.Boolean) : DryRunResult {
         return uniffiRustCallAsync(
         callWithPointer { thisPtr ->
             UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(
                 thisPtr,
-                FfiConverterTypeTransaction.lower(`tx`),FfiConverterOptionalBoolean.lower(`skipChecks`),
+                FfiConverterTypeTransaction.lower(`tx`),FfiConverterBoolean.lower(`skipChecks`),
             )
         },
         { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer(future, callback, continuation) },
@@ -20136,12 +20136,12 @@ open class GraphQlClient: Disposable, AutoCloseable, GraphQlClientInterface
      */
     @Throws(SdkFfiException::class)
     @Suppress("ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
-    override suspend fun `dryRunTxKind`(`txKind`: TransactionKind, `txMeta`: TransactionMetadata, `skipChecks`: kotlin.Boolean?) : DryRunResult {
+    override suspend fun `dryRunTxKind`(`txKind`: TransactionKind, `txMeta`: TransactionMetadata, `skipChecks`: kotlin.Boolean) : DryRunResult {
         return uniffiRustCallAsync(
         callWithPointer { thisPtr ->
             UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(
                 thisPtr,
-                FfiConverterTypeTransactionKind.lower(`txKind`),FfiConverterTypeTransactionMetadata.lower(`txMeta`),FfiConverterOptionalBoolean.lower(`skipChecks`),
+                FfiConverterTypeTransactionKind.lower(`txKind`),FfiConverterTypeTransactionMetadata.lower(`txMeta`),FfiConverterBoolean.lower(`skipChecks`),
             )
         },
         { future, callback, continuation -> UniffiLib.INSTANCE.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer(future, callback, continuation) },
@@ -52572,38 +52572,6 @@ public object FfiConverterOptionalULong: FfiConverterRustBuffer<kotlin.ULong?> {
         } else {
             buf.put(1)
             FfiConverterULong.write(value, buf)
-        }
-    }
-}
-
-
-
-
-/**
- * @suppress
- */
-public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
-    override fun read(buf: ByteBuffer): kotlin.Boolean? {
-        if (buf.get().toInt() == 0) {
-            return null
-        }
-        return FfiConverterBoolean.read(buf)
-    }
-
-    override fun allocationSize(value: kotlin.Boolean?): ULong {
-        if (value == null) {
-            return 1UL
-        } else {
-            return 1UL + FfiConverterBoolean.allocationSize(value)
-        }
-    }
-
-    override fun write(value: kotlin.Boolean?, buf: ByteBuffer) {
-        if (value == null) {
-            buf.put(0)
-        } else {
-            buf.put(1)
-            FfiConverterBoolean.write(value, buf)
         }
     }
 }

--- a/bindings/python/examples/gas_sponsor.py
+++ b/bindings/python/examples/gas_sponsor.py
@@ -40,7 +40,7 @@ async def main():
         print("Signing Digest:", hex_encode(txn.signing_digest()))
         print("Txn Bytes:", base64_encode(txn.bcs_serialize()))
 
-        res = await client.dry_run_tx(txn, False)
+        res = await client.dry_run_tx(txn)
         if res.error is not None:
             raise Exception("Failed to send gas sponsor tx:", res.error)
 

--- a/bindings/python/examples/sign_send_iota.py
+++ b/bindings/python/examples/sign_send_iota.py
@@ -29,7 +29,7 @@ async def main():
         builder.send_iota(recipient_address, [PtbArgument.u64(amount)])
         txn = await builder.finish()
 
-        dry_run_result = await client.dry_run_tx(txn, False)
+        dry_run_result = await client.dry_run_tx(txn)
         if dry_run_result.error is not None:
             raise Exception(f"Dry run failed: {dry_run_result.error}")
 

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -677,9 +677,9 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_coins() != 47450:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx() != 12272:
+    if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx() != 63702:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind() != 40594:
+    if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dry_run_tx_kind() != 1733:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_graphqlclient_dynamic_field() != 17199:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -3341,14 +3341,14 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_coins.restype = ctypes.c_
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx.argtypes = (
     ctypes.c_void_p,
     ctypes.c_void_p,
-    _UniffiRustBuffer,
+    ctypes.c_int8,
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx.restype = ctypes.c_uint64
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind.argtypes = (
     ctypes.c_void_p,
     ctypes.c_void_p,
     _UniffiRustBuffer,
-    _UniffiRustBuffer,
+    ctypes.c_int8,
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind.restype = ctypes.c_uint64
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dynamic_field.argtypes = (
@@ -18931,33 +18931,6 @@ class _UniffiConverterOptionalUInt64(_UniffiConverterRustBuffer):
 
 
 
-class _UniffiConverterOptionalBool(_UniffiConverterRustBuffer):
-    @classmethod
-    def check_lower(cls, value):
-        if value is not None:
-            _UniffiConverterBool.check_lower(value)
-
-    @classmethod
-    def write(cls, value, buf):
-        if value is None:
-            buf.write_u8(0)
-            return
-
-        buf.write_u8(1)
-        _UniffiConverterBool.write(value, buf)
-
-    @classmethod
-    def read(cls, buf):
-        flag = buf.read_u8()
-        if flag == 0:
-            return None
-        elif flag == 1:
-            return _UniffiConverterBool.read(buf)
-        else:
-            raise InternalError("Unexpected flag byte for optional type")
-
-
-
 class _UniffiConverterOptionalString(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -27725,7 +27698,7 @@ class GraphQlClientProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def dry_run_tx(self, tx: "Transaction",skip_checks: "typing.Union[object, typing.Optional[bool]]" = _DEFAULT):
+    def dry_run_tx(self, tx: "Transaction",skip_checks: "typing.Union[object, bool]" = _DEFAULT):
         """
         Dry run a [`Transaction`] and return the transaction effects and dry run
         error (if any).
@@ -27737,7 +27710,7 @@ class GraphQlClientProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def dry_run_tx_kind(self, tx_kind: "TransactionKind",tx_meta: "TransactionMetadata",skip_checks: "typing.Union[object, typing.Optional[bool]]" = _DEFAULT):
+    def dry_run_tx_kind(self, tx_kind: "TransactionKind",tx_meta: "TransactionMetadata",skip_checks: "typing.Union[object, bool]" = _DEFAULT):
         """
         Dry run a [`TransactionKind`] and return the transaction effects and dry
         run error (if any).
@@ -28377,7 +28350,7 @@ _UniffiConverterTypeSdkFfiError,
 
 
 
-    async def dry_run_tx(self, tx: "Transaction",skip_checks: "typing.Union[object, typing.Optional[bool]]" = _DEFAULT) -> "DryRunResult":
+    async def dry_run_tx(self, tx: "Transaction",skip_checks: "typing.Union[object, bool]" = _DEFAULT) -> "DryRunResult":
         """
         Dry run a [`Transaction`] and return the transaction effects and dry run
         error (if any).
@@ -28391,14 +28364,14 @@ _UniffiConverterTypeSdkFfiError,
         _UniffiConverterTypeTransaction.check_lower(tx)
         
         if skip_checks is _DEFAULT:
-            skip_checks = None
-        _UniffiConverterOptionalBool.check_lower(skip_checks)
+            skip_checks = False
+        _UniffiConverterBool.check_lower(skip_checks)
         
         return await _uniffi_rust_call_async(
             _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx(
                 self._uniffi_clone_pointer(), 
         _UniffiConverterTypeTransaction.lower(tx),
-        _UniffiConverterOptionalBool.lower(skip_checks)
+        _UniffiConverterBool.lower(skip_checks)
             ),
             _UniffiLib.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
             _UniffiLib.ffi_iota_sdk_ffi_rust_future_complete_rust_buffer,
@@ -28413,7 +28386,7 @@ _UniffiConverterTypeSdkFfiError,
 
 
 
-    async def dry_run_tx_kind(self, tx_kind: "TransactionKind",tx_meta: "TransactionMetadata",skip_checks: "typing.Union[object, typing.Optional[bool]]" = _DEFAULT) -> "DryRunResult":
+    async def dry_run_tx_kind(self, tx_kind: "TransactionKind",tx_meta: "TransactionMetadata",skip_checks: "typing.Union[object, bool]" = _DEFAULT) -> "DryRunResult":
         """
         Dry run a [`TransactionKind`] and return the transaction effects and dry
         run error (if any).
@@ -28431,15 +28404,15 @@ _UniffiConverterTypeSdkFfiError,
         _UniffiConverterTypeTransactionMetadata.check_lower(tx_meta)
         
         if skip_checks is _DEFAULT:
-            skip_checks = None
-        _UniffiConverterOptionalBool.check_lower(skip_checks)
+            skip_checks = False
+        _UniffiConverterBool.check_lower(skip_checks)
         
         return await _uniffi_rust_call_async(
             _UniffiLib.uniffi_iota_sdk_ffi_fn_method_graphqlclient_dry_run_tx_kind(
                 self._uniffi_clone_pointer(), 
         _UniffiConverterTypeTransactionKind.lower(tx_kind),
         _UniffiConverterTypeTransactionMetadata.lower(tx_meta),
-        _UniffiConverterOptionalBool.lower(skip_checks)
+        _UniffiConverterBool.lower(skip_checks)
             ),
             _UniffiLib.ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
             _UniffiLib.ffi_iota_sdk_ffi_rust_future_complete_rust_buffer,

--- a/crates/iota-sdk-ffi/src/graphql.rs
+++ b/crates/iota-sdk-ffi/src/graphql.rs
@@ -831,17 +831,13 @@ impl GraphQLClient {
     /// prevent access to objects that are owned by addresses other than the
     /// sender, and calling non-public, non-entry functions, and some other
     /// checks. Defaults to false.
-    #[uniffi::method(default(skip_checks = None))]
-    pub async fn dry_run_tx(
-        &self,
-        tx: &Transaction,
-        skip_checks: Option<bool>,
-    ) -> Result<DryRunResult> {
+    #[uniffi::method(default(skip_checks = false))]
+    pub async fn dry_run_tx(&self, tx: &Transaction, skip_checks: bool) -> Result<DryRunResult> {
         Ok(self
             .0
             .read()
             .await
-            .dry_run_tx(&tx.0, skip_checks.unwrap_or(false))
+            .dry_run_tx(&tx.0, skip_checks)
             .await?
             .into())
     }
@@ -855,18 +851,18 @@ impl GraphQLClient {
     /// checks. Defaults to false.
     ///
     /// `tx_meta` is the transaction metadata.
-    #[uniffi::method(default(skip_checks = None))]
+    #[uniffi::method(default(skip_checks = false))]
     pub async fn dry_run_tx_kind(
         &self,
         tx_kind: &TransactionKind,
         tx_meta: TransactionMetadata,
-        skip_checks: Option<bool>,
+        skip_checks: bool,
     ) -> Result<DryRunResult> {
         Ok(self
             .0
             .read()
             .await
-            .dry_run_tx_kind(&tx_kind.0, skip_checks.unwrap_or(false), tx_meta.into())
+            .dry_run_tx_kind(&tx_kind.0, skip_checks, tx_meta.into())
             .await?
             .into())
     }


### PR DESCRIPTION
## Description

Makes the `skip_check` param of `dry_run_tx` in the FFI non optional, but default to `false` for langs that support it.