### PR TITLE
feat(graphql-client): update query types

### DIFF
--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -33344,10 +33344,6 @@ func (_ FfiDestroyerValidatorPage) Destroy(value ValidatorPage) {
 	value.Destroy()
 }
 type ValidatorSet struct {
-	// The current set of active validators.
-	ActiveValidators ValidatorConnection
-	// The current set of committee members.
-	CommitteeMembers ValidatorConnection
 	// Object ID of the `Table` storing the inactive staking pools.
 	InactivePoolsId **ObjectId
 	// Size of the inactive pools `Table`.
@@ -33377,8 +33373,6 @@ type ValidatorSet struct {
 }
 
 func (r *ValidatorSet) Destroy() {
-		FfiDestroyerValidatorConnection{}.Destroy(r.ActiveValidators);
-		FfiDestroyerValidatorConnection{}.Destroy(r.CommitteeMembers);
 		FfiDestroyerOptionalObjectId{}.Destroy(r.InactivePoolsId);
 		FfiDestroyerOptionalInt32{}.Destroy(r.InactivePoolsSize);
 		FfiDestroyerOptionalObjectId{}.Destroy(r.PendingActiveValidatorsId);
@@ -33401,8 +33395,6 @@ func (c FfiConverterValidatorSet) Lift(rb RustBufferI) ValidatorSet {
 
 func (c FfiConverterValidatorSet) Read(reader io.Reader) ValidatorSet {
 	return ValidatorSet {
-			FfiConverterValidatorConnectionINSTANCE.Read(reader),
-			FfiConverterValidatorConnectionINSTANCE.Read(reader),
 			FfiConverterOptionalObjectIdINSTANCE.Read(reader),
 			FfiConverterOptionalInt32INSTANCE.Read(reader),
 			FfiConverterOptionalObjectIdINSTANCE.Read(reader),
@@ -33421,8 +33413,6 @@ func (c FfiConverterValidatorSet) Lower(value ValidatorSet) C.RustBuffer {
 }
 
 func (c FfiConverterValidatorSet) Write(writer io.Writer, value ValidatorSet) {
-		FfiConverterValidatorConnectionINSTANCE.Write(writer, value.ActiveValidators);
-		FfiConverterValidatorConnectionINSTANCE.Write(writer, value.CommitteeMembers);
 		FfiConverterOptionalObjectIdINSTANCE.Write(writer, value.InactivePoolsId);
 		FfiConverterOptionalInt32INSTANCE.Write(writer, value.InactivePoolsSize);
 		FfiConverterOptionalObjectIdINSTANCE.Write(writer, value.PendingActiveValidatorsId);

--- a/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
+++ b/bindings/go/iota_sdk_ffi/iota_sdk_ffi.go
@@ -29940,6 +29940,13 @@ type FfiDestroyerEndOfEpochData struct {}
 func (_ FfiDestroyerEndOfEpochData) Destroy(value EndOfEpochData) {
 	value.Destroy()
 }
+// Operation of the IOTA network is temporally partitioned into non-overlapping
+// epochs, and the network aims to keep epochs roughly the same duration as
+// each other. During a particular epoch the following data is fixed:
+//
+// - the protocol version
+// - the reference gas price
+// - the set of participating validators
 type Epoch struct {
 	// The epoch's id as a sequence number that starts at 0 and is incremented
 	// by one at every epoch change.
@@ -29989,6 +29996,18 @@ type Epoch struct {
 	// For epochs other than the current the data provided refer to the start
 	// of the epoch.
 	ValidatorSet *ValidatorSet
+	// IOTA set aside to account for objects stored on-chain, at the start of
+	// the epoch. This is also used for storage rebates.
+	StorageFund *StorageFund
+	// Information about whether this epoch was started in safe mode, which
+	// happens if the full epoch change logic fails for some reason.
+	SafeMode *SafeMode
+	// The total IOTA supply.
+	IotaTotalSupply *uint64
+	// The treasury-cap id.
+	IotaTreasuryCapId **Address
+	// Details of the system that are decided during genesis.
+	SystemParameters *SystemParameters
 }
 
 func (r *Epoch) Destroy() {
@@ -30008,6 +30027,11 @@ func (r *Epoch) Destroy() {
 		FfiDestroyerOptionalString{}.Destroy(r.TotalStakeRewards);
 		FfiDestroyerOptionalUint64{}.Destroy(r.TotalTransactions);
 		FfiDestroyerOptionalValidatorSet{}.Destroy(r.ValidatorSet);
+		FfiDestroyerOptionalStorageFund{}.Destroy(r.StorageFund);
+		FfiDestroyerOptionalSafeMode{}.Destroy(r.SafeMode);
+		FfiDestroyerOptionalUint64{}.Destroy(r.IotaTotalSupply);
+		FfiDestroyerOptionalAddress{}.Destroy(r.IotaTreasuryCapId);
+		FfiDestroyerOptionalSystemParameters{}.Destroy(r.SystemParameters);
 }
 
 type FfiConverterEpoch struct {}
@@ -30036,6 +30060,11 @@ func (c FfiConverterEpoch) Read(reader io.Reader) Epoch {
 			FfiConverterOptionalStringINSTANCE.Read(reader),
 			FfiConverterOptionalUint64INSTANCE.Read(reader),
 			FfiConverterOptionalValidatorSetINSTANCE.Read(reader),
+			FfiConverterOptionalStorageFundINSTANCE.Read(reader),
+			FfiConverterOptionalSafeModeINSTANCE.Read(reader),
+			FfiConverterOptionalUint64INSTANCE.Read(reader),
+			FfiConverterOptionalAddressINSTANCE.Read(reader),
+			FfiConverterOptionalSystemParametersINSTANCE.Read(reader),
 	}
 }
 
@@ -30060,6 +30089,11 @@ func (c FfiConverterEpoch) Write(writer io.Writer, value Epoch) {
 		FfiConverterOptionalStringINSTANCE.Write(writer, value.TotalStakeRewards);
 		FfiConverterOptionalUint64INSTANCE.Write(writer, value.TotalTransactions);
 		FfiConverterOptionalValidatorSetINSTANCE.Write(writer, value.ValidatorSet);
+		FfiConverterOptionalStorageFundINSTANCE.Write(writer, value.StorageFund);
+		FfiConverterOptionalSafeModeINSTANCE.Write(writer, value.SafeMode);
+		FfiConverterOptionalUint64INSTANCE.Write(writer, value.IotaTotalSupply);
+		FfiConverterOptionalAddressINSTANCE.Write(writer, value.IotaTreasuryCapId);
+		FfiConverterOptionalSystemParametersINSTANCE.Write(writer, value.SystemParameters);
 }
 
 type FfiDestroyerEpoch struct {}
@@ -30511,6 +30545,67 @@ func (c FfiConverterGasPayment) Write(writer io.Writer, value GasPayment) {
 type FfiDestroyerGasPayment struct {}
 
 func (_ FfiDestroyerGasPayment) Destroy(value GasPayment) {
+	value.Destroy()
+}
+// Breakdown of gas costs in effects.
+type GraphQlGasCostSummary struct {
+	// Gas paid for executing this transaction (in NANOS).
+	ComputationCost *string
+	// Gas burned for executing this transaction (in NANOS).
+	ComputationCostBurned *string
+	// Gas paid for the data stored on-chain by this transaction (in NANOS).
+	StorageCost *string
+	// Part of storage cost that can be reclaimed by cleaning up data created
+	// by this transaction (when objects are deleted or an object is
+	// modified, which is treated as a deletion followed by a creation) (in
+	// NANOS).
+	StorageRebate *string
+	// Part of storage cost that is not reclaimed when data created by this
+	// transaction is cleaned up (in NANOS).
+	NonRefundableStorageFee *string
+}
+
+func (r *GraphQlGasCostSummary) Destroy() {
+		FfiDestroyerOptionalString{}.Destroy(r.ComputationCost);
+		FfiDestroyerOptionalString{}.Destroy(r.ComputationCostBurned);
+		FfiDestroyerOptionalString{}.Destroy(r.StorageCost);
+		FfiDestroyerOptionalString{}.Destroy(r.StorageRebate);
+		FfiDestroyerOptionalString{}.Destroy(r.NonRefundableStorageFee);
+}
+
+type FfiConverterGraphQlGasCostSummary struct {}
+
+var FfiConverterGraphQlGasCostSummaryINSTANCE = FfiConverterGraphQlGasCostSummary{}
+
+func (c FfiConverterGraphQlGasCostSummary) Lift(rb RustBufferI) GraphQlGasCostSummary {
+	return LiftFromRustBuffer[GraphQlGasCostSummary](c, rb)
+}
+
+func (c FfiConverterGraphQlGasCostSummary) Read(reader io.Reader) GraphQlGasCostSummary {
+	return GraphQlGasCostSummary {
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGraphQlGasCostSummary) Lower(value GraphQlGasCostSummary) C.RustBuffer {
+	return LowerIntoRustBuffer[GraphQlGasCostSummary](c, value)
+}
+
+func (c FfiConverterGraphQlGasCostSummary) Write(writer io.Writer, value GraphQlGasCostSummary) {
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.ComputationCost);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.ComputationCostBurned);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.StorageCost);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.StorageRebate);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.NonRefundableStorageFee);
+}
+
+type FfiDestroyerGraphQlGasCostSummary struct {}
+
+func (_ FfiDestroyerGraphQlGasCostSummary) Destroy(value GraphQlGasCostSummary) {
 	value.Destroy()
 }
 // A JSON Web Key
@@ -31968,6 +32063,51 @@ type FfiDestroyerRandomnessStateUpdate struct {}
 func (_ FfiDestroyerRandomnessStateUpdate) Destroy(value RandomnessStateUpdate) {
 	value.Destroy()
 }
+// Information about whether epoch changes are using safe mode.
+type SafeMode struct {
+	// Whether safe mode was used for the last epoch change. The system will
+	// retry a full epoch change on every epoch boundary and automatically
+	// reset this flag if so.
+	Enabled *bool
+	// Accumulated fees for computation and cost that have not been added to
+	// the various reward pools, because the full epoch change did not happen.
+	GasSummary *GraphQlGasCostSummary
+}
+
+func (r *SafeMode) Destroy() {
+		FfiDestroyerOptionalBool{}.Destroy(r.Enabled);
+		FfiDestroyerOptionalGraphQlGasCostSummary{}.Destroy(r.GasSummary);
+}
+
+type FfiConverterSafeMode struct {}
+
+var FfiConverterSafeModeINSTANCE = FfiConverterSafeMode{}
+
+func (c FfiConverterSafeMode) Lift(rb RustBufferI) SafeMode {
+	return LiftFromRustBuffer[SafeMode](c, rb)
+}
+
+func (c FfiConverterSafeMode) Read(reader io.Reader) SafeMode {
+	return SafeMode {
+			FfiConverterOptionalBoolINSTANCE.Read(reader),
+			FfiConverterOptionalGraphQlGasCostSummaryINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterSafeMode) Lower(value SafeMode) C.RustBuffer {
+	return LowerIntoRustBuffer[SafeMode](c, value)
+}
+
+func (c FfiConverterSafeMode) Write(writer io.Writer, value SafeMode) {
+		FfiConverterOptionalBoolINSTANCE.Write(writer, value.Enabled);
+		FfiConverterOptionalGraphQlGasCostSummaryINSTANCE.Write(writer, value.GasSummary);
+}
+
+type FfiDestroyerSafeMode struct {}
+
+func (_ FfiDestroyerSafeMode) Destroy(value SafeMode) {
+	value.Destroy()
+}
 type ServiceConfig struct {
 	// Default number of elements allowed on a single page of a connection.
 	DefaultPageSize int32
@@ -32166,6 +32306,124 @@ func (c FfiConverterSignedTransactionPage) Write(writer io.Writer, value SignedT
 type FfiDestroyerSignedTransactionPage struct {}
 
 func (_ FfiDestroyerSignedTransactionPage) Destroy(value SignedTransactionPage) {
+	value.Destroy()
+}
+// IOTA set aside to account for objects stored on-chain.
+type StorageFund struct {
+	// Sum of storage rebates of live objects on chain.
+	TotalObjectStorageRebates *string
+	// The portion of the storage fund that will never be refunded through
+	// storage rebates.
+	// The system maintains an invariant that the sum of
+	// all storage fees into the storage fund is equal to the sum of of all
+	// storage rebates out, the total storage rebates remaining, and the
+	// non-refundable balance.
+	NonRefundableBalance *string
+}
+
+func (r *StorageFund) Destroy() {
+		FfiDestroyerOptionalString{}.Destroy(r.TotalObjectStorageRebates);
+		FfiDestroyerOptionalString{}.Destroy(r.NonRefundableBalance);
+}
+
+type FfiConverterStorageFund struct {}
+
+var FfiConverterStorageFundINSTANCE = FfiConverterStorageFund{}
+
+func (c FfiConverterStorageFund) Lift(rb RustBufferI) StorageFund {
+	return LiftFromRustBuffer[StorageFund](c, rb)
+}
+
+func (c FfiConverterStorageFund) Read(reader io.Reader) StorageFund {
+	return StorageFund {
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterStorageFund) Lower(value StorageFund) C.RustBuffer {
+	return LowerIntoRustBuffer[StorageFund](c, value)
+}
+
+func (c FfiConverterStorageFund) Write(writer io.Writer, value StorageFund) {
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.TotalObjectStorageRebates);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.NonRefundableBalance);
+}
+
+type FfiDestroyerStorageFund struct {}
+
+func (_ FfiDestroyerStorageFund) Destroy(value StorageFund) {
+	value.Destroy()
+}
+// Details of the system that are decided during genesis.
+type SystemParameters struct {
+	// Target duration of an epoch, in milliseconds.
+	DurationMs *string
+	// The minimum number of active validators that the system supports.
+	MinValidatorCount *int32
+	// The maximum number of active validators that the system supports.
+	MaxValidatorCount *int32
+	// Minimum stake needed to become a new validator.
+	MinValidatorJoiningStake *string
+	// Validators with stake below this threshold will enter the grace period
+	// (see `validator_low_stake_grace_period`), after which they are removed
+	// from the active validator set.
+	ValidatorLowStakeThreshold *string
+	// Validators with stake below this threshold will be removed from the
+	// active validator set at the next epoch boundary, without a grace period.
+	ValidatorVeryLowStakeThreshold *string
+	// The number of epochs that a validator has to recover from having less
+	// than `validator_low_stake_threshold` stake.
+	ValidatorLowStakeGracePeriod *string
+}
+
+func (r *SystemParameters) Destroy() {
+		FfiDestroyerOptionalString{}.Destroy(r.DurationMs);
+		FfiDestroyerOptionalInt32{}.Destroy(r.MinValidatorCount);
+		FfiDestroyerOptionalInt32{}.Destroy(r.MaxValidatorCount);
+		FfiDestroyerOptionalString{}.Destroy(r.MinValidatorJoiningStake);
+		FfiDestroyerOptionalString{}.Destroy(r.ValidatorLowStakeThreshold);
+		FfiDestroyerOptionalString{}.Destroy(r.ValidatorVeryLowStakeThreshold);
+		FfiDestroyerOptionalString{}.Destroy(r.ValidatorLowStakeGracePeriod);
+}
+
+type FfiConverterSystemParameters struct {}
+
+var FfiConverterSystemParametersINSTANCE = FfiConverterSystemParameters{}
+
+func (c FfiConverterSystemParameters) Lift(rb RustBufferI) SystemParameters {
+	return LiftFromRustBuffer[SystemParameters](c, rb)
+}
+
+func (c FfiConverterSystemParameters) Read(reader io.Reader) SystemParameters {
+	return SystemParameters {
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalInt32INSTANCE.Read(reader),
+			FfiConverterOptionalInt32INSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+			FfiConverterOptionalStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterSystemParameters) Lower(value SystemParameters) C.RustBuffer {
+	return LowerIntoRustBuffer[SystemParameters](c, value)
+}
+
+func (c FfiConverterSystemParameters) Write(writer io.Writer, value SystemParameters) {
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.DurationMs);
+		FfiConverterOptionalInt32INSTANCE.Write(writer, value.MinValidatorCount);
+		FfiConverterOptionalInt32INSTANCE.Write(writer, value.MaxValidatorCount);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.MinValidatorJoiningStake);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.ValidatorLowStakeThreshold);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.ValidatorVeryLowStakeThreshold);
+		FfiConverterOptionalStringINSTANCE.Write(writer, value.ValidatorLowStakeGracePeriod);
+}
+
+type FfiDestroyerSystemParameters struct {}
+
+func (_ FfiDestroyerSystemParameters) Destroy(value SystemParameters) {
 	value.Destroy()
 }
 type TransactionDataEffects struct {
@@ -33086,6 +33344,10 @@ func (_ FfiDestroyerValidatorPage) Destroy(value ValidatorPage) {
 	value.Destroy()
 }
 type ValidatorSet struct {
+	// The current set of active validators.
+	ActiveValidators ValidatorConnection
+	// The current set of committee members.
+	CommitteeMembers ValidatorConnection
 	// Object ID of the `Table` storing the inactive staking pools.
 	InactivePoolsId **ObjectId
 	// Size of the inactive pools `Table`.
@@ -33115,6 +33377,8 @@ type ValidatorSet struct {
 }
 
 func (r *ValidatorSet) Destroy() {
+		FfiDestroyerValidatorConnection{}.Destroy(r.ActiveValidators);
+		FfiDestroyerValidatorConnection{}.Destroy(r.CommitteeMembers);
 		FfiDestroyerOptionalObjectId{}.Destroy(r.InactivePoolsId);
 		FfiDestroyerOptionalInt32{}.Destroy(r.InactivePoolsSize);
 		FfiDestroyerOptionalObjectId{}.Destroy(r.PendingActiveValidatorsId);
@@ -33137,6 +33401,8 @@ func (c FfiConverterValidatorSet) Lift(rb RustBufferI) ValidatorSet {
 
 func (c FfiConverterValidatorSet) Read(reader io.Reader) ValidatorSet {
 	return ValidatorSet {
+			FfiConverterValidatorConnectionINSTANCE.Read(reader),
+			FfiConverterValidatorConnectionINSTANCE.Read(reader),
 			FfiConverterOptionalObjectIdINSTANCE.Read(reader),
 			FfiConverterOptionalInt32INSTANCE.Read(reader),
 			FfiConverterOptionalObjectIdINSTANCE.Read(reader),
@@ -33155,6 +33421,8 @@ func (c FfiConverterValidatorSet) Lower(value ValidatorSet) C.RustBuffer {
 }
 
 func (c FfiConverterValidatorSet) Write(writer io.Writer, value ValidatorSet) {
+		FfiConverterValidatorConnectionINSTANCE.Write(writer, value.ActiveValidators);
+		FfiConverterValidatorConnectionINSTANCE.Write(writer, value.CommitteeMembers);
 		FfiConverterOptionalObjectIdINSTANCE.Write(writer, value.InactivePoolsId);
 		FfiConverterOptionalInt32INSTANCE.Write(writer, value.InactivePoolsSize);
 		FfiConverterOptionalObjectIdINSTANCE.Write(writer, value.PendingActiveValidatorsId);
@@ -35482,6 +35750,43 @@ func (_ FfiDestroyerOptionalUint64) Destroy(value *uint64) {
 	}
 }
 
+type FfiConverterOptionalBool struct{}
+
+var FfiConverterOptionalBoolINSTANCE = FfiConverterOptionalBool{}
+
+func (c FfiConverterOptionalBool) Lift(rb RustBufferI) *bool {
+	return LiftFromRustBuffer[*bool](c, rb)
+}
+
+func (_ FfiConverterOptionalBool) Read(reader io.Reader) *bool {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterBoolINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalBool) Lower(value *bool) C.RustBuffer {
+	return LowerIntoRustBuffer[*bool](c, value)
+}
+
+func (_ FfiConverterOptionalBool) Write(writer io.Writer, value *bool) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterBoolINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalBool struct {}
+
+func (_ FfiDestroyerOptionalBool) Destroy(value *bool) {
+	if value != nil {
+		FfiDestroyerBool{}.Destroy(*value)
+	}
+}
+
 type FfiConverterOptionalString struct{}
 
 var FfiConverterOptionalStringINSTANCE = FfiConverterOptionalString{}
@@ -36851,6 +37156,43 @@ func (_ FfiDestroyerOptionalFaucetReceipt) Destroy(value *FaucetReceipt) {
 	}
 }
 
+type FfiConverterOptionalGraphQlGasCostSummary struct{}
+
+var FfiConverterOptionalGraphQlGasCostSummaryINSTANCE = FfiConverterOptionalGraphQlGasCostSummary{}
+
+func (c FfiConverterOptionalGraphQlGasCostSummary) Lift(rb RustBufferI) *GraphQlGasCostSummary {
+	return LiftFromRustBuffer[*GraphQlGasCostSummary](c, rb)
+}
+
+func (_ FfiConverterOptionalGraphQlGasCostSummary) Read(reader io.Reader) *GraphQlGasCostSummary {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGraphQlGasCostSummaryINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGraphQlGasCostSummary) Lower(value *GraphQlGasCostSummary) C.RustBuffer {
+	return LowerIntoRustBuffer[*GraphQlGasCostSummary](c, value)
+}
+
+func (_ FfiConverterOptionalGraphQlGasCostSummary) Write(writer io.Writer, value *GraphQlGasCostSummary) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGraphQlGasCostSummaryINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGraphQlGasCostSummary struct {}
+
+func (_ FfiDestroyerOptionalGraphQlGasCostSummary) Destroy(value *GraphQlGasCostSummary) {
+	if value != nil {
+		FfiDestroyerGraphQlGasCostSummary{}.Destroy(*value)
+	}
+}
+
 type FfiConverterOptionalMoveEnumConnection struct{}
 
 var FfiConverterOptionalMoveEnumConnectionINSTANCE = FfiConverterOptionalMoveEnumConnection{}
@@ -37221,6 +37563,43 @@ func (_ FfiDestroyerOptionalProtocolConfigs) Destroy(value *ProtocolConfigs) {
 	}
 }
 
+type FfiConverterOptionalSafeMode struct{}
+
+var FfiConverterOptionalSafeModeINSTANCE = FfiConverterOptionalSafeMode{}
+
+func (c FfiConverterOptionalSafeMode) Lift(rb RustBufferI) *SafeMode {
+	return LiftFromRustBuffer[*SafeMode](c, rb)
+}
+
+func (_ FfiConverterOptionalSafeMode) Read(reader io.Reader) *SafeMode {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterSafeModeINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalSafeMode) Lower(value *SafeMode) C.RustBuffer {
+	return LowerIntoRustBuffer[*SafeMode](c, value)
+}
+
+func (_ FfiConverterOptionalSafeMode) Write(writer io.Writer, value *SafeMode) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterSafeModeINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalSafeMode struct {}
+
+func (_ FfiDestroyerOptionalSafeMode) Destroy(value *SafeMode) {
+	if value != nil {
+		FfiDestroyerSafeMode{}.Destroy(*value)
+	}
+}
+
 type FfiConverterOptionalSignedTransaction struct{}
 
 var FfiConverterOptionalSignedTransactionINSTANCE = FfiConverterOptionalSignedTransaction{}
@@ -37255,6 +37634,80 @@ type FfiDestroyerOptionalSignedTransaction struct {}
 func (_ FfiDestroyerOptionalSignedTransaction) Destroy(value *SignedTransaction) {
 	if value != nil {
 		FfiDestroyerSignedTransaction{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalStorageFund struct{}
+
+var FfiConverterOptionalStorageFundINSTANCE = FfiConverterOptionalStorageFund{}
+
+func (c FfiConverterOptionalStorageFund) Lift(rb RustBufferI) *StorageFund {
+	return LiftFromRustBuffer[*StorageFund](c, rb)
+}
+
+func (_ FfiConverterOptionalStorageFund) Read(reader io.Reader) *StorageFund {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterStorageFundINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalStorageFund) Lower(value *StorageFund) C.RustBuffer {
+	return LowerIntoRustBuffer[*StorageFund](c, value)
+}
+
+func (_ FfiConverterOptionalStorageFund) Write(writer io.Writer, value *StorageFund) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterStorageFundINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalStorageFund struct {}
+
+func (_ FfiDestroyerOptionalStorageFund) Destroy(value *StorageFund) {
+	if value != nil {
+		FfiDestroyerStorageFund{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalSystemParameters struct{}
+
+var FfiConverterOptionalSystemParametersINSTANCE = FfiConverterOptionalSystemParameters{}
+
+func (c FfiConverterOptionalSystemParameters) Lift(rb RustBufferI) *SystemParameters {
+	return LiftFromRustBuffer[*SystemParameters](c, rb)
+}
+
+func (_ FfiConverterOptionalSystemParameters) Read(reader io.Reader) *SystemParameters {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterSystemParametersINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalSystemParameters) Lower(value *SystemParameters) C.RustBuffer {
+	return LowerIntoRustBuffer[*SystemParameters](c, value)
+}
+
+func (_ FfiConverterOptionalSystemParameters) Write(writer io.Writer, value *SystemParameters) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterSystemParametersINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalSystemParameters struct {}
+
+func (_ FfiDestroyerOptionalSystemParameters) Destroy(value *SystemParameters) {
+	if value != nil {
+		FfiDestroyerSystemParameters{}.Destroy(*value)
 	}
 }
 

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -54856,14 +54856,6 @@ public object FfiConverterTypeValidatorPage: FfiConverterRustBuffer<ValidatorPag
 
 data class ValidatorSet (
     /**
-     * The current set of active validators.
-     */
-    var `activeValidators`: ValidatorConnection, 
-    /**
-     * The current set of committee members.
-     */
-    var `committeeMembers`: ValidatorConnection, 
-    /**
      * Object ID of the `Table` storing the inactive staking pools.
      */
     var `inactivePoolsId`: ObjectId? = null, 
@@ -54915,8 +54907,6 @@ data class ValidatorSet (
     override fun destroy() {
         
     Disposable.destroy(
-        this.`activeValidators`,
-        this.`committeeMembers`,
         this.`inactivePoolsId`,
         this.`inactivePoolsSize`,
         this.`pendingActiveValidatorsId`,
@@ -54939,8 +54929,6 @@ data class ValidatorSet (
 public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet> {
     override fun read(buf: ByteBuffer): ValidatorSet {
         return ValidatorSet(
-            FfiConverterTypeValidatorConnection.read(buf),
-            FfiConverterTypeValidatorConnection.read(buf),
             FfiConverterOptionalTypeObjectId.read(buf),
             FfiConverterOptionalInt.read(buf),
             FfiConverterOptionalTypeObjectId.read(buf),
@@ -54955,8 +54943,6 @@ public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet>
     }
 
     override fun allocationSize(value: ValidatorSet) = (
-            FfiConverterTypeValidatorConnection.allocationSize(value.`activeValidators`) +
-            FfiConverterTypeValidatorConnection.allocationSize(value.`committeeMembers`) +
             FfiConverterOptionalTypeObjectId.allocationSize(value.`inactivePoolsId`) +
             FfiConverterOptionalInt.allocationSize(value.`inactivePoolsSize`) +
             FfiConverterOptionalTypeObjectId.allocationSize(value.`pendingActiveValidatorsId`) +
@@ -54970,8 +54956,6 @@ public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet>
     )
 
     override fun write(value: ValidatorSet, buf: ByteBuffer) {
-            FfiConverterTypeValidatorConnection.write(value.`activeValidators`, buf)
-            FfiConverterTypeValidatorConnection.write(value.`committeeMembers`, buf)
             FfiConverterOptionalTypeObjectId.write(value.`inactivePoolsId`, buf)
             FfiConverterOptionalInt.write(value.`inactivePoolsSize`, buf)
             FfiConverterOptionalTypeObjectId.write(value.`pendingActiveValidatorsId`, buf)

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -51108,6 +51108,15 @@ public object FfiConverterTypeEndOfEpochData: FfiConverterRustBuffer<EndOfEpochD
 
 
 
+/**
+ * Operation of the IOTA network is temporally partitioned into non-overlapping
+ * epochs, and the network aims to keep epochs roughly the same duration as
+ * each other. During a particular epoch the following data is fixed:
+ *
+ * - the protocol version
+ * - the reference gas price
+ * - the set of participating validators
+ */
 data class Epoch (
     /**
      * The epoch's id as a sequence number that starts at 0 and is incremented
@@ -51188,7 +51197,29 @@ data class Epoch (
      * For epochs other than the current the data provided refer to the start
      * of the epoch.
      */
-    var `validatorSet`: ValidatorSet? = null
+    var `validatorSet`: ValidatorSet? = null, 
+    /**
+     * IOTA set aside to account for objects stored on-chain, at the start of
+     * the epoch. This is also used for storage rebates.
+     */
+    var `storageFund`: StorageFund? = null, 
+    /**
+     * Information about whether this epoch was started in safe mode, which
+     * happens if the full epoch change logic fails for some reason.
+     */
+    var `safeMode`: SafeMode? = null, 
+    /**
+     * The total IOTA supply.
+     */
+    var `iotaTotalSupply`: kotlin.ULong? = null, 
+    /**
+     * The treasury-cap id.
+     */
+    var `iotaTreasuryCapId`: Address? = null, 
+    /**
+     * Details of the system that are decided during genesis.
+     */
+    var `systemParameters`: SystemParameters? = null
 ) : Disposable {
     
     @Suppress("UNNECESSARY_SAFE_CALL") // codegen is much simpler if we unconditionally emit safe calls here
@@ -51210,7 +51241,12 @@ data class Epoch (
         this.`totalGasFees`,
         this.`totalStakeRewards`,
         this.`totalTransactions`,
-        this.`validatorSet`
+        this.`validatorSet`,
+        this.`storageFund`,
+        this.`safeMode`,
+        this.`iotaTotalSupply`,
+        this.`iotaTreasuryCapId`,
+        this.`systemParameters`
     )
     }
     
@@ -51239,6 +51275,11 @@ public object FfiConverterTypeEpoch: FfiConverterRustBuffer<Epoch> {
             FfiConverterOptionalString.read(buf),
             FfiConverterOptionalULong.read(buf),
             FfiConverterOptionalTypeValidatorSet.read(buf),
+            FfiConverterOptionalTypeStorageFund.read(buf),
+            FfiConverterOptionalTypeSafeMode.read(buf),
+            FfiConverterOptionalULong.read(buf),
+            FfiConverterOptionalTypeAddress.read(buf),
+            FfiConverterOptionalTypeSystemParameters.read(buf),
         )
     }
 
@@ -51258,7 +51299,12 @@ public object FfiConverterTypeEpoch: FfiConverterRustBuffer<Epoch> {
             FfiConverterOptionalString.allocationSize(value.`totalGasFees`) +
             FfiConverterOptionalString.allocationSize(value.`totalStakeRewards`) +
             FfiConverterOptionalULong.allocationSize(value.`totalTransactions`) +
-            FfiConverterOptionalTypeValidatorSet.allocationSize(value.`validatorSet`)
+            FfiConverterOptionalTypeValidatorSet.allocationSize(value.`validatorSet`) +
+            FfiConverterOptionalTypeStorageFund.allocationSize(value.`storageFund`) +
+            FfiConverterOptionalTypeSafeMode.allocationSize(value.`safeMode`) +
+            FfiConverterOptionalULong.allocationSize(value.`iotaTotalSupply`) +
+            FfiConverterOptionalTypeAddress.allocationSize(value.`iotaTreasuryCapId`) +
+            FfiConverterOptionalTypeSystemParameters.allocationSize(value.`systemParameters`)
     )
 
     override fun write(value: Epoch, buf: ByteBuffer) {
@@ -51278,6 +51324,11 @@ public object FfiConverterTypeEpoch: FfiConverterRustBuffer<Epoch> {
             FfiConverterOptionalString.write(value.`totalStakeRewards`, buf)
             FfiConverterOptionalULong.write(value.`totalTransactions`, buf)
             FfiConverterOptionalTypeValidatorSet.write(value.`validatorSet`, buf)
+            FfiConverterOptionalTypeStorageFund.write(value.`storageFund`, buf)
+            FfiConverterOptionalTypeSafeMode.write(value.`safeMode`, buf)
+            FfiConverterOptionalULong.write(value.`iotaTotalSupply`, buf)
+            FfiConverterOptionalTypeAddress.write(value.`iotaTreasuryCapId`, buf)
+            FfiConverterOptionalTypeSystemParameters.write(value.`systemParameters`, buf)
     }
 }
 
@@ -51789,6 +51840,72 @@ public object FfiConverterTypeGasPayment: FfiConverterRustBuffer<GasPayment> {
             FfiConverterTypeAddress.write(value.`owner`, buf)
             FfiConverterULong.write(value.`price`, buf)
             FfiConverterULong.write(value.`budget`, buf)
+    }
+}
+
+
+
+/**
+ * Breakdown of gas costs in effects.
+ */
+data class GraphQlGasCostSummary (
+    /**
+     * Gas paid for executing this transaction (in NANOS).
+     */
+    var `computationCost`: kotlin.String? = null, 
+    /**
+     * Gas burned for executing this transaction (in NANOS).
+     */
+    var `computationCostBurned`: kotlin.String? = null, 
+    /**
+     * Gas paid for the data stored on-chain by this transaction (in NANOS).
+     */
+    var `storageCost`: kotlin.String? = null, 
+    /**
+     * Part of storage cost that can be reclaimed by cleaning up data created
+     * by this transaction (when objects are deleted or an object is
+     * modified, which is treated as a deletion followed by a creation) (in
+     * NANOS).
+     */
+    var `storageRebate`: kotlin.String? = null, 
+    /**
+     * Part of storage cost that is not reclaimed when data created by this
+     * transaction is cleaned up (in NANOS).
+     */
+    var `nonRefundableStorageFee`: kotlin.String? = null
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeGraphQLGasCostSummary: FfiConverterRustBuffer<GraphQlGasCostSummary> {
+    override fun read(buf: ByteBuffer): GraphQlGasCostSummary {
+        return GraphQlGasCostSummary(
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: GraphQlGasCostSummary) = (
+            FfiConverterOptionalString.allocationSize(value.`computationCost`) +
+            FfiConverterOptionalString.allocationSize(value.`computationCostBurned`) +
+            FfiConverterOptionalString.allocationSize(value.`storageCost`) +
+            FfiConverterOptionalString.allocationSize(value.`storageRebate`) +
+            FfiConverterOptionalString.allocationSize(value.`nonRefundableStorageFee`)
+    )
+
+    override fun write(value: GraphQlGasCostSummary, buf: ByteBuffer) {
+            FfiConverterOptionalString.write(value.`computationCost`, buf)
+            FfiConverterOptionalString.write(value.`computationCostBurned`, buf)
+            FfiConverterOptionalString.write(value.`storageCost`, buf)
+            FfiConverterOptionalString.write(value.`storageRebate`, buf)
+            FfiConverterOptionalString.write(value.`nonRefundableStorageFee`, buf)
     }
 }
 
@@ -53248,6 +53365,50 @@ public object FfiConverterTypeRandomnessStateUpdate: FfiConverterRustBuffer<Rand
 
 
 
+/**
+ * Information about whether epoch changes are using safe mode.
+ */
+data class SafeMode (
+    /**
+     * Whether safe mode was used for the last epoch change. The system will
+     * retry a full epoch change on every epoch boundary and automatically
+     * reset this flag if so.
+     */
+    var `enabled`: kotlin.Boolean? = null, 
+    /**
+     * Accumulated fees for computation and cost that have not been added to
+     * the various reward pools, because the full epoch change did not happen.
+     */
+    var `gasSummary`: GraphQlGasCostSummary? = null
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSafeMode: FfiConverterRustBuffer<SafeMode> {
+    override fun read(buf: ByteBuffer): SafeMode {
+        return SafeMode(
+            FfiConverterOptionalBoolean.read(buf),
+            FfiConverterOptionalTypeGraphQLGasCostSummary.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: SafeMode) = (
+            FfiConverterOptionalBoolean.allocationSize(value.`enabled`) +
+            FfiConverterOptionalTypeGraphQLGasCostSummary.allocationSize(value.`gasSummary`)
+    )
+
+    override fun write(value: SafeMode, buf: ByteBuffer) {
+            FfiConverterOptionalBoolean.write(value.`enabled`, buf)
+            FfiConverterOptionalTypeGraphQLGasCostSummary.write(value.`gasSummary`, buf)
+    }
+}
+
+
+
 data class ServiceConfig (
     /**
      * Default number of elements allowed on a single page of a connection.
@@ -53472,6 +53633,132 @@ public object FfiConverterTypeSignedTransactionPage: FfiConverterRustBuffer<Sign
     override fun write(value: SignedTransactionPage, buf: ByteBuffer) {
             FfiConverterTypePageInfo.write(value.`pageInfo`, buf)
             FfiConverterSequenceTypeSignedTransaction.write(value.`data`, buf)
+    }
+}
+
+
+
+/**
+ * IOTA set aside to account for objects stored on-chain.
+ */
+data class StorageFund (
+    /**
+     * Sum of storage rebates of live objects on chain.
+     */
+    var `totalObjectStorageRebates`: kotlin.String? = null, 
+    /**
+     * The portion of the storage fund that will never be refunded through
+     * storage rebates.
+     * The system maintains an invariant that the sum of
+     * all storage fees into the storage fund is equal to the sum of of all
+     * storage rebates out, the total storage rebates remaining, and the
+     * non-refundable balance.
+     */
+    var `nonRefundableBalance`: kotlin.String? = null
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeStorageFund: FfiConverterRustBuffer<StorageFund> {
+    override fun read(buf: ByteBuffer): StorageFund {
+        return StorageFund(
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: StorageFund) = (
+            FfiConverterOptionalString.allocationSize(value.`totalObjectStorageRebates`) +
+            FfiConverterOptionalString.allocationSize(value.`nonRefundableBalance`)
+    )
+
+    override fun write(value: StorageFund, buf: ByteBuffer) {
+            FfiConverterOptionalString.write(value.`totalObjectStorageRebates`, buf)
+            FfiConverterOptionalString.write(value.`nonRefundableBalance`, buf)
+    }
+}
+
+
+
+/**
+ * Details of the system that are decided during genesis.
+ */
+data class SystemParameters (
+    /**
+     * Target duration of an epoch, in milliseconds.
+     */
+    var `durationMs`: kotlin.String? = null, 
+    /**
+     * The minimum number of active validators that the system supports.
+     */
+    var `minValidatorCount`: kotlin.Int? = null, 
+    /**
+     * The maximum number of active validators that the system supports.
+     */
+    var `maxValidatorCount`: kotlin.Int? = null, 
+    /**
+     * Minimum stake needed to become a new validator.
+     */
+    var `minValidatorJoiningStake`: kotlin.String? = null, 
+    /**
+     * Validators with stake below this threshold will enter the grace period
+     * (see `validator_low_stake_grace_period`), after which they are removed
+     * from the active validator set.
+     */
+    var `validatorLowStakeThreshold`: kotlin.String? = null, 
+    /**
+     * Validators with stake below this threshold will be removed from the
+     * active validator set at the next epoch boundary, without a grace period.
+     */
+    var `validatorVeryLowStakeThreshold`: kotlin.String? = null, 
+    /**
+     * The number of epochs that a validator has to recover from having less
+     * than `validator_low_stake_threshold` stake.
+     */
+    var `validatorLowStakeGracePeriod`: kotlin.String? = null
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSystemParameters: FfiConverterRustBuffer<SystemParameters> {
+    override fun read(buf: ByteBuffer): SystemParameters {
+        return SystemParameters(
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalInt.read(buf),
+            FfiConverterOptionalInt.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+            FfiConverterOptionalString.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: SystemParameters) = (
+            FfiConverterOptionalString.allocationSize(value.`durationMs`) +
+            FfiConverterOptionalInt.allocationSize(value.`minValidatorCount`) +
+            FfiConverterOptionalInt.allocationSize(value.`maxValidatorCount`) +
+            FfiConverterOptionalString.allocationSize(value.`minValidatorJoiningStake`) +
+            FfiConverterOptionalString.allocationSize(value.`validatorLowStakeThreshold`) +
+            FfiConverterOptionalString.allocationSize(value.`validatorVeryLowStakeThreshold`) +
+            FfiConverterOptionalString.allocationSize(value.`validatorLowStakeGracePeriod`)
+    )
+
+    override fun write(value: SystemParameters, buf: ByteBuffer) {
+            FfiConverterOptionalString.write(value.`durationMs`, buf)
+            FfiConverterOptionalInt.write(value.`minValidatorCount`, buf)
+            FfiConverterOptionalInt.write(value.`maxValidatorCount`, buf)
+            FfiConverterOptionalString.write(value.`minValidatorJoiningStake`, buf)
+            FfiConverterOptionalString.write(value.`validatorLowStakeThreshold`, buf)
+            FfiConverterOptionalString.write(value.`validatorVeryLowStakeThreshold`, buf)
+            FfiConverterOptionalString.write(value.`validatorLowStakeGracePeriod`, buf)
     }
 }
 
@@ -54569,6 +54856,14 @@ public object FfiConverterTypeValidatorPage: FfiConverterRustBuffer<ValidatorPag
 
 data class ValidatorSet (
     /**
+     * The current set of active validators.
+     */
+    var `activeValidators`: ValidatorConnection, 
+    /**
+     * The current set of committee members.
+     */
+    var `committeeMembers`: ValidatorConnection, 
+    /**
      * Object ID of the `Table` storing the inactive staking pools.
      */
     var `inactivePoolsId`: ObjectId? = null, 
@@ -54620,6 +54915,8 @@ data class ValidatorSet (
     override fun destroy() {
         
     Disposable.destroy(
+        this.`activeValidators`,
+        this.`committeeMembers`,
         this.`inactivePoolsId`,
         this.`inactivePoolsSize`,
         this.`pendingActiveValidatorsId`,
@@ -54642,6 +54939,8 @@ data class ValidatorSet (
 public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet> {
     override fun read(buf: ByteBuffer): ValidatorSet {
         return ValidatorSet(
+            FfiConverterTypeValidatorConnection.read(buf),
+            FfiConverterTypeValidatorConnection.read(buf),
             FfiConverterOptionalTypeObjectId.read(buf),
             FfiConverterOptionalInt.read(buf),
             FfiConverterOptionalTypeObjectId.read(buf),
@@ -54656,6 +54955,8 @@ public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet>
     }
 
     override fun allocationSize(value: ValidatorSet) = (
+            FfiConverterTypeValidatorConnection.allocationSize(value.`activeValidators`) +
+            FfiConverterTypeValidatorConnection.allocationSize(value.`committeeMembers`) +
             FfiConverterOptionalTypeObjectId.allocationSize(value.`inactivePoolsId`) +
             FfiConverterOptionalInt.allocationSize(value.`inactivePoolsSize`) +
             FfiConverterOptionalTypeObjectId.allocationSize(value.`pendingActiveValidatorsId`) +
@@ -54669,6 +54970,8 @@ public object FfiConverterTypeValidatorSet: FfiConverterRustBuffer<ValidatorSet>
     )
 
     override fun write(value: ValidatorSet, buf: ByteBuffer) {
+            FfiConverterTypeValidatorConnection.write(value.`activeValidators`, buf)
+            FfiConverterTypeValidatorConnection.write(value.`committeeMembers`, buf)
             FfiConverterOptionalTypeObjectId.write(value.`inactivePoolsId`, buf)
             FfiConverterOptionalInt.write(value.`inactivePoolsSize`, buf)
             FfiConverterOptionalTypeObjectId.write(value.`pendingActiveValidatorsId`, buf)
@@ -57709,6 +58012,38 @@ public object FfiConverterOptionalULong: FfiConverterRustBuffer<kotlin.ULong?> {
 /**
  * @suppress
  */
+public object FfiConverterOptionalBoolean: FfiConverterRustBuffer<kotlin.Boolean?> {
+    override fun read(buf: ByteBuffer): kotlin.Boolean? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterBoolean.read(buf)
+    }
+
+    override fun allocationSize(value: kotlin.Boolean?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterBoolean.allocationSize(value)
+        }
+    }
+
+    override fun write(value: kotlin.Boolean?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterBoolean.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalString: FfiConverterRustBuffer<kotlin.String?> {
     override fun read(buf: ByteBuffer): kotlin.String? {
         if (buf.get().toInt() == 0) {
@@ -58893,6 +59228,38 @@ public object FfiConverterOptionalTypeFaucetReceipt: FfiConverterRustBuffer<Fauc
 /**
  * @suppress
  */
+public object FfiConverterOptionalTypeGraphQLGasCostSummary: FfiConverterRustBuffer<GraphQlGasCostSummary?> {
+    override fun read(buf: ByteBuffer): GraphQlGasCostSummary? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeGraphQLGasCostSummary.read(buf)
+    }
+
+    override fun allocationSize(value: GraphQlGasCostSummary?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeGraphQLGasCostSummary.allocationSize(value)
+        }
+    }
+
+    override fun write(value: GraphQlGasCostSummary?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeGraphQLGasCostSummary.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalTypeMoveEnumConnection: FfiConverterRustBuffer<MoveEnumConnection?> {
     override fun read(buf: ByteBuffer): MoveEnumConnection? {
         if (buf.get().toInt() == 0) {
@@ -59213,6 +59580,38 @@ public object FfiConverterOptionalTypeProtocolConfigs: FfiConverterRustBuffer<Pr
 /**
  * @suppress
  */
+public object FfiConverterOptionalTypeSafeMode: FfiConverterRustBuffer<SafeMode?> {
+    override fun read(buf: ByteBuffer): SafeMode? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSafeMode.read(buf)
+    }
+
+    override fun allocationSize(value: SafeMode?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSafeMode.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SafeMode?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSafeMode.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalTypeSignedTransaction: FfiConverterRustBuffer<SignedTransaction?> {
     override fun read(buf: ByteBuffer): SignedTransaction? {
         if (buf.get().toInt() == 0) {
@@ -59235,6 +59634,70 @@ public object FfiConverterOptionalTypeSignedTransaction: FfiConverterRustBuffer<
         } else {
             buf.put(1)
             FfiConverterTypeSignedTransaction.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeStorageFund: FfiConverterRustBuffer<StorageFund?> {
+    override fun read(buf: ByteBuffer): StorageFund? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeStorageFund.read(buf)
+    }
+
+    override fun allocationSize(value: StorageFund?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeStorageFund.allocationSize(value)
+        }
+    }
+
+    override fun write(value: StorageFund?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeStorageFund.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeSystemParameters: FfiConverterRustBuffer<SystemParameters?> {
+    override fun read(buf: ByteBuffer): SystemParameters? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeSystemParameters.read(buf)
+    }
+
+    override fun allocationSize(value: SystemParameters?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeSystemParameters.allocationSize(value)
+        }
+    }
+
+    override fun write(value: SystemParameters?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeSystemParameters.write(value, buf)
         }
     }
 }

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -14029,6 +14029,16 @@ class _UniffiConverterTypeEndOfEpochData(_UniffiConverterRustBuffer):
 
 
 class Epoch:
+    """
+    Operation of the IOTA network is temporally partitioned into non-overlapping
+    epochs, and the network aims to keep epochs roughly the same duration as
+    each other. During a particular epoch the following data is fixed:
+
+    - the protocol version
+    - the reference gas price
+    - the set of participating validators
+    """
+
     epoch_id: "int"
     """
     The epoch's id as a sequence number that starts at 0 and is incremented
@@ -14125,7 +14135,34 @@ class Epoch:
     of the epoch.
     """
 
-    def __init__(self, *, epoch_id: "int", fund_inflow: "typing.Optional[str]" = _DEFAULT, fund_outflow: "typing.Optional[str]" = _DEFAULT, fund_size: "typing.Optional[str]" = _DEFAULT, live_object_set_digest: "typing.Optional[str]" = _DEFAULT, net_inflow: "typing.Optional[str]" = _DEFAULT, protocol_configs: "typing.Optional[ProtocolConfigs]" = _DEFAULT, reference_gas_price: "typing.Optional[str]" = _DEFAULT, start_timestamp: "int", end_timestamp: "typing.Optional[int]" = _DEFAULT, system_state_version: "typing.Optional[int]" = _DEFAULT, total_checkpoints: "typing.Optional[int]" = _DEFAULT, total_gas_fees: "typing.Optional[str]" = _DEFAULT, total_stake_rewards: "typing.Optional[str]" = _DEFAULT, total_transactions: "typing.Optional[int]" = _DEFAULT, validator_set: "typing.Optional[ValidatorSet]" = _DEFAULT):
+    storage_fund: "typing.Optional[StorageFund]"
+    """
+    IOTA set aside to account for objects stored on-chain, at the start of
+    the epoch. This is also used for storage rebates.
+    """
+
+    safe_mode: "typing.Optional[SafeMode]"
+    """
+    Information about whether this epoch was started in safe mode, which
+    happens if the full epoch change logic fails for some reason.
+    """
+
+    iota_total_supply: "typing.Optional[int]"
+    """
+    The total IOTA supply.
+    """
+
+    iota_treasury_cap_id: "typing.Optional[Address]"
+    """
+    The treasury-cap id.
+    """
+
+    system_parameters: "typing.Optional[SystemParameters]"
+    """
+    Details of the system that are decided during genesis.
+    """
+
+    def __init__(self, *, epoch_id: "int", fund_inflow: "typing.Optional[str]" = _DEFAULT, fund_outflow: "typing.Optional[str]" = _DEFAULT, fund_size: "typing.Optional[str]" = _DEFAULT, live_object_set_digest: "typing.Optional[str]" = _DEFAULT, net_inflow: "typing.Optional[str]" = _DEFAULT, protocol_configs: "typing.Optional[ProtocolConfigs]" = _DEFAULT, reference_gas_price: "typing.Optional[str]" = _DEFAULT, start_timestamp: "int", end_timestamp: "typing.Optional[int]" = _DEFAULT, system_state_version: "typing.Optional[int]" = _DEFAULT, total_checkpoints: "typing.Optional[int]" = _DEFAULT, total_gas_fees: "typing.Optional[str]" = _DEFAULT, total_stake_rewards: "typing.Optional[str]" = _DEFAULT, total_transactions: "typing.Optional[int]" = _DEFAULT, validator_set: "typing.Optional[ValidatorSet]" = _DEFAULT, storage_fund: "typing.Optional[StorageFund]" = _DEFAULT, safe_mode: "typing.Optional[SafeMode]" = _DEFAULT, iota_total_supply: "typing.Optional[int]" = _DEFAULT, iota_treasury_cap_id: "typing.Optional[Address]" = _DEFAULT, system_parameters: "typing.Optional[SystemParameters]" = _DEFAULT):
         self.epoch_id = epoch_id
         if fund_inflow is _DEFAULT:
             self.fund_inflow = None
@@ -14184,9 +14221,29 @@ class Epoch:
             self.validator_set = None
         else:
             self.validator_set = validator_set
+        if storage_fund is _DEFAULT:
+            self.storage_fund = None
+        else:
+            self.storage_fund = storage_fund
+        if safe_mode is _DEFAULT:
+            self.safe_mode = None
+        else:
+            self.safe_mode = safe_mode
+        if iota_total_supply is _DEFAULT:
+            self.iota_total_supply = None
+        else:
+            self.iota_total_supply = iota_total_supply
+        if iota_treasury_cap_id is _DEFAULT:
+            self.iota_treasury_cap_id = None
+        else:
+            self.iota_treasury_cap_id = iota_treasury_cap_id
+        if system_parameters is _DEFAULT:
+            self.system_parameters = None
+        else:
+            self.system_parameters = system_parameters
 
     def __str__(self):
-        return "Epoch(epoch_id={}, fund_inflow={}, fund_outflow={}, fund_size={}, live_object_set_digest={}, net_inflow={}, protocol_configs={}, reference_gas_price={}, start_timestamp={}, end_timestamp={}, system_state_version={}, total_checkpoints={}, total_gas_fees={}, total_stake_rewards={}, total_transactions={}, validator_set={})".format(self.epoch_id, self.fund_inflow, self.fund_outflow, self.fund_size, self.live_object_set_digest, self.net_inflow, self.protocol_configs, self.reference_gas_price, self.start_timestamp, self.end_timestamp, self.system_state_version, self.total_checkpoints, self.total_gas_fees, self.total_stake_rewards, self.total_transactions, self.validator_set)
+        return "Epoch(epoch_id={}, fund_inflow={}, fund_outflow={}, fund_size={}, live_object_set_digest={}, net_inflow={}, protocol_configs={}, reference_gas_price={}, start_timestamp={}, end_timestamp={}, system_state_version={}, total_checkpoints={}, total_gas_fees={}, total_stake_rewards={}, total_transactions={}, validator_set={}, storage_fund={}, safe_mode={}, iota_total_supply={}, iota_treasury_cap_id={}, system_parameters={})".format(self.epoch_id, self.fund_inflow, self.fund_outflow, self.fund_size, self.live_object_set_digest, self.net_inflow, self.protocol_configs, self.reference_gas_price, self.start_timestamp, self.end_timestamp, self.system_state_version, self.total_checkpoints, self.total_gas_fees, self.total_stake_rewards, self.total_transactions, self.validator_set, self.storage_fund, self.safe_mode, self.iota_total_supply, self.iota_treasury_cap_id, self.system_parameters)
 
     def __eq__(self, other):
         if self.epoch_id != other.epoch_id:
@@ -14221,6 +14278,16 @@ class Epoch:
             return False
         if self.validator_set != other.validator_set:
             return False
+        if self.storage_fund != other.storage_fund:
+            return False
+        if self.safe_mode != other.safe_mode:
+            return False
+        if self.iota_total_supply != other.iota_total_supply:
+            return False
+        if self.iota_treasury_cap_id != other.iota_treasury_cap_id:
+            return False
+        if self.system_parameters != other.system_parameters:
+            return False
         return True
 
 class _UniffiConverterTypeEpoch(_UniffiConverterRustBuffer):
@@ -14243,6 +14310,11 @@ class _UniffiConverterTypeEpoch(_UniffiConverterRustBuffer):
             total_stake_rewards=_UniffiConverterOptionalString.read(buf),
             total_transactions=_UniffiConverterOptionalUInt64.read(buf),
             validator_set=_UniffiConverterOptionalTypeValidatorSet.read(buf),
+            storage_fund=_UniffiConverterOptionalTypeStorageFund.read(buf),
+            safe_mode=_UniffiConverterOptionalTypeSafeMode.read(buf),
+            iota_total_supply=_UniffiConverterOptionalUInt64.read(buf),
+            iota_treasury_cap_id=_UniffiConverterOptionalTypeAddress.read(buf),
+            system_parameters=_UniffiConverterOptionalTypeSystemParameters.read(buf),
         )
 
     @staticmethod
@@ -14263,6 +14335,11 @@ class _UniffiConverterTypeEpoch(_UniffiConverterRustBuffer):
         _UniffiConverterOptionalString.check_lower(value.total_stake_rewards)
         _UniffiConverterOptionalUInt64.check_lower(value.total_transactions)
         _UniffiConverterOptionalTypeValidatorSet.check_lower(value.validator_set)
+        _UniffiConverterOptionalTypeStorageFund.check_lower(value.storage_fund)
+        _UniffiConverterOptionalTypeSafeMode.check_lower(value.safe_mode)
+        _UniffiConverterOptionalUInt64.check_lower(value.iota_total_supply)
+        _UniffiConverterOptionalTypeAddress.check_lower(value.iota_treasury_cap_id)
+        _UniffiConverterOptionalTypeSystemParameters.check_lower(value.system_parameters)
 
     @staticmethod
     def write(value, buf):
@@ -14282,6 +14359,11 @@ class _UniffiConverterTypeEpoch(_UniffiConverterRustBuffer):
         _UniffiConverterOptionalString.write(value.total_stake_rewards, buf)
         _UniffiConverterOptionalUInt64.write(value.total_transactions, buf)
         _UniffiConverterOptionalTypeValidatorSet.write(value.validator_set, buf)
+        _UniffiConverterOptionalTypeStorageFund.write(value.storage_fund, buf)
+        _UniffiConverterOptionalTypeSafeMode.write(value.safe_mode, buf)
+        _UniffiConverterOptionalUInt64.write(value.iota_total_supply, buf)
+        _UniffiConverterOptionalTypeAddress.write(value.iota_treasury_cap_id, buf)
+        _UniffiConverterOptionalTypeSystemParameters.write(value.system_parameters, buf)
 
 
 class EpochPage:
@@ -14824,6 +14906,106 @@ class _UniffiConverterTypeGqlAddress(_UniffiConverterRustBuffer):
     @staticmethod
     def write(value, buf):
         _UniffiConverterTypeAddress.write(value.address, buf)
+
+
+class GraphQlGasCostSummary:
+    """
+    Breakdown of gas costs in effects.
+    """
+
+    computation_cost: "typing.Optional[str]"
+    """
+    Gas paid for executing this transaction (in NANOS).
+    """
+
+    computation_cost_burned: "typing.Optional[str]"
+    """
+    Gas burned for executing this transaction (in NANOS).
+    """
+
+    storage_cost: "typing.Optional[str]"
+    """
+    Gas paid for the data stored on-chain by this transaction (in NANOS).
+    """
+
+    storage_rebate: "typing.Optional[str]"
+    """
+    Part of storage cost that can be reclaimed by cleaning up data created
+    by this transaction (when objects are deleted or an object is
+    modified, which is treated as a deletion followed by a creation) (in
+    NANOS).
+    """
+
+    non_refundable_storage_fee: "typing.Optional[str]"
+    """
+    Part of storage cost that is not reclaimed when data created by this
+    transaction is cleaned up (in NANOS).
+    """
+
+    def __init__(self, *, computation_cost: "typing.Optional[str]" = _DEFAULT, computation_cost_burned: "typing.Optional[str]" = _DEFAULT, storage_cost: "typing.Optional[str]" = _DEFAULT, storage_rebate: "typing.Optional[str]" = _DEFAULT, non_refundable_storage_fee: "typing.Optional[str]" = _DEFAULT):
+        if computation_cost is _DEFAULT:
+            self.computation_cost = None
+        else:
+            self.computation_cost = computation_cost
+        if computation_cost_burned is _DEFAULT:
+            self.computation_cost_burned = None
+        else:
+            self.computation_cost_burned = computation_cost_burned
+        if storage_cost is _DEFAULT:
+            self.storage_cost = None
+        else:
+            self.storage_cost = storage_cost
+        if storage_rebate is _DEFAULT:
+            self.storage_rebate = None
+        else:
+            self.storage_rebate = storage_rebate
+        if non_refundable_storage_fee is _DEFAULT:
+            self.non_refundable_storage_fee = None
+        else:
+            self.non_refundable_storage_fee = non_refundable_storage_fee
+
+    def __str__(self):
+        return "GraphQlGasCostSummary(computation_cost={}, computation_cost_burned={}, storage_cost={}, storage_rebate={}, non_refundable_storage_fee={})".format(self.computation_cost, self.computation_cost_burned, self.storage_cost, self.storage_rebate, self.non_refundable_storage_fee)
+
+    def __eq__(self, other):
+        if self.computation_cost != other.computation_cost:
+            return False
+        if self.computation_cost_burned != other.computation_cost_burned:
+            return False
+        if self.storage_cost != other.storage_cost:
+            return False
+        if self.storage_rebate != other.storage_rebate:
+            return False
+        if self.non_refundable_storage_fee != other.non_refundable_storage_fee:
+            return False
+        return True
+
+class _UniffiConverterTypeGraphQlGasCostSummary(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return GraphQlGasCostSummary(
+            computation_cost=_UniffiConverterOptionalString.read(buf),
+            computation_cost_burned=_UniffiConverterOptionalString.read(buf),
+            storage_cost=_UniffiConverterOptionalString.read(buf),
+            storage_rebate=_UniffiConverterOptionalString.read(buf),
+            non_refundable_storage_fee=_UniffiConverterOptionalString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterOptionalString.check_lower(value.computation_cost)
+        _UniffiConverterOptionalString.check_lower(value.computation_cost_burned)
+        _UniffiConverterOptionalString.check_lower(value.storage_cost)
+        _UniffiConverterOptionalString.check_lower(value.storage_rebate)
+        _UniffiConverterOptionalString.check_lower(value.non_refundable_storage_fee)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterOptionalString.write(value.computation_cost, buf)
+        _UniffiConverterOptionalString.write(value.computation_cost_burned, buf)
+        _UniffiConverterOptionalString.write(value.storage_cost, buf)
+        _UniffiConverterOptionalString.write(value.storage_rebate, buf)
+        _UniffiConverterOptionalString.write(value.non_refundable_storage_fee, buf)
 
 
 class Jwk:
@@ -16452,6 +16634,63 @@ class _UniffiConverterTypeRandomnessStateUpdate(_UniffiConverterRustBuffer):
         _UniffiConverterUInt64.write(value.randomness_obj_initial_shared_version, buf)
 
 
+class SafeMode:
+    """
+    Information about whether epoch changes are using safe mode.
+    """
+
+    enabled: "typing.Optional[bool]"
+    """
+    Whether safe mode was used for the last epoch change. The system will
+    retry a full epoch change on every epoch boundary and automatically
+    reset this flag if so.
+    """
+
+    gas_summary: "typing.Optional[GraphQlGasCostSummary]"
+    """
+    Accumulated fees for computation and cost that have not been added to
+    the various reward pools, because the full epoch change did not happen.
+    """
+
+    def __init__(self, *, enabled: "typing.Optional[bool]" = _DEFAULT, gas_summary: "typing.Optional[GraphQlGasCostSummary]" = _DEFAULT):
+        if enabled is _DEFAULT:
+            self.enabled = None
+        else:
+            self.enabled = enabled
+        if gas_summary is _DEFAULT:
+            self.gas_summary = None
+        else:
+            self.gas_summary = gas_summary
+
+    def __str__(self):
+        return "SafeMode(enabled={}, gas_summary={})".format(self.enabled, self.gas_summary)
+
+    def __eq__(self, other):
+        if self.enabled != other.enabled:
+            return False
+        if self.gas_summary != other.gas_summary:
+            return False
+        return True
+
+class _UniffiConverterTypeSafeMode(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return SafeMode(
+            enabled=_UniffiConverterOptionalBool.read(buf),
+            gas_summary=_UniffiConverterOptionalTypeGraphQlGasCostSummary.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterOptionalBool.check_lower(value.enabled)
+        _UniffiConverterOptionalTypeGraphQlGasCostSummary.check_lower(value.gas_summary)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterOptionalBool.write(value.enabled, buf)
+        _UniffiConverterOptionalTypeGraphQlGasCostSummary.write(value.gas_summary, buf)
+
+
 class ServiceConfig:
     default_page_size: "int"
     """
@@ -16722,6 +16961,193 @@ class _UniffiConverterTypeSignedTransactionPage(_UniffiConverterRustBuffer):
     def write(value, buf):
         _UniffiConverterTypePageInfo.write(value.page_info, buf)
         _UniffiConverterSequenceTypeSignedTransaction.write(value.data, buf)
+
+
+class StorageFund:
+    """
+    IOTA set aside to account for objects stored on-chain.
+    """
+
+    total_object_storage_rebates: "typing.Optional[str]"
+    """
+    Sum of storage rebates of live objects on chain.
+    """
+
+    non_refundable_balance: "typing.Optional[str]"
+    """
+    The portion of the storage fund that will never be refunded through
+    storage rebates.
+    The system maintains an invariant that the sum of
+    all storage fees into the storage fund is equal to the sum of of all
+    storage rebates out, the total storage rebates remaining, and the
+    non-refundable balance.
+    """
+
+    def __init__(self, *, total_object_storage_rebates: "typing.Optional[str]" = _DEFAULT, non_refundable_balance: "typing.Optional[str]" = _DEFAULT):
+        if total_object_storage_rebates is _DEFAULT:
+            self.total_object_storage_rebates = None
+        else:
+            self.total_object_storage_rebates = total_object_storage_rebates
+        if non_refundable_balance is _DEFAULT:
+            self.non_refundable_balance = None
+        else:
+            self.non_refundable_balance = non_refundable_balance
+
+    def __str__(self):
+        return "StorageFund(total_object_storage_rebates={}, non_refundable_balance={})".format(self.total_object_storage_rebates, self.non_refundable_balance)
+
+    def __eq__(self, other):
+        if self.total_object_storage_rebates != other.total_object_storage_rebates:
+            return False
+        if self.non_refundable_balance != other.non_refundable_balance:
+            return False
+        return True
+
+class _UniffiConverterTypeStorageFund(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return StorageFund(
+            total_object_storage_rebates=_UniffiConverterOptionalString.read(buf),
+            non_refundable_balance=_UniffiConverterOptionalString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterOptionalString.check_lower(value.total_object_storage_rebates)
+        _UniffiConverterOptionalString.check_lower(value.non_refundable_balance)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterOptionalString.write(value.total_object_storage_rebates, buf)
+        _UniffiConverterOptionalString.write(value.non_refundable_balance, buf)
+
+
+class SystemParameters:
+    """
+    Details of the system that are decided during genesis.
+    """
+
+    duration_ms: "typing.Optional[str]"
+    """
+    Target duration of an epoch, in milliseconds.
+    """
+
+    min_validator_count: "typing.Optional[int]"
+    """
+    The minimum number of active validators that the system supports.
+    """
+
+    max_validator_count: "typing.Optional[int]"
+    """
+    The maximum number of active validators that the system supports.
+    """
+
+    min_validator_joining_stake: "typing.Optional[str]"
+    """
+    Minimum stake needed to become a new validator.
+    """
+
+    validator_low_stake_threshold: "typing.Optional[str]"
+    """
+    Validators with stake below this threshold will enter the grace period
+    (see `validator_low_stake_grace_period`), after which they are removed
+    from the active validator set.
+    """
+
+    validator_very_low_stake_threshold: "typing.Optional[str]"
+    """
+    Validators with stake below this threshold will be removed from the
+    active validator set at the next epoch boundary, without a grace period.
+    """
+
+    validator_low_stake_grace_period: "typing.Optional[str]"
+    """
+    The number of epochs that a validator has to recover from having less
+    than `validator_low_stake_threshold` stake.
+    """
+
+    def __init__(self, *, duration_ms: "typing.Optional[str]" = _DEFAULT, min_validator_count: "typing.Optional[int]" = _DEFAULT, max_validator_count: "typing.Optional[int]" = _DEFAULT, min_validator_joining_stake: "typing.Optional[str]" = _DEFAULT, validator_low_stake_threshold: "typing.Optional[str]" = _DEFAULT, validator_very_low_stake_threshold: "typing.Optional[str]" = _DEFAULT, validator_low_stake_grace_period: "typing.Optional[str]" = _DEFAULT):
+        if duration_ms is _DEFAULT:
+            self.duration_ms = None
+        else:
+            self.duration_ms = duration_ms
+        if min_validator_count is _DEFAULT:
+            self.min_validator_count = None
+        else:
+            self.min_validator_count = min_validator_count
+        if max_validator_count is _DEFAULT:
+            self.max_validator_count = None
+        else:
+            self.max_validator_count = max_validator_count
+        if min_validator_joining_stake is _DEFAULT:
+            self.min_validator_joining_stake = None
+        else:
+            self.min_validator_joining_stake = min_validator_joining_stake
+        if validator_low_stake_threshold is _DEFAULT:
+            self.validator_low_stake_threshold = None
+        else:
+            self.validator_low_stake_threshold = validator_low_stake_threshold
+        if validator_very_low_stake_threshold is _DEFAULT:
+            self.validator_very_low_stake_threshold = None
+        else:
+            self.validator_very_low_stake_threshold = validator_very_low_stake_threshold
+        if validator_low_stake_grace_period is _DEFAULT:
+            self.validator_low_stake_grace_period = None
+        else:
+            self.validator_low_stake_grace_period = validator_low_stake_grace_period
+
+    def __str__(self):
+        return "SystemParameters(duration_ms={}, min_validator_count={}, max_validator_count={}, min_validator_joining_stake={}, validator_low_stake_threshold={}, validator_very_low_stake_threshold={}, validator_low_stake_grace_period={})".format(self.duration_ms, self.min_validator_count, self.max_validator_count, self.min_validator_joining_stake, self.validator_low_stake_threshold, self.validator_very_low_stake_threshold, self.validator_low_stake_grace_period)
+
+    def __eq__(self, other):
+        if self.duration_ms != other.duration_ms:
+            return False
+        if self.min_validator_count != other.min_validator_count:
+            return False
+        if self.max_validator_count != other.max_validator_count:
+            return False
+        if self.min_validator_joining_stake != other.min_validator_joining_stake:
+            return False
+        if self.validator_low_stake_threshold != other.validator_low_stake_threshold:
+            return False
+        if self.validator_very_low_stake_threshold != other.validator_very_low_stake_threshold:
+            return False
+        if self.validator_low_stake_grace_period != other.validator_low_stake_grace_period:
+            return False
+        return True
+
+class _UniffiConverterTypeSystemParameters(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return SystemParameters(
+            duration_ms=_UniffiConverterOptionalString.read(buf),
+            min_validator_count=_UniffiConverterOptionalInt32.read(buf),
+            max_validator_count=_UniffiConverterOptionalInt32.read(buf),
+            min_validator_joining_stake=_UniffiConverterOptionalString.read(buf),
+            validator_low_stake_threshold=_UniffiConverterOptionalString.read(buf),
+            validator_very_low_stake_threshold=_UniffiConverterOptionalString.read(buf),
+            validator_low_stake_grace_period=_UniffiConverterOptionalString.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterOptionalString.check_lower(value.duration_ms)
+        _UniffiConverterOptionalInt32.check_lower(value.min_validator_count)
+        _UniffiConverterOptionalInt32.check_lower(value.max_validator_count)
+        _UniffiConverterOptionalString.check_lower(value.min_validator_joining_stake)
+        _UniffiConverterOptionalString.check_lower(value.validator_low_stake_threshold)
+        _UniffiConverterOptionalString.check_lower(value.validator_very_low_stake_threshold)
+        _UniffiConverterOptionalString.check_lower(value.validator_low_stake_grace_period)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterOptionalString.write(value.duration_ms, buf)
+        _UniffiConverterOptionalInt32.write(value.min_validator_count, buf)
+        _UniffiConverterOptionalInt32.write(value.max_validator_count, buf)
+        _UniffiConverterOptionalString.write(value.min_validator_joining_stake, buf)
+        _UniffiConverterOptionalString.write(value.validator_low_stake_threshold, buf)
+        _UniffiConverterOptionalString.write(value.validator_very_low_stake_threshold, buf)
+        _UniffiConverterOptionalString.write(value.validator_low_stake_grace_period, buf)
 
 
 class TransactionDataEffects:
@@ -18050,6 +18476,16 @@ class _UniffiConverterTypeValidatorPage(_UniffiConverterRustBuffer):
 
 
 class ValidatorSet:
+    active_validators: "ValidatorConnection"
+    """
+    The current set of active validators.
+    """
+
+    committee_members: "ValidatorConnection"
+    """
+    The current set of committee members.
+    """
+
     inactive_pools_id: "typing.Optional[ObjectId]"
     """
     Object ID of the `Table` storing the inactive staking pools.
@@ -18106,7 +18542,9 @@ class ValidatorSet:
     Object ID of the `Table` storing the validator candidates.
     """
 
-    def __init__(self, *, inactive_pools_id: "typing.Optional[ObjectId]" = _DEFAULT, inactive_pools_size: "typing.Optional[int]" = _DEFAULT, pending_active_validators_id: "typing.Optional[ObjectId]" = _DEFAULT, pending_active_validators_size: "typing.Optional[int]" = _DEFAULT, pending_removals: "typing.Optional[typing.List[int]]" = _DEFAULT, staking_pool_mappings_id: "typing.Optional[ObjectId]" = _DEFAULT, staking_pool_mappings_size: "typing.Optional[int]" = _DEFAULT, total_stake: "typing.Optional[str]" = _DEFAULT, validator_candidates_size: "typing.Optional[int]" = _DEFAULT, validator_candidates_id: "typing.Optional[ObjectId]" = _DEFAULT):
+    def __init__(self, *, active_validators: "ValidatorConnection", committee_members: "ValidatorConnection", inactive_pools_id: "typing.Optional[ObjectId]" = _DEFAULT, inactive_pools_size: "typing.Optional[int]" = _DEFAULT, pending_active_validators_id: "typing.Optional[ObjectId]" = _DEFAULT, pending_active_validators_size: "typing.Optional[int]" = _DEFAULT, pending_removals: "typing.Optional[typing.List[int]]" = _DEFAULT, staking_pool_mappings_id: "typing.Optional[ObjectId]" = _DEFAULT, staking_pool_mappings_size: "typing.Optional[int]" = _DEFAULT, total_stake: "typing.Optional[str]" = _DEFAULT, validator_candidates_size: "typing.Optional[int]" = _DEFAULT, validator_candidates_id: "typing.Optional[ObjectId]" = _DEFAULT):
+        self.active_validators = active_validators
+        self.committee_members = committee_members
         if inactive_pools_id is _DEFAULT:
             self.inactive_pools_id = None
         else:
@@ -18149,9 +18587,13 @@ class ValidatorSet:
             self.validator_candidates_id = validator_candidates_id
 
     def __str__(self):
-        return "ValidatorSet(inactive_pools_id={}, inactive_pools_size={}, pending_active_validators_id={}, pending_active_validators_size={}, pending_removals={}, staking_pool_mappings_id={}, staking_pool_mappings_size={}, total_stake={}, validator_candidates_size={}, validator_candidates_id={})".format(self.inactive_pools_id, self.inactive_pools_size, self.pending_active_validators_id, self.pending_active_validators_size, self.pending_removals, self.staking_pool_mappings_id, self.staking_pool_mappings_size, self.total_stake, self.validator_candidates_size, self.validator_candidates_id)
+        return "ValidatorSet(active_validators={}, committee_members={}, inactive_pools_id={}, inactive_pools_size={}, pending_active_validators_id={}, pending_active_validators_size={}, pending_removals={}, staking_pool_mappings_id={}, staking_pool_mappings_size={}, total_stake={}, validator_candidates_size={}, validator_candidates_id={})".format(self.active_validators, self.committee_members, self.inactive_pools_id, self.inactive_pools_size, self.pending_active_validators_id, self.pending_active_validators_size, self.pending_removals, self.staking_pool_mappings_id, self.staking_pool_mappings_size, self.total_stake, self.validator_candidates_size, self.validator_candidates_id)
 
     def __eq__(self, other):
+        if self.active_validators != other.active_validators:
+            return False
+        if self.committee_members != other.committee_members:
+            return False
         if self.inactive_pools_id != other.inactive_pools_id:
             return False
         if self.inactive_pools_size != other.inactive_pools_size:
@@ -18178,6 +18620,8 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         return ValidatorSet(
+            active_validators=_UniffiConverterTypeValidatorConnection.read(buf),
+            committee_members=_UniffiConverterTypeValidatorConnection.read(buf),
             inactive_pools_id=_UniffiConverterOptionalTypeObjectId.read(buf),
             inactive_pools_size=_UniffiConverterOptionalInt32.read(buf),
             pending_active_validators_id=_UniffiConverterOptionalTypeObjectId.read(buf),
@@ -18192,6 +18636,8 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
 
     @staticmethod
     def check_lower(value):
+        _UniffiConverterTypeValidatorConnection.check_lower(value.active_validators)
+        _UniffiConverterTypeValidatorConnection.check_lower(value.committee_members)
         _UniffiConverterOptionalTypeObjectId.check_lower(value.inactive_pools_id)
         _UniffiConverterOptionalInt32.check_lower(value.inactive_pools_size)
         _UniffiConverterOptionalTypeObjectId.check_lower(value.pending_active_validators_id)
@@ -18205,6 +18651,8 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
 
     @staticmethod
     def write(value, buf):
+        _UniffiConverterTypeValidatorConnection.write(value.active_validators, buf)
+        _UniffiConverterTypeValidatorConnection.write(value.committee_members, buf)
         _UniffiConverterOptionalTypeObjectId.write(value.inactive_pools_id, buf)
         _UniffiConverterOptionalInt32.write(value.inactive_pools_size, buf)
         _UniffiConverterOptionalTypeObjectId.write(value.pending_active_validators_id, buf)
@@ -22176,6 +22624,33 @@ class _UniffiConverterOptionalUInt64(_UniffiConverterRustBuffer):
 
 
 
+class _UniffiConverterOptionalBool(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterBool.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterBool.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterBool.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
 class _UniffiConverterOptionalString(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -23175,6 +23650,33 @@ class _UniffiConverterOptionalTypeFaucetReceipt(_UniffiConverterRustBuffer):
 
 
 
+class _UniffiConverterOptionalTypeGraphQlGasCostSummary(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeGraphQlGasCostSummary.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeGraphQlGasCostSummary.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeGraphQlGasCostSummary.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
 class _UniffiConverterOptionalTypeMoveEnumConnection(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -23445,6 +23947,33 @@ class _UniffiConverterOptionalTypeProtocolConfigs(_UniffiConverterRustBuffer):
 
 
 
+class _UniffiConverterOptionalTypeSafeMode(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeSafeMode.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeSafeMode.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeSafeMode.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
 class _UniffiConverterOptionalTypeSignedTransaction(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -23467,6 +23996,60 @@ class _UniffiConverterOptionalTypeSignedTransaction(_UniffiConverterRustBuffer):
             return None
         elif flag == 1:
             return _UniffiConverterTypeSignedTransaction.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
+class _UniffiConverterOptionalTypeStorageFund(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeStorageFund.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeStorageFund.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeStorageFund.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
+class _UniffiConverterOptionalTypeSystemParameters(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeSystemParameters.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeSystemParameters.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeSystemParameters.read(buf)
         else:
             raise InternalError("Unexpected flag byte for optional type")
 
@@ -48880,6 +49463,7 @@ __all__ = [
     "GasCostSummary",
     "GasPayment",
     "GqlAddress",
+    "GraphQlGasCostSummary",
     "Jwk",
     "JwkId",
     "MoveEnum",
@@ -48912,9 +49496,12 @@ __all__ = [
     "ProtocolConfigs",
     "Query",
     "RandomnessStateUpdate",
+    "SafeMode",
     "ServiceConfig",
     "SignedTransaction",
     "SignedTransactionPage",
+    "StorageFund",
+    "SystemParameters",
     "TransactionDataEffects",
     "TransactionDataEffectsPage",
     "TransactionEffectsPage",

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -18476,16 +18476,6 @@ class _UniffiConverterTypeValidatorPage(_UniffiConverterRustBuffer):
 
 
 class ValidatorSet:
-    active_validators: "ValidatorConnection"
-    """
-    The current set of active validators.
-    """
-
-    committee_members: "ValidatorConnection"
-    """
-    The current set of committee members.
-    """
-
     inactive_pools_id: "typing.Optional[ObjectId]"
     """
     Object ID of the `Table` storing the inactive staking pools.
@@ -18542,9 +18532,7 @@ class ValidatorSet:
     Object ID of the `Table` storing the validator candidates.
     """
 
-    def __init__(self, *, active_validators: "ValidatorConnection", committee_members: "ValidatorConnection", inactive_pools_id: "typing.Optional[ObjectId]" = _DEFAULT, inactive_pools_size: "typing.Optional[int]" = _DEFAULT, pending_active_validators_id: "typing.Optional[ObjectId]" = _DEFAULT, pending_active_validators_size: "typing.Optional[int]" = _DEFAULT, pending_removals: "typing.Optional[typing.List[int]]" = _DEFAULT, staking_pool_mappings_id: "typing.Optional[ObjectId]" = _DEFAULT, staking_pool_mappings_size: "typing.Optional[int]" = _DEFAULT, total_stake: "typing.Optional[str]" = _DEFAULT, validator_candidates_size: "typing.Optional[int]" = _DEFAULT, validator_candidates_id: "typing.Optional[ObjectId]" = _DEFAULT):
-        self.active_validators = active_validators
-        self.committee_members = committee_members
+    def __init__(self, *, inactive_pools_id: "typing.Optional[ObjectId]" = _DEFAULT, inactive_pools_size: "typing.Optional[int]" = _DEFAULT, pending_active_validators_id: "typing.Optional[ObjectId]" = _DEFAULT, pending_active_validators_size: "typing.Optional[int]" = _DEFAULT, pending_removals: "typing.Optional[typing.List[int]]" = _DEFAULT, staking_pool_mappings_id: "typing.Optional[ObjectId]" = _DEFAULT, staking_pool_mappings_size: "typing.Optional[int]" = _DEFAULT, total_stake: "typing.Optional[str]" = _DEFAULT, validator_candidates_size: "typing.Optional[int]" = _DEFAULT, validator_candidates_id: "typing.Optional[ObjectId]" = _DEFAULT):
         if inactive_pools_id is _DEFAULT:
             self.inactive_pools_id = None
         else:
@@ -18587,13 +18575,9 @@ class ValidatorSet:
             self.validator_candidates_id = validator_candidates_id
 
     def __str__(self):
-        return "ValidatorSet(active_validators={}, committee_members={}, inactive_pools_id={}, inactive_pools_size={}, pending_active_validators_id={}, pending_active_validators_size={}, pending_removals={}, staking_pool_mappings_id={}, staking_pool_mappings_size={}, total_stake={}, validator_candidates_size={}, validator_candidates_id={})".format(self.active_validators, self.committee_members, self.inactive_pools_id, self.inactive_pools_size, self.pending_active_validators_id, self.pending_active_validators_size, self.pending_removals, self.staking_pool_mappings_id, self.staking_pool_mappings_size, self.total_stake, self.validator_candidates_size, self.validator_candidates_id)
+        return "ValidatorSet(inactive_pools_id={}, inactive_pools_size={}, pending_active_validators_id={}, pending_active_validators_size={}, pending_removals={}, staking_pool_mappings_id={}, staking_pool_mappings_size={}, total_stake={}, validator_candidates_size={}, validator_candidates_id={})".format(self.inactive_pools_id, self.inactive_pools_size, self.pending_active_validators_id, self.pending_active_validators_size, self.pending_removals, self.staking_pool_mappings_id, self.staking_pool_mappings_size, self.total_stake, self.validator_candidates_size, self.validator_candidates_id)
 
     def __eq__(self, other):
-        if self.active_validators != other.active_validators:
-            return False
-        if self.committee_members != other.committee_members:
-            return False
         if self.inactive_pools_id != other.inactive_pools_id:
             return False
         if self.inactive_pools_size != other.inactive_pools_size:
@@ -18620,8 +18604,6 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         return ValidatorSet(
-            active_validators=_UniffiConverterTypeValidatorConnection.read(buf),
-            committee_members=_UniffiConverterTypeValidatorConnection.read(buf),
             inactive_pools_id=_UniffiConverterOptionalTypeObjectId.read(buf),
             inactive_pools_size=_UniffiConverterOptionalInt32.read(buf),
             pending_active_validators_id=_UniffiConverterOptionalTypeObjectId.read(buf),
@@ -18636,8 +18618,6 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
 
     @staticmethod
     def check_lower(value):
-        _UniffiConverterTypeValidatorConnection.check_lower(value.active_validators)
-        _UniffiConverterTypeValidatorConnection.check_lower(value.committee_members)
         _UniffiConverterOptionalTypeObjectId.check_lower(value.inactive_pools_id)
         _UniffiConverterOptionalInt32.check_lower(value.inactive_pools_size)
         _UniffiConverterOptionalTypeObjectId.check_lower(value.pending_active_validators_id)
@@ -18651,8 +18631,6 @@ class _UniffiConverterTypeValidatorSet(_UniffiConverterRustBuffer):
 
     @staticmethod
     def write(value, buf):
-        _UniffiConverterTypeValidatorConnection.write(value.active_validators, buf)
-        _UniffiConverterTypeValidatorConnection.write(value.committee_members, buf)
         _UniffiConverterOptionalTypeObjectId.write(value.inactive_pools_id, buf)
         _UniffiConverterOptionalInt32.write(value.inactive_pools_size, buf)
         _UniffiConverterOptionalTypeObjectId.write(value.pending_active_validators_id, buf)

--- a/crates/iota-sdk-ffi/src/types/graphql.rs
+++ b/crates/iota-sdk-ffi/src/types/graphql.rs
@@ -365,6 +365,191 @@ impl From<ObjectRef> for iota_sdk::graphql_client::query_types::ObjectRef {
     }
 }
 
+/// Breakdown of gas costs in effects.
+#[derive(uniffi::Record)]
+pub struct GraphQLGasCostSummary {
+    /// Gas paid for executing this transaction (in NANOS).
+    #[uniffi(default = None)]
+    pub computation_cost: Option<String>,
+    /// Gas burned for executing this transaction (in NANOS).
+    #[uniffi(default = None)]
+    pub computation_cost_burned: Option<String>,
+    /// Gas paid for the data stored on-chain by this transaction (in NANOS).
+    #[uniffi(default = None)]
+    pub storage_cost: Option<String>,
+    /// Part of storage cost that can be reclaimed by cleaning up data created
+    /// by this transaction (when objects are deleted or an object is
+    /// modified, which is treated as a deletion followed by a creation) (in
+    /// NANOS).
+    #[uniffi(default = None)]
+    pub storage_rebate: Option<String>,
+    /// Part of storage cost that is not reclaimed when data created by this
+    /// transaction is cleaned up (in NANOS).
+    #[uniffi(default = None)]
+    pub non_refundable_storage_fee: Option<String>,
+}
+
+impl From<iota_sdk::graphql_client::query_types::GasCostSummary> for GraphQLGasCostSummary {
+    fn from(value: iota_sdk::graphql_client::query_types::GasCostSummary) -> Self {
+        Self {
+            computation_cost: value.computation_cost.map(|v| v.0),
+            computation_cost_burned: value.computation_cost_burned.map(|v| v.0),
+            storage_cost: value.storage_cost.map(|v| v.0),
+            storage_rebate: value.storage_rebate.map(|v| v.0),
+            non_refundable_storage_fee: value.non_refundable_storage_fee.map(|v| v.0),
+        }
+    }
+}
+
+impl From<GraphQLGasCostSummary> for iota_sdk::graphql_client::query_types::GasCostSummary {
+    fn from(value: GraphQLGasCostSummary) -> Self {
+        Self {
+            computation_cost: value.computation_cost.map(|v| v.into()),
+            computation_cost_burned: value.computation_cost_burned.map(|v| v.into()),
+            storage_cost: value.storage_cost.map(|v| v.into()),
+            storage_rebate: value.storage_rebate.map(|v| v.into()),
+            non_refundable_storage_fee: value.non_refundable_storage_fee.map(|v| v.into()),
+        }
+    }
+}
+
+/// Information about whether epoch changes are using safe mode.
+#[derive(uniffi::Record)]
+pub struct SafeMode {
+    /// Whether safe mode was used for the last epoch change. The system will
+    /// retry a full epoch change on every epoch boundary and automatically
+    /// reset this flag if so.
+    #[uniffi(default = None)]
+    pub enabled: Option<bool>,
+    /// Accumulated fees for computation and cost that have not been added to
+    /// the various reward pools, because the full epoch change did not happen.
+    #[uniffi(default = None)]
+    pub gas_summary: Option<GraphQLGasCostSummary>,
+}
+
+impl From<iota_sdk::graphql_client::query_types::SafeMode> for SafeMode {
+    fn from(value: iota_sdk::graphql_client::query_types::SafeMode) -> Self {
+        Self {
+            enabled: value.enabled,
+            gas_summary: value.gas_summary.map(Into::into),
+        }
+    }
+}
+
+impl From<SafeMode> for iota_sdk::graphql_client::query_types::SafeMode {
+    fn from(value: SafeMode) -> Self {
+        Self {
+            enabled: value.enabled,
+            gas_summary: value.gas_summary.map(Into::into),
+        }
+    }
+}
+
+/// IOTA set aside to account for objects stored on-chain.
+#[derive(uniffi::Record)]
+pub struct StorageFund {
+    /// Sum of storage rebates of live objects on chain.
+    #[uniffi(default = None)]
+    pub total_object_storage_rebates: Option<String>,
+    /// The portion of the storage fund that will never be refunded through
+    /// storage rebates.
+    /// The system maintains an invariant that the sum of
+    /// all storage fees into the storage fund is equal to the sum of of all
+    /// storage rebates out, the total storage rebates remaining, and the
+    /// non-refundable balance.
+    #[uniffi(default = None)]
+    pub non_refundable_balance: Option<String>,
+}
+
+impl From<iota_sdk::graphql_client::query_types::StorageFund> for StorageFund {
+    fn from(value: iota_sdk::graphql_client::query_types::StorageFund) -> Self {
+        Self {
+            total_object_storage_rebates: value.total_object_storage_rebates.map(|v| v.0),
+            non_refundable_balance: value.non_refundable_balance.map(|v| v.0),
+        }
+    }
+}
+
+impl From<StorageFund> for iota_sdk::graphql_client::query_types::StorageFund {
+    fn from(value: StorageFund) -> Self {
+        Self {
+            total_object_storage_rebates: value.total_object_storage_rebates.map(|v| v.into()),
+            non_refundable_balance: value.non_refundable_balance.map(|v| v.into()),
+        }
+    }
+}
+
+/// Details of the system that are decided during genesis.
+#[derive(uniffi::Record)]
+pub struct SystemParameters {
+    /// Target duration of an epoch, in milliseconds.
+    #[uniffi(default = None)]
+    pub duration_ms: Option<String>,
+    /// The minimum number of active validators that the system supports.
+    #[uniffi(default = None)]
+    pub min_validator_count: Option<i32>,
+    /// The maximum number of active validators that the system supports.
+    #[uniffi(default = None)]
+    pub max_validator_count: Option<i32>,
+    /// Minimum stake needed to become a new validator.
+    #[uniffi(default = None)]
+    pub min_validator_joining_stake: Option<String>,
+    /// Validators with stake below this threshold will enter the grace period
+    /// (see `validator_low_stake_grace_period`), after which they are removed
+    /// from the active validator set.
+    #[uniffi(default = None)]
+    pub validator_low_stake_threshold: Option<String>,
+    /// Validators with stake below this threshold will be removed from the
+    /// active validator set at the next epoch boundary, without a grace period.
+    #[uniffi(default = None)]
+    pub validator_very_low_stake_threshold: Option<String>,
+    /// The number of epochs that a validator has to recover from having less
+    /// than `validator_low_stake_threshold` stake.
+    #[uniffi(default = None)]
+    pub validator_low_stake_grace_period: Option<String>,
+}
+
+impl From<iota_sdk::graphql_client::query_types::SystemParameters> for SystemParameters {
+    fn from(value: iota_sdk::graphql_client::query_types::SystemParameters) -> Self {
+        Self {
+            duration_ms: value.duration_ms.map(|v| v.0),
+            min_validator_count: value.min_validator_count,
+            max_validator_count: value.max_validator_count,
+            min_validator_joining_stake: value.min_validator_joining_stake.map(|v| v.0),
+            validator_low_stake_threshold: value.validator_low_stake_threshold.map(|v| v.0),
+            validator_very_low_stake_threshold: value
+                .validator_very_low_stake_threshold
+                .map(|v| v.0),
+            validator_low_stake_grace_period: value.validator_low_stake_grace_period.map(|v| v.0),
+        }
+    }
+}
+
+impl From<SystemParameters> for iota_sdk::graphql_client::query_types::SystemParameters {
+    fn from(value: SystemParameters) -> Self {
+        Self {
+            duration_ms: value.duration_ms.map(|v| v.into()),
+            min_validator_count: value.min_validator_count,
+            max_validator_count: value.max_validator_count,
+            min_validator_joining_stake: value.min_validator_joining_stake.map(|v| v.into()),
+            validator_low_stake_threshold: value.validator_low_stake_threshold.map(|v| v.into()),
+            validator_very_low_stake_threshold: value
+                .validator_very_low_stake_threshold
+                .map(|v| v.into()),
+            validator_low_stake_grace_period: value
+                .validator_low_stake_grace_period
+                .map(|v| v.into()),
+        }
+    }
+}
+
+/// Operation of the IOTA network is temporally partitioned into non-overlapping
+/// epochs, and the network aims to keep epochs roughly the same duration as
+/// each other. During a particular epoch the following data is fixed:
+///
+/// - the protocol version
+/// - the reference gas price
+/// - the set of participating validators
 #[derive(uniffi::Record)]
 pub struct Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented
@@ -429,6 +614,23 @@ pub struct Epoch {
     /// of the epoch.
     #[uniffi(default = None)]
     pub validator_set: Option<ValidatorSet>,
+    /// IOTA set aside to account for objects stored on-chain, at the start of
+    /// the epoch. This is also used for storage rebates.
+    #[uniffi(default = None)]
+    pub storage_fund: Option<StorageFund>,
+    /// Information about whether this epoch was started in safe mode, which
+    /// happens if the full epoch change logic fails for some reason.
+    #[uniffi(default = None)]
+    pub safe_mode: Option<SafeMode>,
+    /// The total IOTA supply.
+    #[uniffi(default = None)]
+    pub iota_total_supply: Option<u64>,
+    /// The treasury-cap id.
+    #[uniffi(default = None)]
+    pub iota_treasury_cap_id: Option<Arc<Address>>,
+    /// Details of the system that are decided during genesis.
+    #[uniffi(default = None)]
+    pub system_parameters: Option<SystemParameters>,
 }
 
 impl From<iota_sdk::graphql_client::query_types::Epoch> for Epoch {
@@ -449,21 +651,12 @@ impl From<iota_sdk::graphql_client::query_types::Epoch> for Epoch {
             total_gas_fees: value.total_gas_fees.map(|v| v.0),
             total_stake_rewards: value.total_stake_rewards.map(|v| v.0),
             total_transactions: value.total_transactions,
-            validator_set: value.validator_set.map(|vs| ValidatorSet {
-                inactive_pools_id: vs.inactive_pools_id.map(Into::into).map(Arc::new),
-                inactive_pools_size: vs.inactive_pools_size,
-                pending_active_validators_id: vs
-                    .pending_active_validators_id
-                    .map(Into::into)
-                    .map(Arc::new),
-                pending_active_validators_size: vs.pending_active_validators_size,
-                pending_removals: vs.pending_removals,
-                staking_pool_mappings_id: vs.staking_pool_mappings_id.map(Into::into).map(Arc::new),
-                staking_pool_mappings_size: vs.staking_pool_mappings_size,
-                total_stake: vs.total_stake.map(|v| v.0),
-                validator_candidates_size: vs.validator_candidates_size,
-                validator_candidates_id: vs.validator_candidates_id.map(Into::into).map(Arc::new),
-            }),
+            validator_set: value.validator_set.map(Into::into),
+            storage_fund: value.storage_fund.map(Into::into),
+            safe_mode: value.safe_mode.map(Into::into),
+            iota_total_supply: value.iota_total_supply,
+            iota_treasury_cap_id: value.iota_treasury_cap_id.map(Into::into).map(Arc::new),
+            system_parameters: value.system_parameters.map(Into::into),
         }
     }
 }
@@ -491,12 +684,21 @@ impl From<Epoch> for iota_sdk::graphql_client::query_types::Epoch {
             total_stake_rewards: value.total_stake_rewards.map(|v| v.into()),
             total_transactions: value.total_transactions,
             validator_set: value.validator_set.map(Into::into),
+            storage_fund: value.storage_fund.map(Into::into),
+            safe_mode: value.safe_mode.map(Into::into),
+            iota_total_supply: value.iota_total_supply,
+            iota_treasury_cap_id: value.iota_treasury_cap_id.map(|a| **a),
+            system_parameters: value.system_parameters.map(Into::into),
         }
     }
 }
 
 #[derive(uniffi::Record)]
 pub struct ValidatorSet {
+    /// The current set of active validators.
+    pub active_validators: ValidatorConnection,
+    /// The current set of committee members.
+    pub committee_members: ValidatorConnection,
     /// Object ID of the `Table` storing the inactive staking pools.
     #[uniffi(default = None)]
     pub inactive_pools_id: Option<Arc<ObjectId>>,
@@ -538,6 +740,8 @@ pub struct ValidatorSet {
 impl From<iota_sdk::graphql_client::query_types::ValidatorSet> for ValidatorSet {
     fn from(value: iota_sdk::graphql_client::query_types::ValidatorSet) -> Self {
         Self {
+            active_validators: value.active_validators.into(),
+            committee_members: value.committee_members.into(),
             inactive_pools_id: value.inactive_pools_id.map(Into::into).map(Arc::new),
             inactive_pools_size: value.inactive_pools_size,
             pending_active_validators_id: value
@@ -558,6 +762,8 @@ impl From<iota_sdk::graphql_client::query_types::ValidatorSet> for ValidatorSet 
 impl From<ValidatorSet> for iota_sdk::graphql_client::query_types::ValidatorSet {
     fn from(value: ValidatorSet) -> Self {
         Self {
+            active_validators: value.active_validators.into(),
+            committee_members: value.committee_members.into(),
             inactive_pools_id: value.inactive_pools_id.map(|v| **v),
             inactive_pools_size: value.inactive_pools_size,
             pending_active_validators_id: value.pending_active_validators_id.map(|v| **v),

--- a/crates/iota-sdk-ffi/src/types/graphql.rs
+++ b/crates/iota-sdk-ffi/src/types/graphql.rs
@@ -695,10 +695,6 @@ impl From<Epoch> for iota_sdk::graphql_client::query_types::Epoch {
 
 #[derive(uniffi::Record)]
 pub struct ValidatorSet {
-    /// The current set of active validators.
-    pub active_validators: ValidatorConnection,
-    /// The current set of committee members.
-    pub committee_members: ValidatorConnection,
     /// Object ID of the `Table` storing the inactive staking pools.
     #[uniffi(default = None)]
     pub inactive_pools_id: Option<Arc<ObjectId>>,
@@ -740,8 +736,6 @@ pub struct ValidatorSet {
 impl From<iota_sdk::graphql_client::query_types::ValidatorSet> for ValidatorSet {
     fn from(value: iota_sdk::graphql_client::query_types::ValidatorSet) -> Self {
         Self {
-            active_validators: value.active_validators.into(),
-            committee_members: value.committee_members.into(),
             inactive_pools_id: value.inactive_pools_id.map(Into::into).map(Arc::new),
             inactive_pools_size: value.inactive_pools_size,
             pending_active_validators_id: value
@@ -762,8 +756,6 @@ impl From<iota_sdk::graphql_client::query_types::ValidatorSet> for ValidatorSet 
 impl From<ValidatorSet> for iota_sdk::graphql_client::query_types::ValidatorSet {
     fn from(value: ValidatorSet) -> Self {
         Self {
-            active_validators: value.active_validators.into(),
-            committee_members: value.committee_members.into(),
             inactive_pools_id: value.inactive_pools_id.map(|v| **v),
             inactive_pools_size: value.inactive_pools_size,
             pending_active_validators_id: value.pending_active_validators_id.map(|v| **v),

--- a/crates/iota-sdk-graphql-client-build/schema.graphql
+++ b/crates/iota-sdk-graphql-client-build/schema.graphql
@@ -1232,7 +1232,7 @@ type Epoch {
 	"""
 	The total IOTA supply.
 	"""
-	iotaTotalSupply: Int
+	iotaTotalSupply: UInt53
 	"""
 	The treasury-cap id.
 	"""

--- a/crates/iota-sdk-graphql-client/src/query_types/active_validators.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/active_validators.rs
@@ -45,7 +45,7 @@ pub struct ValidatorSetQuery {
     pub active_validators: ValidatorConnection,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "ValidatorConnection")]
 pub struct ValidatorConnection {
     pub page_info: PageInfo,

--- a/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
@@ -88,7 +88,7 @@ pub struct Checkpoint {
     pub rolling_gas_summary: Option<GasCostSummary>,
 }
 
-#[derive(cynic::QueryFragment, Debug)]
+#[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "GasCostSummary")]
 pub struct GasCostSummary {
     pub computation_cost: Option<BigInt>,

--- a/crates/iota-sdk-graphql-client/src/query_types/epoch.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/epoch.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::query_types::{BigInt, DateTime, ObjectId, ProtocolConfigs, schema};
+use crate::query_types::{Address, BigInt, DateTime, ObjectId, ProtocolConfigs, schema};
 
 // ===========================================================================
 // Epoch Queries
@@ -54,54 +54,70 @@ pub struct Epoch {
     /// The epoch's id as a sequence number that starts at 0 and is incremented
     /// by one at every epoch change.
     pub epoch_id: u64,
-    /// The storage fees paid for transactions executed during the epoch.
-    pub fund_inflow: Option<BigInt>,
-    /// The storage fee rebates paid to users who deleted the data associated
-    /// with past transactions.
-    pub fund_outflow: Option<BigInt>,
-    /// The storage fund available in this epoch.
-    /// This fund is used to redistribute storage fees from past transactions
-    /// to future validators.
-    pub fund_size: Option<BigInt>,
-    /// A commitment by the committee at the end of epoch on the contents of the
-    /// live object set at that time. This can be used to verify state
-    /// snapshots.
-    pub live_object_set_digest: Option<String>,
-    /// The difference between the fund inflow and outflow, representing
-    /// the net amount of storage fees accumulated in this epoch.
-    pub net_inflow: Option<BigInt>,
-    /// The epoch's corresponding protocol configuration, including the feature
-    /// flags and the configuration options.
-    pub protocol_configs: Option<ProtocolConfigs>,
     /// The minimum gas price that a quorum of validators are guaranteed to sign
     /// a transaction for.
     pub reference_gas_price: Option<BigInt>,
+    /// Validator related properties, including the active validators.
+    pub validator_set: Option<ValidatorSet>,
     /// The epoch's starting timestamp.
     pub start_timestamp: DateTime,
     /// The epoch's ending timestamp. Note that this is available only on epochs
     /// that have ended.
     pub end_timestamp: Option<DateTime>,
+    /// The total number of checkpoints in this epoch.
+    pub total_checkpoints: Option<u64>,
+    /// The total number of transaction blocks in this epoch.
+    pub total_transactions: Option<u64>,
+    /// The total amount of gas fees (in NANOS) that were paid in this epoch.
+    pub total_gas_fees: Option<BigInt>,
+    /// The total NANOS rewarded as stake.
+    pub total_stake_rewards: Option<BigInt>,
+    /// The storage fund available in this epoch.
+    /// This fund is used to redistribute storage fees from past transactions
+    /// to future validators.
+    pub fund_size: Option<BigInt>,
+    /// The difference between the fund inflow and outflow, representing
+    /// the net amount of storage fees accumulated in this epoch.
+    pub net_inflow: Option<BigInt>,
+    /// The storage fees paid for transactions executed during the epoch.
+    pub fund_inflow: Option<BigInt>,
+    /// The storage fee rebates paid to users who deleted the data associated
+    /// with past transactions.
+    pub fund_outflow: Option<BigInt>,
+    /// The epoch's corresponding protocol configuration, including the feature
+    /// flags and the configuration options.
+    pub protocol_configs: Option<ProtocolConfigs>,
+    /// IOTA set aside to account for objects stored on-chain, at the start of
+    /// the epoch. This is also used for storage rebates.
+    pub storage_fund: Option<StorageFund>,
+    /// Information about whether this epoch was started in safe mode, which
+    /// happens if the full epoch change logic fails for some reason.
+    pub safe_mode: Option<SafeMode>,
     /// The value of the `version` field of `0x5`, the
     /// `0x3::iota::IotaSystemState` object.  This version changes whenever
     /// the fields contained in the system state object (held in a dynamic
     /// field attached to `0x5`) change.
     pub system_state_version: Option<u64>,
-    /// The total number of checkpoints in this epoch.
-    pub total_checkpoints: Option<u64>,
-    /// The total amount of gas fees (in IOTA) that were paid in this epoch.
-    pub total_gas_fees: Option<BigInt>,
-    /// The total IOTA rewarded as stake.
-    pub total_stake_rewards: Option<BigInt>,
-    /// The total number of transaction in this epoch.
-    pub total_transactions: Option<u64>,
-    /// Validator related properties. For active validators, see
-    /// `active_validators` API.
-    pub validator_set: Option<ValidatorSet>,
+    /// The total IOTA supply.
+    pub iota_total_supply: Option<u64>,
+    /// The treasury-cap id.
+    pub iota_treasury_cap_id: Option<Address>,
+    /// Details of the system that are decided during genesis.
+    pub system_parameters: Option<SystemParameters>,
+    /// A commitment by the committee at the end of epoch on the contents of the
+    /// live object set at that time. This can be used to verify state
+    /// snapshots.
+    pub live_object_set_digest: Option<String>,
 }
 
+/// Representation of `0x3::validator_set::ValidatorSet`.
 #[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "ValidatorSet")]
 pub struct ValidatorSet {
+    /// The current set of active validators.
+    pub active_validators: crate::query_types::ValidatorConnection,
+    /// The current set of committee members.
+    pub committee_members: crate::query_types::ValidatorConnection,
     /// Object ID of the `Table` storing the inactive staking pools.
     pub inactive_pools_id: Option<ObjectId>,
     /// Size of the inactive pools `Table`.
@@ -128,4 +144,56 @@ pub struct ValidatorSet {
     pub validator_candidates_size: Option<i32>,
     /// Object ID of the `Table` storing the validator candidates.
     pub validator_candidates_id: Option<ObjectId>,
+}
+
+/// Information about whether epoch changes are using safe mode.
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema = "rpc", graphql_type = "SafeMode")]
+pub struct SafeMode {
+    /// Whether safe mode was used for the last epoch change. The system will
+    /// retry a full epoch change on every epoch boundary and automatically
+    /// reset this flag if so.
+    pub enabled: Option<bool>,
+    /// Accumulated fees for computation and cost that have not been added to
+    /// the various reward pools, because the full epoch change did not happen.
+    pub gas_summary: Option<crate::query_types::GasCostSummary>,
+}
+
+/// IOTA set aside to account for objects stored on-chain.
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema = "rpc", graphql_type = "StorageFund")]
+pub struct StorageFund {
+    /// Sum of storage rebates of live objects on chain.
+    pub total_object_storage_rebates: Option<BigInt>,
+    /// The portion of the storage fund that will never be refunded through
+    /// storage rebates.
+    /// The system maintains an invariant that the sum of
+    /// all storage fees into the storage fund is equal to the sum of of all
+    /// storage rebates out, the total storage rebates remaining, and the
+    /// non-refundable balance.
+    pub non_refundable_balance: Option<BigInt>,
+}
+
+/// Details of the system that are decided during genesis.
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema = "rpc", graphql_type = "SystemParameters")]
+pub struct SystemParameters {
+    /// Target duration of an epoch, in milliseconds.
+    pub duration_ms: Option<BigInt>,
+    /// The minimum number of active validators that the system supports.
+    pub min_validator_count: Option<i32>,
+    /// The maximum number of active validators that the system supports.
+    pub max_validator_count: Option<i32>,
+    /// Minimum stake needed to become a new validator.
+    pub min_validator_joining_stake: Option<BigInt>,
+    /// Validators with stake below this threshold will enter the grace period
+    /// (see `validator_low_stake_grace_period`), after which they are removed
+    /// from the active validator set.
+    pub validator_low_stake_threshold: Option<BigInt>,
+    /// Validators with stake below this threshold will be removed from the
+    /// active validator set at the next epoch boundary, without a grace period.
+    pub validator_very_low_stake_threshold: Option<BigInt>,
+    /// The number of epochs that a validator has to recover from having less
+    /// than `validator_low_stake_threshold` stake.
+    pub validator_low_stake_grace_period: Option<BigInt>,
 }

--- a/crates/iota-sdk-graphql-client/src/query_types/epoch.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/epoch.rs
@@ -111,13 +111,15 @@ pub struct Epoch {
 }
 
 /// Representation of `0x3::validator_set::ValidatorSet`.
+/// This is a minimal version used in Epoch queries that excludes the validator
+/// lists to keep query sizes manageable.
 #[derive(cynic::QueryFragment, Debug, Clone)]
 #[cynic(schema = "rpc", graphql_type = "ValidatorSet")]
 pub struct ValidatorSet {
-    /// The current set of active validators.
-    pub active_validators: crate::query_types::ValidatorConnection,
-    /// The current set of committee members.
-    pub committee_members: crate::query_types::ValidatorConnection,
+    // ///The current set of active validators.
+    // pub active_validators: crate::query_types::ValidatorConnection,
+    // /// The current set of committee members.
+    // pub committee_members: crate::query_types::ValidatorConnection,
     /// Object ID of the `Table` storing the inactive staking pools.
     pub inactive_pools_id: Option<ObjectId>,
     /// Size of the inactive pools `Table`.

--- a/crates/iota-sdk-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/mod.rs
@@ -28,7 +28,7 @@ pub use balance::{Balance, BalanceArgs, BalanceQuery, Owner};
 pub use chain::ChainIdentifierQuery;
 pub use checkpoint::{
     CheckpointArgs, CheckpointId, CheckpointQuery, CheckpointTotalTxQuery, CheckpointsArgs,
-    CheckpointsQuery,
+    CheckpointsQuery, GasCostSummary,
 };
 pub use coin::{CoinMetadata, CoinMetadataArgs, CoinMetadataQuery};
 use cynic::impl_scalar;
@@ -40,7 +40,10 @@ pub use dynamic_fields::{
     DynamicFieldArgs, DynamicFieldConnectionArgs, DynamicFieldName, DynamicFieldQuery,
     DynamicFieldsOwnerQuery, DynamicObjectFieldQuery,
 };
-pub use epoch::{Epoch, EpochArgs, EpochQuery, EpochSummaryQuery, ValidatorSet};
+pub use epoch::{
+    Epoch, EpochArgs, EpochQuery, EpochSummaryQuery, SafeMode, StorageFund, SystemParameters,
+    ValidatorSet,
+};
 pub use events::{Event, EventConnection, EventFilter, EventsQuery, EventsQueryArgs};
 pub use execute_tx::{ExecuteTransactionArgs, ExecuteTransactionQuery, ExecutionResult};
 pub use iota_names::{


### PR DESCRIPTION
Added missing types/fields that are defined in the graphql schema but were missing in the query types. Only the validator fields I left commented out as these would make the query too big and make it fail: `Query error: [Query payload is too large. The maximum allowed is 5000 bytes]`
Also changed the iota_total_supply type to work, as the number it holds is larger than i32::MAX and decoding failed without this change