### PR TITLE
chore(ci): Publish at the specific tag from the release

### DIFF
--- a/.github/workflows/pre_publish.yml
+++ b/.github/workflows/pre_publish.yml
@@ -3,9 +3,6 @@ name: Pre-publish
 on:
   workflow_dispatch:
     inputs:
-      version:
-        type: string
-        description: The exact version to release. Will override the level bump.
       level:
         type: choice
         required: true
@@ -35,12 +32,12 @@ on:
         required: true
         description: The package to publish.
         options:
-          - iota-sdk
-          - iota-sdk-crypto
-          - iota-sdk-graphql-client
-          - iota-sdk-graphql-client-build
-          - iota-sdk-transaction-builder
           - iota-sdk-types
+          - iota-sdk-crypto
+          - iota-sdk-graphql-client-build
+          - iota-sdk-graphql-client
+          - iota-sdk-transaction-builder
+          - iota-sdk
 
 jobs:
   publish:
@@ -76,7 +73,7 @@ jobs:
         uses: cargo-bins/release-pr@0c019c0e5a6b9f722578d231d43ba900cacc5ffa # v2.1.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: ${{ inputs.version != null && inputs.version || inputs.level }}
+          version: ${{ inputs.level }}
           crate-name: ${{ inputs.package }}
           git-user-name: "IOTA Foundation"
           git-user-email: info@iota.org

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,13 +11,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
-      - run: cargo install cargo-release --version 0.25.20
+      - name: Install cargo-release
+        uses: taiki-e/install-action@f535147c22906d77695e11cb199e764aa610a4fc # v2.62.46
+        with:
+          tool: cargo-release@0.25.20
 
       - name: Cargo release publish
         run: |
-          pkg=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|(.*)-v.*|\1|p'
-          version=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|.*-v(.*)|\1|p'
+          pkg=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|(.*)-v.*|\1|p')
+          version=$(echo "${{github.event.release.tag_name}}" | sed -nr 's|.*-v(.*)|\1|p')
 
           echo "Publishing $pkg at version $version"
           eval "cargo release publish \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,12 @@ on:
         required: true
         description: The package to publish.
         options:
-          - iota-sdk
-          - iota-sdk-crypto
-          - iota-sdk-graphql-client
-          - iota-sdk-graphql-client-build
-          - iota-sdk-transaction-builder
           - iota-sdk-types
+          - iota-sdk-crypto
+          - iota-sdk-graphql-client-build
+          - iota-sdk-graphql-client
+          - iota-sdk-transaction-builder
+          - iota-sdk
       version:
         type: string
         description: The exact version.


### PR DESCRIPTION
## Description

Fixes the `publish` workflow commands and checks out the specific tag which was created by the release rather than HEAD. Also re-orders the packages in the options dropdown in the order they should be published.
