### PR TITLE
fix: make kotlin example output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ kotlin-example: ## Run a specific Kotlin example. Usage: make kotlin-example exa
 %:
 	@true
 kotlin-example:
-	@printf "\nRunning Kotlin example \"$(word 2,$(MAKECMDGOALS))" \n \"
+	@printf "\nRunning Kotlin example \"$(word 2,$(MAKECMDGOALS))\"\n"
 	@cd bindings/kotlin; \
 	./gradlew build clean || exit $$?; \
 	LD_LIBRARY_PATH=./lib ./gradlew example -Pexample=$(word 2,$(MAKECMDGOALS)) -q || exit $$?; \


### PR DESCRIPTION
Prints
```
thibault@Mac ~/i/iota-rust-sdk (sdk-bindings) [2]> make kotlin-example coin_balances

Running Kotlin example "coin_balances"
Calculating task graph as configuration cache cannot be reused because JVM has changed.
```
instead of
```
thibault@Mac ~/i/iota-rust-sdk (sdk-bindings)> make kotlin-example coin_balances

Running Kotlin example "coin_balancesStarting a Gradle Daemon (subsequent builds will be faster)
Calculating task graph as configuration cache cannot be reused because JVM has changed.
```