### PR TITLE
fix(kotlin): fail CI if example panics

### DIFF
--- a/bindings/kotlin/examples/ChainId.kt
+++ b/bindings/kotlin/examples/ChainId.kt
@@ -11,5 +11,6 @@ fun main() = runBlocking {
         println("Chain ID: $chainId")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/CoinBalances.kt
+++ b/bindings/kotlin/examples/CoinBalances.kt
@@ -13,6 +13,7 @@ fun main() = runBlocking {
                         "0xb14f13f5343641e5b52d144fd6f106a7058efe2f1ad44598df5cda73acf0101f",
                 )
 
+        error("panic")
         val coins = client.coins(address)
         for (coin in coins.data) {
             println("Coin = 0x${coin.id().toHex()}, Coin Type = ${coin.coinType().asStructTag()}, Balance = ${coin.balance()}")
@@ -22,6 +23,6 @@ fun main() = runBlocking {
         println("Total Balance = $balance")
     } catch (e: Exception) {
         e.printStackTrace()
-        kotlin.system.exitProcess(1)
+        throw e
     }
 }

--- a/bindings/kotlin/examples/CoinBalances.kt
+++ b/bindings/kotlin/examples/CoinBalances.kt
@@ -23,6 +23,6 @@ fun main() = runBlocking {
         println("Total Balance = $balance")
     } catch (e: Exception) {
         e.printStackTrace()
-        throw e
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/CoinBalances.kt
+++ b/bindings/kotlin/examples/CoinBalances.kt
@@ -22,5 +22,6 @@ fun main() = runBlocking {
         println("Total Balance = $balance")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/CoinBalances.kt
+++ b/bindings/kotlin/examples/CoinBalances.kt
@@ -13,7 +13,6 @@ fun main() = runBlocking {
                         "0xb14f13f5343641e5b52d144fd6f106a7058efe2f1ad44598df5cda73acf0101f",
                 )
 
-        error("panic")
         val coins = client.coins(address)
         for (coin in coins.data) {
             println("Coin = 0x${coin.id().toHex()}, Coin Type = ${coin.coinType().asStructTag()}, Balance = ${coin.balance()}")

--- a/bindings/kotlin/examples/DevInspect.kt
+++ b/bindings/kotlin/examples/DevInspect.kt
@@ -137,5 +137,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/DryRunBytes.kt
+++ b/bindings/kotlin/examples/DryRunBytes.kt
@@ -22,5 +22,6 @@ fun main() = runBlocking {
         println("Dry run result: $res")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/DynamicFields.kt
+++ b/bindings/kotlin/examples/DynamicFields.kt
@@ -19,5 +19,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Epoch.kt
+++ b/bindings/kotlin/examples/Epoch.kt
@@ -32,5 +32,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Example.kt
+++ b/bindings/kotlin/examples/Example.kt
@@ -42,5 +42,6 @@ fun main() = runBlocking {
                         )
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Faucet.kt
+++ b/bindings/kotlin/examples/Faucet.kt
@@ -25,5 +25,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/GasSponsor.kt
+++ b/bindings/kotlin/examples/GasSponsor.kt
@@ -50,5 +50,6 @@ fun main() = runBlocking {
         println("Gas sponsor tx dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/GasStation.kt
+++ b/bindings/kotlin/examples/GasStation.kt
@@ -30,6 +30,8 @@ fun main() = runBlocking {
                 )
         )
 
+        error("panic")
+
         builder.gasStationSponsor(
                 gasStationUrl,
                 headers = mapOf("Authorization" to listOf("Bearer $gasStationAuthToken"))

--- a/bindings/kotlin/examples/GasStation.kt
+++ b/bindings/kotlin/examples/GasStation.kt
@@ -46,5 +46,6 @@ fun main() = runBlocking {
         println("Sponsored transaction was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/GasStation.kt
+++ b/bindings/kotlin/examples/GasStation.kt
@@ -30,8 +30,6 @@ fun main() = runBlocking {
                 )
         )
 
-        error("panic")
-
         builder.gasStationSponsor(
                 gasStationUrl,
                 headers = mapOf("Authorization" to listOf("Bearer $gasStationAuthToken"))

--- a/bindings/kotlin/examples/GenericMoveFunction.kt
+++ b/bindings/kotlin/examples/GenericMoveFunction.kt
@@ -53,6 +53,7 @@ fun main() = runBlocking {
         println("Successfully called generic Move function!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }
 

--- a/bindings/kotlin/examples/GetObject.kt
+++ b/bindings/kotlin/examples/GetObject.kt
@@ -28,5 +28,6 @@ fun main() = runBlocking {
         println("BCS bytes: ${hexEncode(obj.asStruct().contents)}")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/MoveFunctions.kt
+++ b/bindings/kotlin/examples/MoveFunctions.kt
@@ -41,5 +41,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/ObjectsByType.kt
+++ b/bindings/kotlin/examples/ObjectsByType.kt
@@ -21,5 +21,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/OwnedObjects.kt
+++ b/bindings/kotlin/examples/OwnedObjects.kt
@@ -18,5 +18,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PackageEvents.kt
+++ b/bindings/kotlin/examples/PackageEvents.kt
@@ -30,5 +30,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Pagination.kt
+++ b/bindings/kotlin/examples/Pagination.kt
@@ -43,5 +43,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareMergeCoins.kt
+++ b/bindings/kotlin/examples/PrepareMergeCoins.kt
@@ -39,6 +39,7 @@ fun main() = runBlocking {
 
         println("Merge coins dry run was successful!")
     } catch (e: Exception) {
-        println("Error: $e")
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareSendCoins.kt
+++ b/bindings/kotlin/examples/PrepareSendCoins.kt
@@ -42,5 +42,6 @@ fun main() = runBlocking {
         println("Send coins dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareSendIota.kt
+++ b/bindings/kotlin/examples/PrepareSendIota.kt
@@ -39,5 +39,6 @@ fun main() = runBlocking {
         println("Send IOTA dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareSendIotaMulti.kt
+++ b/bindings/kotlin/examples/PrepareSendIotaMulti.kt
@@ -68,5 +68,6 @@ fun main() = runBlocking {
         println("Send IOTA dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareSplitCoins.kt
+++ b/bindings/kotlin/examples/PrepareSplitCoins.kt
@@ -54,5 +54,6 @@ fun main() = runBlocking {
         println("Split coins dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/PrepareTransferObjects.kt
+++ b/bindings/kotlin/examples/PrepareTransferObjects.kt
@@ -47,5 +47,6 @@ fun main() = runBlocking {
         println("Transfer objects dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/SignSendIota.kt
+++ b/bindings/kotlin/examples/SignSendIota.kt
@@ -45,5 +45,6 @@ fun main() = runBlocking {
         println("Effects: ${effects.asV1()}")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Stake.kt
+++ b/bindings/kotlin/examples/Stake.kt
@@ -37,5 +37,6 @@ fun main() = runBlocking {
         println("Stake dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/TransactionsWithFunction.kt
+++ b/bindings/kotlin/examples/TransactionsWithFunction.kt
@@ -17,5 +17,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/TransactionsWithShared.kt
+++ b/bindings/kotlin/examples/TransactionsWithShared.kt
@@ -21,5 +21,6 @@ fun main() = runBlocking {
         }
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/TxCommandResults.kt
+++ b/bindings/kotlin/examples/TxCommandResults.kt
@@ -64,5 +64,6 @@ fun main() = runBlocking {
         println("Tx dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }

--- a/bindings/kotlin/examples/Unstake.kt
+++ b/bindings/kotlin/examples/Unstake.kt
@@ -31,5 +31,6 @@ fun main() = runBlocking {
         println("Unstake dry run was successful!")
     } catch (e: Exception) {
         e.printStackTrace()
+        kotlin.system.exitProcess(1)
     }
 }


### PR DESCRIPTION
Fixes https://github.com/iotaledger/iota-rust-sdk/issues/313

The Kotlin examples catch panics to display a stacktrace, preventing the error code from reaching the shell and then failing the CI. We then add an explicit error code after the stacktrace.