### PR TITLE
fix(ffi): do not use `as_v1` for `Transaction::{to_bcs, to_base64}`

### DIFF
--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -88,12 +88,12 @@ impl Transaction {
 
     /// Serialize the transaction as a `Vec<u8>` of BCS bytes.
     pub fn to_bcs(&self) -> Vec<u8> {
-        self.as_v1().to_bcs()
+        self.0.to_bcs()
     }
 
     /// Serialize the transaction as a base64-encoded string.
     pub fn to_base64(&self) -> String {
-        self.as_v1().to_base64()
+        self.0.to_base64()
     }
 
     /// Deserialize a transaction from a `Vec<u8>` of BCS bytes.


### PR DESCRIPTION
Otherwise it doesn't serialise the type byte and the result is different from what `from_bcs` and `from_base64` are expecting, making round trips erroneous.

I have tested it with the `dry_run_bytes` example which were producing 
`AAIAIAAApJhL1JXUNG+iCN3/T11eWtSMId7GMd3ryZgJ8WkAAAgA8gUqAQAAAAICAAEBAQABAQIAAAEAAGEYMNNkGmj5SmkNzCXR9LDayUgyWsGPbdMlZDcXNfMsAgsCcO6dJ9oNsJZR5fczjfoyx+5kQczvofbjBXNbz8erczoyHAAAAAAgqUjvvTgfDEQpwAlQNq9jEW4mC+mwXBCS2prf+2sQjifQQHf+O2+tE7PU7Q1TW3ypKvysjw8qDgkl+59PCzDGmXI6MhwAAAAAIHCjhEicUeSyUMVTOcSW1jD849wfgQWjT8C3uQwtmmhwYRgw02QaaPlKaQ3MJdH0sNrJSDJawY9t0yVkNxc18yzoAwAAAAAAAKAtLQAAAAAAAA==`
instead of 
`AAACACAAAKSYS9SV1DRvogjd/09dXlrUjCHexjHd68mYCfFpAAAIAPIFKgEAAAACAgABAQEAAQECAAABAABhGDDTZBpo+UppDcwl0fSw2slIMlrBj23TJWQ3FzXzLAILAnDunSfaDbCWUeX3M436MsfuZEHM76H24wVzW8/Hq3M6MhwAAAAAIKlI7704HwxEKcAJUDavYxFuJgvpsFwQktqa3/trEI4n0EB3/jtvrROz1O0NU1t8qSr8rI8PKg4JJfufTwswxplyOjIcAAAAACBwo4RInFHkslDFUznEltYw/OPcH4EFo0/At7kMLZpocGEYMNNkGmj5SmkNzCXR9LDayUgyWsGPbdMlZDcXNfMs6AMAAAAAAACgLS0AAAAAAAA=`
without this fix.