### PR TITLE
fix(transaction-builder): Require `send_iota` amount param

### DIFF
--- a/bindings/go/examples/prepare_send_iota/main.go
+++ b/bindings/go/examples/prepare_send_iota/main.go
@@ -15,10 +15,9 @@ func main() {
 	fromAddress, _ := sdk.AddressFromHex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
 
 	toAddress, _ := sdk.AddressFromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
-	amount := sdk.PtbArgumentU64(5000000000)
 
 	builder := sdk.TransactionBuilderInit(fromAddress, client)
-	builder.SendIota(toAddress, &amount)
+	builder.SendIota(toAddress, sdk.PtbArgumentU64(5000000000))
 
 	txn, err := builder.Finish()
 	if err.(*sdk.SdkFfiError) != nil {

--- a/bindings/go/examples/sign_send_iota/main.go
+++ b/bindings/go/examples/sign_send_iota/main.go
@@ -10,8 +10,6 @@ import (
 )
 
 func main() {
-	// Amount to send in nanos
-	amount := sdk.PtbArgumentU64(1000)
 	recipientAddress, err := sdk.AddressFromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
 	if err != nil {
 		log.Fatalf("Failed to parse recipient address: %v", err)
@@ -35,7 +33,7 @@ func main() {
 	client := sdk.GraphQlClientNewLocalnet()
 
 	builder := sdk.TransactionBuilderInit(senderAddress, client)
-	builder.SendIota(recipientAddress, &amount)
+	builder.SendIota(recipientAddress, sdk.PtbArgumentU64(1000))
 	txn, err := builder.Finish()
 	if err.(*sdk.SdkFfiError) != nil {
 		log.Fatalf("Failed to create transaction: %v", err)

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -3836,7 +3836,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota()
 	})
-	if checksum != 16395 {
+	if checksum != 38983 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota: UniFFI API checksum mismatch")
 	}
@@ -22287,7 +22287,7 @@ type TransactionBuilderInterface interface {
 	// provided then they will be merged.
 	SendCoins(coins []*PtbArgument, recipient *Address, amount **PtbArgument) *TransactionBuilder
 	// Send IOTA to a recipient address.
-	SendIota(recipient *Address, amount **PtbArgument) *TransactionBuilder
+	SendIota(recipient *Address, amount *PtbArgument) *TransactionBuilder
 	// Split a coin by the provided amounts.
 	SplitCoins(coin *PtbArgument, amounts []*PtbArgument, names []string) *TransactionBuilder
 	// Set the sponsor of the transaction.
@@ -22595,12 +22595,12 @@ func (_self *TransactionBuilder) SendCoins(coins []*PtbArgument, recipient *Addr
 }
 
 // Send IOTA to a recipient address.
-func (_self *TransactionBuilder) SendIota(recipient *Address, amount **PtbArgument) *TransactionBuilder {
+func (_self *TransactionBuilder) SendIota(recipient *Address, amount *PtbArgument) *TransactionBuilder {
 	_pointer := _self.ffiObject.incrementPointer("*TransactionBuilder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterTransactionBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(
-		_pointer,FfiConverterAddressINSTANCE.Lower(recipient), FfiConverterOptionalPtbArgumentINSTANCE.Lower(amount),_uniffiStatus)
+		_pointer,FfiConverterAddressINSTANCE.Lower(recipient), FfiConverterPtbArgumentINSTANCE.Lower(amount),_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.h
@@ -4371,7 +4371,7 @@ void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_coins(void* ptr, Rus
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SEND_IOTA
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SEND_IOTA
-void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(void* ptr, void* recipient, RustBuffer amount, RustCallStatus *out_status
+void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(void* ptr, void* recipient, void* amount, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SPLIT_COINS

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -5632,7 +5632,7 @@ fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_publish(`ptr`: Pointer,`pac
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_coins(`ptr`: Pointer,`coins`: RustBuffer.ByValue,`recipient`: Pointer,`amount`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(`ptr`: Pointer,`recipient`: Pointer,`amount`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(`ptr`: Pointer,`recipient`: Pointer,`amount`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_split_coins(`ptr`: Pointer,`coin`: Pointer,`amounts`: RustBuffer.ByValue,`names`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -7296,7 +7296,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins() != 434.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 16395.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 38983.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins() != 17747.toShort()) {
@@ -38835,7 +38835,7 @@ public interface TransactionBuilderInterface {
     /**
      * Send IOTA to a recipient address.
      */
-    fun `sendIota`(`recipient`: Address, `amount`: PtbArgument? = null): TransactionBuilder
+    fun `sendIota`(`recipient`: Address, `amount`: PtbArgument): TransactionBuilder
     
     /**
      * Split a coin by the provided amounts.
@@ -39235,12 +39235,12 @@ open class TransactionBuilder: Disposable, AutoCloseable, TransactionBuilderInte
     
     /**
      * Send IOTA to a recipient address.
-     */override fun `sendIota`(`recipient`: Address, `amount`: PtbArgument?): TransactionBuilder {
+     */override fun `sendIota`(`recipient`: Address, `amount`: PtbArgument): TransactionBuilder {
             return FfiConverterTypeTransactionBuilder.lift(
     callWithPointer {
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(
-        it, FfiConverterTypeAddress.lower(`recipient`),FfiConverterOptionalTypePTBArgument.lower(`amount`),_status)
+        it, FfiConverterTypeAddress.lower(`recipient`),FfiConverterTypePTBArgument.lower(`amount`),_status)
 }
     }
     )

--- a/bindings/python/examples/sign_send_iota.py
+++ b/bindings/python/examples/sign_send_iota.py
@@ -26,7 +26,7 @@ async def main():
         client = GraphQlClient.new_localnet()
 
         builder = await TransactionBuilder.init(sender_address, client)
-        builder.send_iota(recipient_address, [PtbArgument.u64(amount)])
+        builder.send_iota(recipient_address, PtbArgument.u64(amount))
         txn = await builder.finish()
 
         dry_run_result = await client.dry_run_tx(txn)

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -1233,7 +1233,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins() != 434:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 16395:
+    if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 38983:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins() != 17747:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -6197,7 +6197,7 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_coins.restype =
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota.argtypes = (
     ctypes.c_void_p,
     ctypes.c_void_p,
-    _UniffiRustBuffer,
+    ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota.restype = ctypes.c_void_p
@@ -38587,7 +38587,7 @@ class TransactionBuilderProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
-    def send_iota(self, recipient: "Address",amount: "typing.Union[object, typing.Optional[PtbArgument]]" = _DEFAULT):
+    def send_iota(self, recipient: "Address",amount: "PtbArgument"):
         """
         Send IOTA to a recipient address.
         """
@@ -39038,21 +39038,19 @@ _UniffiConverterTypeSdkFfiError,
 
 
 
-    def send_iota(self, recipient: "Address",amount: "typing.Union[object, typing.Optional[PtbArgument]]" = _DEFAULT) -> "TransactionBuilder":
+    def send_iota(self, recipient: "Address",amount: "PtbArgument") -> "TransactionBuilder":
         """
         Send IOTA to a recipient address.
         """
 
         _UniffiConverterTypeAddress.check_lower(recipient)
         
-        if amount is _DEFAULT:
-            amount = None
-        _UniffiConverterOptionalTypePtbArgument.check_lower(amount)
+        _UniffiConverterTypePtbArgument.check_lower(amount)
         
         return _UniffiConverterTypeTransactionBuilder.lift(
             _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota,self._uniffi_clone_pointer(),
         _UniffiConverterTypeAddress.lower(recipient),
-        _UniffiConverterOptionalTypePtbArgument.lower(amount))
+        _UniffiConverterTypePtbArgument.lower(amount))
         )
 
 

--- a/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/mod.rs
@@ -165,14 +165,9 @@ impl TransactionBuilder {
     }
 
     /// Send IOTA to a recipient address.
-    #[uniffi::method(default(amount = None))]
-    pub fn send_iota(
-        self: Arc<Self>,
-        recipient: &Address,
-        amount: Option<Arc<PTBArgument>>,
-    ) -> Arc<Self> {
+    pub fn send_iota(self: Arc<Self>, recipient: &Address, amount: &PTBArgument) -> Arc<Self> {
         self.write(|builder| {
-            builder.send_iota::<&PTBArgument>(**recipient, amount.as_deref());
+            builder.send_iota(**recipient, amount);
         });
         self
     }

--- a/crates/iota-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-transaction-builder/src/builder/mod.rs
@@ -396,18 +396,14 @@ impl<C, L> TransactionBuilder<C, L> {
     pub fn send_iota<T: PTBArgument>(
         &mut self,
         recipient: Address,
-        amount: impl Into<Option<T>>,
+        amount: T,
     ) -> &mut TransactionBuilder<C> {
         let rec_arg = self.pure(recipient);
-        let coin_arg = if let Some(amount) = amount.into() {
-            let amt_arg = self.apply_argument(amount);
-            self.command(Command::SplitCoins(SplitCoins {
-                coin: Argument::Gas,
-                amounts: vec![amt_arg],
-            }))
-        } else {
-            Argument::Gas
-        };
+        let amt_arg = self.apply_argument(amount);
+        let coin_arg = self.command(Command::SplitCoins(SplitCoins {
+            coin: Argument::Gas,
+            amounts: vec![amt_arg],
+        }));
         self.command(Command::TransferObjects(TransferObjects {
             objects: vec![coin_arg],
             address: rec_arg,


### PR DESCRIPTION
## Description

The `amount` param for `send_iota` was optional, but this meant that not providing it would send the entire gas coin, which is probably undesirable. This PR makes it required.