### PR TITLE
chore: Add rust release CI

### DIFF
--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -30,12 +30,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - run: cargo install cargo-release
+      - run: cargo install cargo-release --version 0.25.20
 
       - name: Cargo release publish
         run: |
           pkg_args="-p ${{inputs.package}}"
-          args="--allow-branch develop,sdk-bindings --no-confirm --execute"
+          args="--allow-branch develop,sdk-bindings --no-confirm"
+
+          echo "Dry-running publish"
+          eval "cargo release $pkg_args $args --all-features"
 
           echo "Commits since last tag:"
           eval "cargo release changes"

--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -18,39 +18,43 @@ on:
           - beta:    Increase the beta pre-version (x.y.z-beta.M)
           - alpha:   Increase the alpha pre-version (x.y.z-alpha.M)
       package:
-        type: string
+        type: choice
         required: true
         description: The package to publish.
+        options:
+          - iota-sdk
+          - iota-sdk-crypto
+          - iota-sdk-ffi
+          - iota-sdk-graphql-client
+          - iota-sdk-graphql-client-build
+          - iota-sdk-transaction-builder
+          - iota-sdk-types
 
 jobs:
   publish:
-    name: Publish to crates.io
+    name: Setup for publish to crates.io
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - run: cargo install cargo-release --version 0.25.20
+      - name: Install cargo-release
+        run: cargo install cargo-release --version 0.25.20
 
-      - name: Cargo release publish
-        run: |
-          pkg_args="-p ${{inputs.package}}"
-          args="--allow-branch develop,sdk-bindings --no-confirm"
+      - name: Dry run publish
+        run: eval "cargo release -p ${{inputs.package}} --allow-branch develop,sdk-bindings --no-confirm --all-features"
 
-          echo "Dry-running publish"
-          eval "cargo release $pkg_args $args --all-features"
+      - name: Get commits since last tag
+        run: eval "cargo release changes"
 
-          echo "Commits since last tag:"
-          eval "cargo release changes"
+      - name: Bump versions
+        run: eval "cargo release version -p ${{inputs.package}} --allow-branch develop,sdk-bindings --no-confirm ${{inputs.level}}"
 
-          echo "Bumping versions"
-          eval "cargo release version $pkg_args $args ${{inputs.level}}"
+      - name: Commit packages
+        run: eval "cargo release commit --allow-branch develop,sdk-bindings --no-confirm"
 
-          echo "Committing packages"
-          eval "cargo release commit $args"
+      - name: Tag commit
+        run: eval "cargo release tag -p ${{inputs.package}} --allow-branch develop,sdk-bindings --no-confirm --tag-prefix '${{inputs.package}}-'"
 
-          echo "Tagging the commit"
-          eval "cargo release tag $pkg_args $args --tag-prefix '${{inputs.package}}-'"
-
-          echo "Pushing commit"
-          eval "cargo release push $pkg_args $args"
+      - name: Push commit
+        run: eval "cargo release push -p ${{inputs.package}} --allow-branch develop,sdk-bindings --no-confirm"

--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -1,0 +1,53 @@
+name: Pre-publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        type: string
+        required: true
+        description: |
+          The level of version bump to make.
+
+          Possible values:
+          - major:   Increase the major version (x.0.0)
+          - minor:   Increase the minor version (x.y.0)
+          - patch:   Increase the patch version (x.y.z)
+          - release: Remove the pre-version (x.y.z)
+          - rc:      Increase the rc pre-version (x.y.z-rc.M)
+          - beta:    Increase the beta pre-version (x.y.z-beta.M)
+          - alpha:   Increase the alpha pre-version (x.y.z-alpha.M)
+      package:
+        type: string
+        required: true
+        description: The package to publish.
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - run: cargo install cargo-release
+
+      - name: Cargo release publish
+        run: |
+          pkg_args="-p ${{inputs.package}}"
+          args="--allow-branch develop,sdk-bindings --no-confirm --execute"
+
+          echo "Commits since last tag:"
+          eval "cargo release changes"
+
+          echo "Bumping versions"
+          eval "cargo release version $pkg_args $args ${{inputs.level}}"
+
+          echo "Committing packages"
+          eval "cargo release commit $args"
+
+          echo "Tagging the commit"
+          eval "cargo release tag $pkg_args $args --tag-prefix '${{inputs.package}}-'"
+
+          echo "Pushing commit"
+          eval "cargo release push $pkg_args $args"

--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -24,7 +24,6 @@ on:
         options:
           - iota-sdk
           - iota-sdk-crypto
-          - iota-sdk-ffi
           - iota-sdk-graphql-client
           - iota-sdk-graphql-client-build
           - iota-sdk-transaction-builder

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Cargo release publish
         run: |-
           cargo release \
-            publish \
             --workspace \
             --exclude iota-graphql-client-build \
             --exclude iota-sdk-ffi \
             --all-features \
+            --allow-branch develop,sdk-bindings
             --no-confirm \
             --execute

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - run: cargo install cargo-release
+      - run: cargo install cargo-release --version 0.25.20
 
       - name: Cargo release publish
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
           cargo release \
             publish \
             --workspace \
+            --exclude iota-graphql-client-build \
             --all-features \
             --no-confirm \
             --execute

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,8 @@
 name: Publish
 
 on:
-  workflow_dispatch:
-    inputs:
-      level:
-        type: string
-        description: |
-          The level of version bump to make.
-
-          Possible values:
-          - major:   Increase the major version (x.0.0)
-          - minor:   Increase the minor version (x.y.0)
-          - patch:   Increase the patch version (x.y.z)
-          - release: Remove the pre-version (x.y.z)
-          - rc:      Increase the rc pre-version (x.y.z-rc.M)
-          - beta:    Increase the beta pre-version (x.y.z-beta.M)
-          - alpha:   Increase the alpha pre-version (x.y.z-alpha.M)
-      package:
-        type: string
-        description: The package to publish. If not provided, all packages will be bumped and published.
+  release:
+    types: [published]
 
 jobs:
   publish:
@@ -32,18 +16,13 @@ jobs:
 
       - name: Cargo release publish
         run: |
-          cmd="cargo release \
-            --workspace \
-            --exclude iota-graphql-client-build \
-            --exclude iota-sdk-ffi \
+          pkg=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|(.*)-v.*|\1|p'
+          version=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|.*-v(.*)|\1|p'
+
+          echo "Publishing $pkg at version $version"
+          eval "cargo release publish \
+            -p $pkg \
             --all-features \
-            --allow-branch develop,sdk-bindings
+            --allow-branch develop,sdk-bindings \
             --no-confirm \
             --execute"
-          if [ -n ${{inputs.package}} ]; then
-            cmd="$cmd -p ${{inputs.package}}"
-          fi
-          if [ -n ${{inputs.level}} ]; then
-            cmd="$cmd ${{inputs.level}}"
-          fi
-          eval "$cmd"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
             publish \
             --workspace \
             --exclude iota-graphql-client-build \
+            --exclude iota-sdk-ffi \
             --all-features \
             --no-confirm \
             --execute

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on: workflow_dispatch
+
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - run: cargo install cargo-release
+
+      - name: Cargo release publish
+        run: |-
+          cargo release \
+            publish \
+            --package iota-sdk \
+            --all-features \
+            --no-confirm \
+            --execute

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,24 @@
 name: Publish
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        type: string
+        description: |
+          The level of version bump to make.
+
+          Possible values:
+          - major:   Increase the major version (x.0.0)
+          - minor:   Increase the minor version (x.y.0)
+          - patch:   Increase the patch version (x.y.z)
+          - release: Remove the pre-version (x.y.z)
+          - rc:      Increase the rc pre-version (x.y.z-rc.M)
+          - beta:    Increase the beta pre-version (x.y.z-beta.M)
+          - alpha:   Increase the alpha pre-version (x.y.z-alpha.M)
+      package:
+        type: string
+        description: The package to publish. If not provided, all packages will be bumped and published.
 
 jobs:
   publish:
@@ -13,12 +31,19 @@ jobs:
       - run: cargo install cargo-release
 
       - name: Cargo release publish
-        run: |-
-          cargo release \
+        run: |
+          cmd="cargo release \
             --workspace \
             --exclude iota-graphql-client-build \
             --exclude iota-sdk-ffi \
             --all-features \
             --allow-branch develop,sdk-bindings
             --no-confirm \
-            --execute
+            --execute"
+          if [ -n ${{inputs.package}} ]; then
+            cmd="$cmd -p ${{inputs.package}}"
+          fi
+          if [ -n ${{inputs.level}} ]; then
+            cmd="$cmd ${{inputs.level}}"
+          fi
+          eval "$cmd"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         run: |-
           cargo release \
             publish \
-            --package iota-sdk \
+            --workspace \
             --all-features \
             --no-confirm \
             --execute

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+# We need this to be able to create releases.
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Show the tag
+        run: |
+          echo "tag is: ${{ github.ref_name }}"
+
+      - name: Install node
+        uses: actions/setup-node@v6
+
+      - name: Install conventional-commits
+        run: npm -g i conventional-commits
+
+      - name: Generate Release Notes
+        run: conventional-changelog -p conventionalcommits -i notes-${{ github.ref_name }}.md -s
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create $TAG --verify-tag --title $TAG --notes-file notes-${{ github.ref_name }}.md
+
+      - name: Update major tag
+        uses: rickstaa/action-update-semver@77e8cb0f3cd805b38ffe25c07236336e05dcb4da # v1.1.4
+        with:
+          major_version_tag_only: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "*-v*.*.*"
 
 # We need this to be able to create releases.
 permissions:
@@ -28,14 +28,11 @@ jobs:
         run: npm -g i conventional-commits
 
       - name: Generate Release Notes
-        run: conventional-changelog -p conventionalcommits -i notes-${{ github.ref_name }}.md -s
+        run: |
+          pkg=$(echo "${{github.ref_name}}" | sed -nr 's|(.*)-v.*|\1|p'
+          conventional-changelog -p conventionalcommits -i notes-${{ github.ref_name }}.md -s --commit-path "crates/$pkg"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release create $TAG --verify-tag --title $TAG --draft --notes-file notes-${{ github.ref_name }}.md
-
-      - name: Update major tag
-        uses: rickstaa/action-update-semver@77e8cb0f3cd805b38ffe25c07236336e05dcb4da # v1.1.4
-        with:
-          major_version_tag_only: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 
 jobs:
   create-release:
-    name: create-release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,7 +21,7 @@ jobs:
           echo "tag is: ${{ github.ref_name }}"
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
 
       - name: Install conventional-commits
         run: npm -g i conventional-commits
@@ -34,5 +33,5 @@ jobs:
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release create $TAG --verify-tag --title $TAG --draft --notes-file notes-${{ github.ref_name }}.md
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ github.ref_name }} --verify-tag --title ${{ github.ref_name }} --draft --notes-file notes-${{ github.ref_name }}.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create $TAG --verify-tag --title $TAG --notes-file notes-${{ github.ref_name }}.md
+        run: gh release create $TAG --verify-tag --title $TAG --draft --notes-file notes-${{ github.ref_name }}.md
 
       - name: Update major tag
         uses: rickstaa/action-update-semver@77e8cb0f3cd805b38ffe25c07236336e05dcb4da # v1.1.4

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -56,7 +56,7 @@ pem = [
 bls12381 = ["dep:blst", "dep:rand_core", "dep:roaring", "signature/std"]
 
 [dependencies]
-iota-types = { version = "0.0.1", package = "iota-sdk-types", path = "../iota-sdk-types", default-features = false, features = ["hash", "serde"] }
+iota-types = { workspace = true, features = ["hash", "serde"] }
 signature = "2.2"
 thiserror.workspace = true
 

--- a/crates/iota-sdk-graphql-client-build/Cargo.toml
+++ b/crates/iota-sdk-graphql-client-build/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = ["IOTA Foundation <info@iota.org>"]
 edition = "2021"
 license = "Apache-2.0"
+publish = false
 readme = "README.md"
 repository = "https://github.com/iotaledger/iota-rust-sdk/"
 description = "GraphQL RPC Client for the IOTA Blockchain"

--- a/crates/iota-sdk-graphql-client-build/Cargo.toml
+++ b/crates/iota-sdk-graphql-client-build/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 authors = ["IOTA Foundation <info@iota.org>"]
 edition = "2021"
 license = "Apache-2.0"
-publish = false
 readme = "README.md"
 repository = "https://github.com/iotaledger/iota-rust-sdk/"
 description = "GraphQL RPC Client for the IOTA Blockchain"


### PR DESCRIPTION
## Description

Adds a CI job to publish the rust crates, and one to create a github release.  The first workflow uses [`cargo-release`](https://github.com/crate-ci/cargo-release) to do the hard work of bumping the versions, publishing the crates, and pushing the commit to the branch. The second workflow creates a github release with a changelog.

Renames the `iota-crypto` crate to `iota-crypto-2`.

The following crates will be published:
- `iota-crypto-2 v0.0.1`
- `iota-graphql-client v0.0.1`
- `iota-sdk v3.0.0`
- `iota-sdk-types v0.0.1`
- `iota-transaction-builder v0.0.1`

Closes #242