### PR TITLE
chore(*): rename `name` and `res`

### DIFF
--- a/bindings/go/examples/dev_inspect/main.go
+++ b/bindings/go/examples/dev_inspect/main.go
@@ -68,7 +68,7 @@ func main() {
 		iotaNamesPackageAddress,
 		registryModule,
 		lookupFn,
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("iota_names"), sdk.PtbArgumentRes("name")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("iota_names"), sdk.PtbArgumentResultRef("name")},
 		nil,
 		[]string{"name_record_opt"},
 	)
@@ -78,7 +78,7 @@ func main() {
 		stdlibAddress,
 		optionModule,
 		borrowFn,
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("name_record_opt")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("name_record_opt")},
 		[]*sdk.TypeTag{sdk.TypeTagNewStruct(nameRecordType)},
 		[]string{"name_record"},
 	)
@@ -88,7 +88,7 @@ func main() {
 		iotaNamesPackageAddress,
 		nameRecordModule,
 		targetAddressFn,
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("name_record")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("name_record")},
 		nil,
 		[]string{"target_address_opt"},
 	)
@@ -98,7 +98,7 @@ func main() {
 		stdlibAddress,
 		optionModule,
 		borrowFn,
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("target_address_opt")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("target_address_opt")},
 		[]*sdk.TypeTag{sdk.TypeTagNewAddress()},
 		[]string{"target_address"},
 	)

--- a/bindings/go/examples/prepare_send_iota_multi/main.go
+++ b/bindings/go/examples/prepare_send_iota_multi/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	for idx, r := range recipients {
 		recipient, _ := sdk.AddressFromHex(r.address)
-		builder.TransferObjects(recipient, []*sdk.PtbArgument{sdk.PtbArgumentRes(labels[idx])})
+		builder.TransferObjects(recipient, []*sdk.PtbArgument{sdk.PtbArgumentResultRef(labels[idx])})
 	}
 
 	txn, err := builder.Finish()

--- a/bindings/go/examples/prepare_split_coins/main.go
+++ b/bindings/go/examples/prepare_split_coins/main.go
@@ -28,7 +28,7 @@ func main() {
 	)
 	builder.TransferObjects(
 		sender,
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("coin1"), sdk.PtbArgumentRes("coin2"), sdk.PtbArgumentRes("coin3")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("coin1"), sdk.PtbArgumentResultRef("coin2"), sdk.PtbArgumentResultRef("coin3")},
 	)
 	builder.Gas(coinObjId).GasBudget(1000000000)
 

--- a/bindings/go/examples/tx_command_results/main.go
+++ b/bindings/go/examples/tx_command_results/main.go
@@ -42,13 +42,13 @@ func main() {
 	builder.SplitCoins(
 		sdk.PtbArgumentGas(),
 		// Use the named results of previous commands to use as arguments
-		[]*sdk.PtbArgument{sdk.PtbArgumentRes("res0"), sdk.PtbArgumentRes("res1")},
+		[]*sdk.PtbArgument{sdk.PtbArgumentResultRef("res0"), sdk.PtbArgumentResultRef("res1")},
 		// For nested results, a tuple or vec can be used to name them
 		[]string{"coin0", "coin1"},
 	)
 
 	// Use named results as arguments
-	builder.TransferObjects(sender, []*sdk.PtbArgument{sdk.PtbArgumentRes("coin0"), sdk.PtbArgumentRes("coin1")})
+	builder.TransferObjects(sender, []*sdk.PtbArgument{sdk.PtbArgumentResultRef("coin0"), sdk.PtbArgumentResultRef("coin1")})
 
 	txn, err := builder.Finish()
 	if err.(*sdk.SdkFfiError) != nil {

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -3728,7 +3728,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call()
 	})
-	if checksum != 22281 {
+	if checksum != 29250 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call: UniFFI API checksum mismatch")
 	}
@@ -6012,11 +6012,11 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res()
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref()
 	})
-	if checksum != 47661 {
+	if checksum != 61397 {
 		// If this happens try cleaning and rebuilding your project
-		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res: UniFFI API checksum mismatch")
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -17941,9 +17941,9 @@ func PtbArgumentReceivingFromHex(hex string) (*PtbArgument, error) {
 		}
 }
 
-func PtbArgumentRes(name string) *PtbArgument {
+func PtbArgumentResultRef(name string) *PtbArgument {
 	return FfiConverterPtbArgumentINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res(FfiConverterStringINSTANCE.Lower(name),_uniffiStatus)
+		return C.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref(FfiConverterStringINSTANCE.Lower(name),_uniffiStatus)
 	}))
 }
 
@@ -21958,7 +21958,7 @@ type TransactionBuilderInterface interface {
 	// Merge a list of coins into a single coin, without producing any result.
 	MergeCoins(coin *PtbArgument, coinsToMerge []*PtbArgument) *TransactionBuilder
 	// Call a Move function with the given arguments.
-	MoveCall(varPackage *Address, module *Identifier, function *Identifier, arguments []*PtbArgument, typeArgs []*TypeTag, names []string) *TransactionBuilder
+	MoveCall(varPackage *Address, module *Identifier, function *Identifier, arguments []*PtbArgument, typeArgs []*TypeTag, resultRefs []string) *TransactionBuilder
 	// Publish a list of modules with the given dependencies. The result
 	// assigned to `upgrade_cap_name` is the `0x2::package::UpgradeCap`
 	// Move type. Note that the upgrade capability needs to be handled
@@ -22232,12 +22232,12 @@ func (_self *TransactionBuilder) MergeCoins(coin *PtbArgument, coinsToMerge []*P
 }
 
 // Call a Move function with the given arguments.
-func (_self *TransactionBuilder) MoveCall(varPackage *Address, module *Identifier, function *Identifier, arguments []*PtbArgument, typeArgs []*TypeTag, names []string) *TransactionBuilder {
+func (_self *TransactionBuilder) MoveCall(varPackage *Address, module *Identifier, function *Identifier, arguments []*PtbArgument, typeArgs []*TypeTag, resultRefs []string) *TransactionBuilder {
 	_pointer := _self.ffiObject.incrementPointer("*TransactionBuilder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterTransactionBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(
-		_pointer,FfiConverterAddressINSTANCE.Lower(varPackage), FfiConverterIdentifierINSTANCE.Lower(module), FfiConverterIdentifierINSTANCE.Lower(function), FfiConverterSequencePtbArgumentINSTANCE.Lower(arguments), FfiConverterSequenceTypeTagINSTANCE.Lower(typeArgs), FfiConverterSequenceStringINSTANCE.Lower(names),_uniffiStatus)
+		_pointer,FfiConverterAddressINSTANCE.Lower(varPackage), FfiConverterIdentifierINSTANCE.Lower(module), FfiConverterIdentifierINSTANCE.Lower(function), FfiConverterSequencePtbArgumentINSTANCE.Lower(arguments), FfiConverterSequenceTypeTagINSTANCE.Lower(typeArgs), FfiConverterSequenceStringINSTANCE.Lower(resultRefs),_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -3052,9 +3052,9 @@ void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving(void* id, RustCal
 void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving_from_hex(RustBuffer hex, RustCallStatus *out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_RES
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_RES
-void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res(RustBuffer name, RustCallStatus *out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_RESULT_REF
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_RESULT_REF
+void* uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref(RustBuffer name, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_PTBARGUMENT_SHARED
@@ -4286,7 +4286,7 @@ void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_merge_coins(void* ptr, vo
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_MOVE_CALL
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_MOVE_CALL
-void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(void* ptr, void* package, void* module, void* function, RustBuffer arguments, RustBuffer type_args, RustBuffer names, RustCallStatus *out_status
+void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(void* ptr, void* package, void* module, void* function, RustBuffer arguments, RustBuffer type_args, RustBuffer result_refs, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_PUBLISH
@@ -9274,9 +9274,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_RES
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_RES
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_RESULT_REF
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_PTBARGUMENT_RESULT_REF
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref(void
     
 );
 #endif

--- a/bindings/kotlin/examples/DevInspect.kt
+++ b/bindings/kotlin/examples/DevInspect.kt
@@ -67,7 +67,7 @@ fun main() = runBlocking {
                 iotaNamesPackageAddress,
                 Identifier("registry"),
                 Identifier("lookup"),
-                listOf(PtbArgument.res("iota_names"), PtbArgument.res("name")),
+                listOf(PtbArgument.resultRef("iota_names"), PtbArgument.resultRef("name")),
                 emptyList(),
                 listOf("name_record_opt")
         )
@@ -77,7 +77,7 @@ fun main() = runBlocking {
                 stdlibAddress,
                 Identifier("option"),
                 Identifier("borrow"),
-                listOf(PtbArgument.res("name_record_opt")),
+                listOf(PtbArgument.resultRef("name_record_opt")),
                 listOf(
                         TypeTag.newStruct(
                                 StructTag(
@@ -95,7 +95,7 @@ fun main() = runBlocking {
                 iotaNamesPackageAddress,
                 Identifier("name_record"),
                 Identifier("target_address"),
-                listOf(PtbArgument.res("name_record")),
+                listOf(PtbArgument.resultRef("name_record")),
                 emptyList(),
                 listOf("target_address_opt")
         )
@@ -105,7 +105,7 @@ fun main() = runBlocking {
                 stdlibAddress,
                 Identifier("option"),
                 Identifier("borrow"),
-                listOf(PtbArgument.res("target_address_opt")),
+                listOf(PtbArgument.resultRef("target_address_opt")),
                 listOf(TypeTag.newAddress()),
                 listOf("target_address")
         )

--- a/bindings/kotlin/examples/PrepareSendIotaMulti.kt
+++ b/bindings/kotlin/examples/PrepareSendIotaMulti.kt
@@ -51,7 +51,10 @@ fun main() = runBlocking {
         )
 
         for ((i, r) in recipients.withIndex()) {
-            builder.transferObjects(Address.fromHex(r.first), listOf(PtbArgument.res(labels[i])))
+            builder.transferObjects(
+                    Address.fromHex(r.first),
+                    listOf(PtbArgument.resultRef(labels[i]))
+            )
         }
 
         val txn = builder.finish()

--- a/bindings/kotlin/examples/PrepareSplitCoins.kt
+++ b/bindings/kotlin/examples/PrepareSplitCoins.kt
@@ -32,9 +32,9 @@ fun main() = runBlocking {
                 .transferObjects(
                         sender,
                         listOf(
-                                PtbArgument.res("coin1"),
-                                PtbArgument.res("coin2"),
-                                PtbArgument.res("coin3")
+                                PtbArgument.resultRef("coin1"),
+                                PtbArgument.resultRef("coin2"),
+                                PtbArgument.resultRef("coin3")
                         )
                 )
                 .gas(coinId)

--- a/bindings/kotlin/examples/TxCommandResults.kt
+++ b/bindings/kotlin/examples/TxCommandResults.kt
@@ -25,7 +25,7 @@ fun main() = runBlocking {
                 functionName,
                 listOf(PtbArgument.u64(0u), PtbArgument.u64(1000u)),
                 // Assign a name to the result of this command
-                names = listOf("res0"),
+                resultRefs = listOf("res0"),
         )
 
         builder.moveCall(
@@ -34,13 +34,13 @@ fun main() = runBlocking {
                 functionName,
                 listOf(PtbArgument.u64(1000u), PtbArgument.u64(2000u)),
                 // Assign a name to the result of this command
-                names = listOf("res1"),
+                resultRefs = listOf("res1"),
         )
 
         builder.splitCoins(
                 PtbArgument.gas(),
                 // Use the named results of previous commands to use as arguments
-                listOf(PtbArgument.res("res0"), PtbArgument.res("res1")),
+                listOf(PtbArgument.resultRef("res0"), PtbArgument.resultRef("res1")),
                 // For nested results, a tuple or vec can be used to name them
                 listOf("coin0", "coin1"),
         )
@@ -48,7 +48,7 @@ fun main() = runBlocking {
         // Use named results as arguments
         builder.transferObjects(
                 sender,
-                listOf(PtbArgument.res("coin0"), PtbArgument.res("coin1")),
+                listOf(PtbArgument.resultRef("coin0"), PtbArgument.resultRef("coin1")),
         )
 
         val txn = builder.finish()

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -3695,7 +3695,7 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex(
 ): Short
-fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res(
+fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_shared(
 ): Short
@@ -5038,7 +5038,7 @@ fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving(`id`: Pointer,uniff
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving_from_hex(`hex`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res(`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref(`name`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_ptbargument_shared(`id`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -5526,7 +5526,7 @@ fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_make_move_vec(`ptr`: Pointe
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_merge_coins(`ptr`: Pointer,`coin`: Pointer,`coinsToMerge`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(`ptr`: Pointer,`package`: Pointer,`module`: Pointer,`function`: Pointer,`arguments`: RustBuffer.ByValue,`typeArgs`: RustBuffer.ByValue,`names`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(`ptr`: Pointer,`package`: Pointer,`module`: Pointer,`function`: Pointer,`arguments`: RustBuffer.ByValue,`typeArgs`: RustBuffer.ByValue,`resultRefs`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_publish(`ptr`: Pointer,`modules`: RustBuffer.ByValue,`dependencies`: RustBuffer.ByValue,`upgradeCapName`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -7146,7 +7146,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_merge_coins() != 15164.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call() != 22281.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call() != 29250.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_publish() != 46833.toShort()) {
@@ -7908,7 +7908,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex() != 48453.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res() != 47661.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref() != 61397.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_shared() != 59619.toShort()) {
@@ -29722,10 +29722,10 @@ open class PtbArgument: Disposable, AutoCloseable, PtbArgumentInterface
     }
     
 
-         fun `res`(`name`: kotlin.String): PtbArgument {
+         fun `resultRef`(`name`: kotlin.String): PtbArgument {
             return FfiConverterTypePTBArgument.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res(
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref(
         FfiConverterString.lower(`name`),_status)
 }
     )
@@ -38269,7 +38269,7 @@ public interface TransactionBuilderInterface {
     /**
      * Call a Move function with the given arguments.
      */
-    fun `moveCall`(`package`: Address, `module`: Identifier, `function`: Identifier, `arguments`: List<PtbArgument> = listOf(), `typeArgs`: List<TypeTag> = listOf(), `names`: List<kotlin.String> = listOf()): TransactionBuilder
+    fun `moveCall`(`package`: Address, `module`: Identifier, `function`: Identifier, `arguments`: List<PtbArgument> = listOf(), `typeArgs`: List<TypeTag> = listOf(), `resultRefs`: List<kotlin.String> = listOf()): TransactionBuilder
     
     /**
      * Publish a list of modules with the given dependencies. The result
@@ -38624,12 +38624,12 @@ open class TransactionBuilder: Disposable, AutoCloseable, TransactionBuilderInte
     
     /**
      * Call a Move function with the given arguments.
-     */override fun `moveCall`(`package`: Address, `module`: Identifier, `function`: Identifier, `arguments`: List<PtbArgument>, `typeArgs`: List<TypeTag>, `names`: List<kotlin.String>): TransactionBuilder {
+     */override fun `moveCall`(`package`: Address, `module`: Identifier, `function`: Identifier, `arguments`: List<PtbArgument>, `typeArgs`: List<TypeTag>, `resultRefs`: List<kotlin.String>): TransactionBuilder {
             return FfiConverterTypeTransactionBuilder.lift(
     callWithPointer {
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call(
-        it, FfiConverterTypeAddress.lower(`package`),FfiConverterTypeIdentifier.lower(`module`),FfiConverterTypeIdentifier.lower(`function`),FfiConverterSequenceTypePTBArgument.lower(`arguments`),FfiConverterSequenceTypeTypeTag.lower(`typeArgs`),FfiConverterSequenceString.lower(`names`),_status)
+        it, FfiConverterTypeAddress.lower(`package`),FfiConverterTypeIdentifier.lower(`module`),FfiConverterTypeIdentifier.lower(`function`),FfiConverterSequenceTypePTBArgument.lower(`arguments`),FfiConverterSequenceTypeTypeTag.lower(`typeArgs`),FfiConverterSequenceString.lower(`resultRefs`),_status)
 }
     }
     )

--- a/bindings/python/examples/dev_inspect.py
+++ b/bindings/python/examples/dev_inspect.py
@@ -48,7 +48,7 @@ async def main():
             Identifier("name"),
             Identifier("new"),
             [PtbArgument.string(name)],
-            names=["name"],
+            result_refs=["name"],
         )
 
         # 3. Lookup name record
@@ -56,8 +56,8 @@ async def main():
             iota_names_package_address,
             Identifier("registry"),
             Identifier("lookup"),
-            [PtbArgument.res("iota_names"), PtbArgument.res("name")],
-            names=["name_record_opt"],
+            [PtbArgument.result_ref("iota_names"), PtbArgument.result_ref("name")],
+            result_refs=["name_record_opt"],
         )
 
         # 4. Borrow name record from option
@@ -65,7 +65,7 @@ async def main():
             stdlib_address,
             Identifier("option"),
             Identifier("borrow"),
-            [PtbArgument.res("name_record_opt")],
+            [PtbArgument.result_ref("name_record_opt")],
             [
                 TypeTag.new_struct(
                     StructTag(
@@ -83,8 +83,8 @@ async def main():
             iota_names_package_address,
             Identifier("name_record"),
             Identifier("target_address"),
-            [PtbArgument.res("name_record")],
-            names=["target_address_opt"],
+            [PtbArgument.result_ref("name_record")],
+            result_refs=["target_address_opt"],
         )
 
         # 6. Borrow address from option
@@ -92,7 +92,7 @@ async def main():
             stdlib_address,
             Identifier("option"),
             Identifier("borrow"),
-            [PtbArgument.res("target_address_opt")],
+            [PtbArgument.result_ref("target_address_opt")],
             [TypeTag.new_address()],
             ["target_address"],
         )

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1209,7 +1209,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_merge_coins() != 15164:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call() != 22281:
+    if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_move_call() != 29250:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_publish() != 46833:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -1717,7 +1717,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex() != 48453:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res() != 47661:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref() != 61397:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_shared() != 59619:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -4796,11 +4796,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving_from_hex.arg
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_receiving_from_hex.restype = ctypes.c_void_p
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref.argtypes = (
     _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_shared.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -9192,9 +9192,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving.restyp
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_receiving_from_hex.restype = ctypes.c_uint16
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref.argtypes = (
 )
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_res.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_result_ref.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_shared.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_shared.restype = ctypes.c_uint16
@@ -34675,11 +34675,11 @@ class PtbArgument():
         return cls._make_instance_(pointer)
 
     @classmethod
-    def res(cls, name: "str"):
+    def result_ref(cls, name: "str"):
         _UniffiConverterString.check_lower(name)
         
         # Call the (fallible) function before creating any half-baked object instances.
-        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_res,
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_ptbargument_result_ref,
         _UniffiConverterString.lower(name))
         return cls._make_instance_(pointer)
 
@@ -38175,7 +38175,7 @@ class TransactionBuilderProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def move_call(self, package: "Address",module: "Identifier",function: "Identifier",arguments: "typing.Union[object, typing.List[PtbArgument]]" = _DEFAULT,type_args: "typing.Union[object, typing.List[TypeTag]]" = _DEFAULT,names: "typing.Union[object, typing.List[str]]" = _DEFAULT):
+    def move_call(self, package: "Address",module: "Identifier",function: "Identifier",arguments: "typing.Union[object, typing.List[PtbArgument]]" = _DEFAULT,type_args: "typing.Union[object, typing.List[TypeTag]]" = _DEFAULT,result_refs: "typing.Union[object, typing.List[str]]" = _DEFAULT):
         """
         Call a Move function with the given arguments.
         """
@@ -38548,7 +38548,7 @@ _UniffiConverterTypeSdkFfiError,
 
 
 
-    def move_call(self, package: "Address",module: "Identifier",function: "Identifier",arguments: "typing.Union[object, typing.List[PtbArgument]]" = _DEFAULT,type_args: "typing.Union[object, typing.List[TypeTag]]" = _DEFAULT,names: "typing.Union[object, typing.List[str]]" = _DEFAULT) -> "TransactionBuilder":
+    def move_call(self, package: "Address",module: "Identifier",function: "Identifier",arguments: "typing.Union[object, typing.List[PtbArgument]]" = _DEFAULT,type_args: "typing.Union[object, typing.List[TypeTag]]" = _DEFAULT,result_refs: "typing.Union[object, typing.List[str]]" = _DEFAULT) -> "TransactionBuilder":
         """
         Call a Move function with the given arguments.
         """
@@ -38567,9 +38567,9 @@ _UniffiConverterTypeSdkFfiError,
             type_args = []
         _UniffiConverterSequenceTypeTypeTag.check_lower(type_args)
         
-        if names is _DEFAULT:
-            names = []
-        _UniffiConverterSequenceString.check_lower(names)
+        if result_refs is _DEFAULT:
+            result_refs = []
+        _UniffiConverterSequenceString.check_lower(result_refs)
         
         return _UniffiConverterTypeTransactionBuilder.lift(
             _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_move_call,self._uniffi_clone_pointer(),
@@ -38578,7 +38578,7 @@ _UniffiConverterTypeSdkFfiError,
         _UniffiConverterTypeIdentifier.lower(function),
         _UniffiConverterSequenceTypePtbArgument.lower(arguments),
         _UniffiConverterSequenceTypeTypeTag.lower(type_args),
-        _UniffiConverterSequenceString.lower(names))
+        _UniffiConverterSequenceString.lower(result_refs))
         )
 
 

--- a/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
@@ -136,7 +136,7 @@ impl TransactionBuilder {
     // Commands
 
     /// Call a Move function with the given arguments.
-    #[uniffi::method(default(type_args = [], arguments = [], names = []))]
+    #[uniffi::method(default(type_args = [], arguments = [], result_refs = []))]
     pub fn move_call(
         self: Arc<Self>,
         package: &Address,
@@ -144,14 +144,14 @@ impl TransactionBuilder {
         function: &Identifier,
         arguments: Vec<Arc<PTBArgument>>,
         type_args: Vec<Arc<TypeTag>>,
-        names: Vec<String>,
+        result_refs: Vec<String>,
     ) -> Arc<Self> {
         self.write(|builder| {
             builder
                 .move_call(**package, &module.as_str(), &function.as_str())
                 .arguments(arguments)
                 .type_tags(type_args.into_iter().map(|v| v.0.clone()))
-                .name(names);
+                .result_refs(result_refs);
         });
         self
     }
@@ -206,7 +206,7 @@ impl TransactionBuilder {
         names: Vec<String>,
     ) -> Arc<Self> {
         self.write(|builder| {
-            builder.split_coins(coin, amounts).name(names);
+            builder.split_coins(coin, amounts).result_refs(names);
         });
         self
     }
@@ -307,7 +307,7 @@ impl TransactionBuilder {
                         digest: None,
                     },
                 )
-                .name(name);
+                .result_refs(name);
         });
         self
     }

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use iota_transaction_builder::{
-    PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::CommandResult, result_ref,
+    PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::CommandResultRef, result_ref,
 };
 use primitive_types::U256;
 
@@ -205,7 +205,7 @@ impl iota_transaction_builder::types::MoveArg for &MoveArg {
 pub enum PTBArgument {
     ObjectId(iota_types::ObjectId),
     Move(MoveArg),
-    CommandResult(CommandResult),
+    CommandResult(CommandResultRef),
     Shared(Shared<iota_types::ObjectId>),
     SharedMut(SharedMut<iota_types::ObjectId>),
     Receiving(Receiving<iota_types::ObjectId>),

--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use iota_transaction_builder::{
-    PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::Res, res,
+    PureBytes, Receiving, Shared, SharedMut, builder::ptb_arguments::CommandResult, result_ref,
 };
 use primitive_types::U256;
 
@@ -205,7 +205,7 @@ impl iota_transaction_builder::types::MoveArg for &MoveArg {
 pub enum PTBArgument {
     ObjectId(iota_types::ObjectId),
     Move(MoveArg),
-    Res(Res),
+    CommandResult(CommandResult),
     Shared(Shared<iota_types::ObjectId>),
     SharedMut(SharedMut<iota_types::ObjectId>),
     Receiving(Receiving<iota_types::ObjectId>),
@@ -215,8 +215,8 @@ pub enum PTBArgument {
 #[uniffi::export]
 impl PTBArgument {
     #[uniffi::constructor]
-    pub fn res(name: String) -> Self {
-        Self::Res(res(name))
+    pub fn result_ref(name: String) -> Self {
+        Self::CommandResult(result_ref(name))
     }
 
     #[uniffi::constructor]
@@ -402,7 +402,7 @@ impl iota_transaction_builder::PTBArgument for &PTBArgument {
         match self {
             PTBArgument::ObjectId(object_id) => object_id.arg(ptb),
             PTBArgument::Move(arg) => arg.arg(ptb),
-            PTBArgument::Res(res) => res.arg(ptb),
+            PTBArgument::CommandResult(res) => res.arg(ptb),
             PTBArgument::Shared(shared) => shared.arg(ptb),
             PTBArgument::SharedMut(shared_mut) => shared_mut.arg(ptb),
             PTBArgument::Receiving(receiving) => receiving.arg(ptb),

--- a/crates/iota-sdk/examples/dev_inspect.rs
+++ b/crates/iota-sdk/examples/dev_inspect.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use eyre::Result;
 use iota_graphql_client::Client;
-use iota_transaction_builder::{SharedMut, TransactionBuilder, res};
+use iota_transaction_builder::{SharedMut, TransactionBuilder, result_ref};
 use iota_types::{Address, Identifier, ObjectId, StructTag, TypeTag};
 
 #[tokio::main]
@@ -34,45 +34,45 @@ async fn main() -> Result<()> {
             name: Identifier::new("Registry")?,
             type_params: vec![],
         }))])
-        .name("iota_names");
+        .result_refs("iota_names");
 
     // Step 2: Create the name object from the string
     builder
         .move_call(iota_names_package_address, "name", "new")
         .arguments([name])
-        .name("name");
+        .result_refs("name");
 
     // Step 3: Look up the name record in the registry
     builder
         .move_call(iota_names_package_address, "registry", "lookup")
-        .arguments((res("iota_names"), res("name")))
-        .name("name_record_opt");
+        .arguments((result_ref("iota_names"), result_ref("name")))
+        .result_refs("name_record_opt");
 
     // Step 4: Borrow the name record from the option
     builder
         .move_call(Address::STD_LIB, "option", "borrow")
-        .arguments([res("name_record_opt")])
+        .arguments([result_ref("name_record_opt")])
         .type_tags([TypeTag::Struct(Box::new(StructTag {
             address: iota_names_package_address,
             module: Identifier::new("name_record")?,
             name: Identifier::new("NameRecord")?,
             type_params: vec![],
         }))])
-        .name("name_record");
+        .result_refs("name_record");
 
     // Step 5: Get the target address from the name record
     builder
         .move_call(iota_names_package_address, "name_record", "target_address")
-        .arguments([res("name_record")])
-        .name("target_address_opt");
+        .arguments([result_ref("name_record")])
+        .result_refs("target_address_opt");
 
     // Step 6: Borrow the address from the option (this returns the resolved
     // address)
     builder
         .move_call(Address::STD_LIB, "option", "borrow")
-        .arguments([res("target_address_opt")])
+        .arguments([result_ref("target_address_opt")])
         .generics::<Address>()
-        .name("target_address");
+        .result_refs("target_address");
 
     let res = builder.dry_run(true).await?;
 

--- a/crates/iota-sdk/examples/prepare_send_iota_multi.rs
+++ b/crates/iota-sdk/examples/prepare_send_iota_multi.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use base64ct::Encoding;
 use eyre::Result;
 use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res};
+use iota_transaction_builder::{TransactionBuilder, result_ref};
 use iota_types::{Address, ObjectId};
 
 #[tokio::main]
@@ -38,11 +38,13 @@ async fn main() -> Result<()> {
 
     let labels: Vec<String> = (0..recipients.len()).map(|i| format!("coin{i}")).collect();
 
-    builder.split_coins(coin, amounts).name(labels.clone());
+    builder
+        .split_coins(coin, amounts)
+        .result_refs(labels.clone());
 
     // Transfer each split coin to the corresponding recipient
     for (i, (address, _)) in recipients.iter().enumerate() {
-        builder.transfer_objects(Address::from_str(address)?, [res(&labels[i])]);
+        builder.transfer_objects(Address::from_str(address)?, [result_ref(&labels[i])]);
     }
 
     let txn = builder.finish().await?;

--- a/crates/iota-sdk/examples/prepare_split_coins.rs
+++ b/crates/iota-sdk/examples/prepare_split_coins.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use base64ct::Encoding;
 use eyre::Result;
 use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res};
+use iota_transaction_builder::{TransactionBuilder, result_ref};
 use iota_types::{Address, ObjectId};
 
 #[tokio::main]
@@ -22,8 +22,15 @@ async fn main() -> Result<()> {
 
     builder
         .split_coins(coin, [1000u64, 2000, 3000])
-        .name(("coin1", "coin2", "coin3"))
-        .transfer_objects(sender, (res("coin1"), res("coin2"), res("coin3")))
+        .result_refs(("coin1", "coin2", "coin3"))
+        .transfer_objects(
+            sender,
+            (
+                result_ref("coin1"),
+                result_ref("coin2"),
+                result_ref("coin3"),
+            ),
+        )
         .gas(coin)
         .gas_budget(1000000000);
 

--- a/crates/iota-sdk/examples/tx_command_results.rs
+++ b/crates/iota-sdk/examples/tx_command_results.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use eyre::Result;
 use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res, unresolved::Argument};
+use iota_transaction_builder::{TransactionBuilder, result_ref, unresolved::Argument};
 use iota_types::Address;
 
 #[tokio::main]
@@ -20,20 +20,20 @@ async fn main() -> Result<()> {
         .move_call(Address::STD_LIB, "u64", "max")
         .arguments((0u64, 1000u64))
         // Assign a name to the result of this command
-        .name("res0");
+        .result_refs("res0");
     builder
         .move_call(Address::STD_LIB, "u64", "max")
         .arguments((1000u64, 2000u64))
-        .name("res1");
+        .result_refs("res1");
 
     builder
         // Use the named results of previous commands to use as arguments
-        .split_coins(Argument::Gas, [res("res0"), res("res1")])
+        .split_coins(Argument::Gas, [result_ref("res0"), result_ref("res1")])
         // For nested results, a tuple or vec can be used to name them
-        .name(vec!["coin0", "coin1"]);
+        .result_refs(vec!["coin0", "coin1"]);
 
     // Use named results as arguments
-    builder.transfer_objects(sender_address, [res("coin0"), res("coin1")]);
+    builder.transfer_objects(sender_address, [result_ref("coin0"), result_ref("coin1")]);
 
     let tx = builder.finish().await?;
 

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -935,7 +935,7 @@ impl TransactionBuilder<(), Publish> {
         let cap = self.arg();
         self.move_call(Address::FRAMEWORK, "package", "upgrade_package")
             .arguments([cap])
-            .name(name)
+            .result_refs(name)
             .reset()
     }
 }
@@ -947,7 +947,7 @@ impl TransactionBuilder<Client, Publish> {
         let cap = self.arg();
         self.move_call(Address::FRAMEWORK, "package", "upgrade_package")
             .arguments([cap])
-            .name(name)
+            .result_refs(name)
             .reset()
     }
 }
@@ -961,9 +961,18 @@ impl<C> TransactionBuilder<C, Publish> {
     }
 }
 
-impl<C, L: Into<Command>> TransactionBuilder<C, L> {
-    /// Set the name for the last command.
-    pub fn name(&mut self, name: impl NamedResults) -> &mut Self {
+impl<C, L> TransactionBuilder<C, L> {
+    /// Set a name to the result of the current command, so it can be
+    /// referenced by follow-up calls using the `result_ref()` method.
+    ///
+    /// e.g.
+    /// ```rust,nocheck
+    /// builder
+    ///     .move_call(iota_names_package_address, "registry", "lookup")
+    ///     .arguments((get_result("iota_names"), get_result("name")))
+    ///     .result_refs("name_record_opt");
+    /// ```
+    pub fn result_refs(&mut self, name: impl NamedResults) -> &mut Self {
         name.push_named_results(&mut self.data);
         self
     }

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -962,15 +962,25 @@ impl<C> TransactionBuilder<C, Publish> {
 }
 
 impl<C, L> TransactionBuilder<C, L> {
-    /// Set a name to the result of the current command, so it can be
+    /// Set names to the results of the current command, so they can be
     /// referenced by follow-up calls using the `result_ref()` method.
     ///
-    /// e.g.
+    /// ### Example
+    ///
     /// ```rust,ignore
     /// builder
-    ///     .move_call(iota_names_package_address, "registry", "lookup")
-    ///     .arguments((result_ref("iota_names"), result_ref("name")))
-    ///     .result_refs("name_record_opt");
+    ///     .split_coins(coin, [1000u64, 2000, 3000])
+    ///     .result_refs(("coin1", "coin2", "coin3"))
+    ///     .transfer_objects(
+    ///         sender,
+    ///         (
+    ///             result_ref("coin1"),
+    ///             result_ref("coin2"),
+    ///             result_ref("coin3"),
+    ///         ),
+    ///     )
+    ///     .gas(coin)
+    ///     .gas_budget(1000000000);
     /// ```
     pub fn result_refs(&mut self, name: impl NamedResults) -> &mut Self {
         name.push_named_results(&mut self.data);

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -966,10 +966,10 @@ impl<C, L> TransactionBuilder<C, L> {
     /// referenced by follow-up calls using the `result_ref()` method.
     ///
     /// e.g.
-    /// ```rust,nocheck
+    /// ```rust,ignore
     /// builder
     ///     .move_call(iota_names_package_address, "registry", "lookup")
-    ///     .arguments((get_result("iota_names"), get_result("name")))
+    ///     .arguments((result_ref("iota_names"), result_ref("name")))
     ///     .result_refs("name_record_opt");
     /// ```
     pub fn result_refs(&mut self, name: impl NamedResults) -> &mut Self {

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -257,30 +257,41 @@ impl PTBArgument for &Receiving<ObjectReference> {
     }
 }
 
-/// The result of a previous command by name.
+/// A reference to a result of a previous command.
 #[derive(Debug, Clone)]
-pub struct CommandResult(String);
+pub struct CommandResultRef(String);
 
 /// Get the result of a previous command by its name, which was defined
 /// using the `.result_ref()` method.
 ///
+/// ### Example
+///
 /// ```rust,ignore
 /// builder
-///     .move_call(iota_names_package_address, "name", "new")
-///     .arguments([name])
-///     .result_ref("name");
+///     .split_coins(coin, [1000u64, 2000, 3000])
+///     .result_refs(("coin1", "coin2", "coin3"))
+///     .transfer_objects(
+///         sender,
+///         (
+///             result_ref("coin1"),
+///             result_ref("coin2"),
+///             result_ref("coin3"),
+///         ),
+///     )
+///     .gas(coin)
+///     .gas_budget(1000000000);
 /// ```
-pub fn result_ref(named_result: impl Into<String>) -> CommandResult {
-    CommandResult(named_result.into())
+pub fn result_ref(result_ref: impl Into<String>) -> CommandResultRef {
+    CommandResultRef(result_ref.into())
 }
 
-impl PTBArgument for CommandResult {
+impl PTBArgument for CommandResultRef {
     fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
         (&self).arg(ptb)
     }
 }
 
-impl PTBArgument for &CommandResult {
+impl PTBArgument for &CommandResultRef {
     fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
         if let Some(arg) = ptb.named_results.get(&self.0) {
             *arg

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -264,7 +264,7 @@ pub struct CommandResult(String);
 /// Get the result of a previous command by its name, which was defined
 /// using the `.result_ref()` method.
 ///
-/// ```rust,nocheck
+/// ```rust,ignore
 /// builder
 ///     .move_call(iota_names_package_address, "name", "new")
 ///     .arguments([name])

--- a/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-transaction-builder/src/builder/ptb_arguments.rs
@@ -259,20 +259,28 @@ impl PTBArgument for &Receiving<ObjectReference> {
 
 /// The result of a previous command by name.
 #[derive(Debug, Clone)]
-pub struct Res(String);
+pub struct CommandResult(String);
 
-/// Get the result of a previous command by name.
-pub fn res(name: impl Into<String>) -> Res {
-    Res(name.into())
+/// Get the result of a previous command by its name, which was defined
+/// using the `.result_ref()` method.
+///
+/// ```rust,nocheck
+/// builder
+///     .move_call(iota_names_package_address, "name", "new")
+///     .arguments([name])
+///     .result_ref("name");
+/// ```
+pub fn result_ref(named_result: impl Into<String>) -> CommandResult {
+    CommandResult(named_result.into())
 }
 
-impl PTBArgument for Res {
+impl PTBArgument for CommandResult {
     fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
         (&self).arg(ptb)
     }
 }
 
-impl PTBArgument for &Res {
+impl PTBArgument for &CommandResult {
     fn arg(self, ptb: &mut TransactionBuildData) -> Argument {
         if let Some(arg) = ptb.named_results.get(&self.0) {
             *arg

--- a/crates/iota-transaction-builder/src/lib.rs
+++ b/crates/iota-transaction-builder/src/lib.rs
@@ -16,7 +16,7 @@ pub mod unresolved;
 pub use self::{
     builder::{
         TransactionBuilder,
-        ptb_arguments::{PTBArgument, PTBArgumentList, Receiving, Shared, SharedMut, res},
+        ptb_arguments::{PTBArgument, PTBArgumentList, Receiving, Shared, SharedMut, result_ref},
     },
     publish_type::MovePackageData,
     types::PureBytes,
@@ -36,7 +36,7 @@ mod tests {
         TransactionEffects,
     };
 
-    use crate::{TransactionBuilder, error::Error, publish_type::MovePackageData, res};
+    use crate::{TransactionBuilder, error::Error, publish_type::MovePackageData, result_ref};
 
     /// This is used to read the json file that contains the modules/deps/digest
     /// generated with iota move build --dump-bytecode-as-base64 on the
@@ -198,9 +198,9 @@ mod tests {
 
         // transfer 1 IOTA from Gas coin
         let gas = tx.get_gas()[0];
-        tx.split_coins(gas, [1_000_000_000u64]).name("coin");
+        tx.split_coins(gas, [1_000_000_000u64]).result_refs("coin");
         let recipient = Address::generate(rand::thread_rng());
-        tx.transfer_objects(recipient, [res("coin")]);
+        tx.transfer_objects(recipient, [result_ref("coin")]);
 
         let effects = tx.execute(&pk.into(), true).await;
         wait_for_tx_and_check_effects_status_success(effects).await;
@@ -272,7 +272,7 @@ mod tests {
         let package = move_package_data("package_test_example_v1.json");
         tx.publish(package)
             .upgrade_cap("cap")
-            .transfer_objects(address, [res("cap")]);
+            .transfer_objects(address, [result_ref("cap")]);
 
         let effects = tx.execute(&pk.into(), true).await;
         wait_for_tx_and_check_effects_status_success(effects).await;
@@ -286,7 +286,7 @@ mod tests {
         let package = move_package_data("package_test_example_v2.json");
         tx.publish(package)
             .upgrade_cap("cap")
-            .transfer_objects(address, [res("cap")]);
+            .transfer_objects(address, [result_ref("cap")]);
 
         let effects = tx.execute(&key, true).await;
         let mut package_id: Option<ObjectId> = None;
@@ -336,10 +336,10 @@ mod tests {
                 0u8,
                 updated_package.digest.as_ref().unwrap(),
             ))
-            .name("ticket");
+            .result_refs("ticket");
         // now we can upgrade the package
         let receipt = tx
-            .upgrade(package_id.unwrap(), res("ticket"), updated_package)
+            .upgrade(package_id.unwrap(), result_ref("ticket"), updated_package)
             .arg();
 
         // commit the upgrade


### PR DESCRIPTION
This PR renames some public API because I hope this will make it a bit easier for the user to tag/name/label results from a command, and later reference them again in follow-up commands. By no means I think this PR has to be merged. It's here to discuss whether we want to keep the old naming or whether we pick something else. IMHO the current naming is a bit confusing and favors conciseness, the new names are a bit less concise but I hope easier to understand for the user. I also added more docs to the methods in question to foster this even more.

UPDATE: I drafted this PR again as it's now heavily out-of-date and the question remains whether we actually want to pursue the suggestion.