### PR TITLE
chore(types,crypto): Remove serde_derive dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rand_core = "0.6.4"
 reqwest = { version = "0.12", default-features = false }
 roaring = { version = "0.11.2", default-features = false }
 serde = "1.0.210"
-serde_derive = "1.0.210"
 serde_json = "1.0.128"
 strum = "0.27.2"
 test-strategy = "0.4.0"

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -38,8 +38,6 @@ zklogin = [
   "dep:base64ct",
   "dep:bnum",
   "dep:itertools",
-  "dep:serde",
-  "dep:serde_derive",
   "dep:serde_json",
   "signature/std",
 ]
@@ -85,8 +83,6 @@ ark-std = { version = "0.4.0", optional = true }
 base64ct = { workspace = true, features = ["alloc"], optional = true }
 bnum = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 # pkcs8 der and pem support

--- a/crates/iota-sdk-graphql-client/Cargo.toml
+++ b/crates/iota-sdk-graphql-client/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["time"] }
 tracing = "0.1.37"
 url = "2.5.3"
 
-iota-types = { workspace = true, features = ["serde"] }
+iota-types = { workspace = true, features = ["serde", "hash"] }
 
 [dev-dependencies]
 hex.workspace = true

--- a/crates/iota-sdk-types/Cargo.toml
+++ b/crates/iota-sdk-types/Cargo.toml
@@ -26,7 +26,6 @@ rustdoc-args = [
 default = []
 serde = [
   "dep:serde",
-  "dep:serde_derive",
   "dep:serde_with",
   "dep:bcs",
   "dep:serde_json",
@@ -53,8 +52,7 @@ winnow = "0.7"
 # Serialization and Deserialization support
 bcs = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
-serde_derive = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { version = "3.9", default-features = false, features = ["alloc"], optional = true }
 

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -56,10 +56,7 @@
 /// address = 32OCTET
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Address(
     #[cfg_attr(

--- a/crates/iota-sdk-types/src/checkpoint.rs
+++ b/crates/iota-sdk-types/src/checkpoint.rs
@@ -60,10 +60,7 @@ impl CheckpointCommitment {
 ///                     (vector checkpoint-commitment)      ; epoch_commitments
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct EndOfEpochData {
@@ -170,10 +167,7 @@ pub struct CheckpointSummary {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SignedCheckpointSummary {
@@ -223,10 +217,7 @@ impl CheckpointContents {
 
 /// Transaction information committed to in a checkpoint
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CheckpointTransactionInfo {
@@ -237,10 +228,7 @@ pub struct CheckpointTransactionInfo {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CheckpointData {
@@ -251,10 +239,7 @@ pub struct CheckpointData {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CheckpointTransaction {
@@ -285,7 +270,7 @@ mod serialization {
 
     use super::*;
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct ReadableCheckpointSummaryRef<'a> {
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: &'a EpochId,
@@ -308,7 +293,7 @@ mod serialization {
         version_specific_data: &'a Vec<u8>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ReadableCheckpointSummary {
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: EpochId,
@@ -331,7 +316,7 @@ mod serialization {
         version_specific_data: Vec<u8>,
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct BinaryCheckpointSummaryRef<'a> {
         epoch: &'a EpochId,
         sequence_number: &'a CheckpointSequenceNumber,
@@ -345,7 +330,7 @@ mod serialization {
         version_specific_data: &'a Vec<u8>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct BinaryCheckpointSummary {
         epoch: EpochId,
         sequence_number: CheckpointSequenceNumber,
@@ -478,7 +463,7 @@ mod serialization {
             if serializer.is_human_readable() {
                 serializer.serialize_newtype_struct("CheckpointContents", &self.0)
             } else {
-                #[derive(serde_derive::Serialize)]
+                #[derive(serde::Serialize)]
                 struct Digests<'a> {
                     transaction: &'a Digest,
                     effects: &'a Digest,
@@ -524,19 +509,19 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ExecutionDigests {
         transaction: Digest,
         effects: Digest,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct BinaryContentsV1 {
         digests: Vec<ExecutionDigests>,
         signatures: Vec<Vec<UserSignature>>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum BinaryContents {
         V1(BinaryContentsV1),
     }
@@ -585,13 +570,13 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "type", rename_all = "snake_case")]
     enum ReadableCommitment {
         EcmhLiveObjectSet { digest: Digest },
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryCommitment {
         EcmhLiveObjectSet { digest: Digest },
     }

--- a/crates/iota-sdk-types/src/crypto/bls12381.rs
+++ b/crates/iota-sdk-types/src/crypto/bls12381.rs
@@ -19,10 +19,7 @@
 /// `Bls12381PublicKey` is prefixed with its length meaning its serialized
 /// binary form (in bcs) is 97 bytes long vs a more compact 96 bytes.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Bls12381PublicKey(
@@ -129,10 +126,7 @@ impl std::fmt::Debug for Bls12381PublicKey {
 /// bls-signature = 48OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Bls12381Signature(

--- a/crates/iota-sdk-types/src/crypto/ed25519.rs
+++ b/crates/iota-sdk-types/src/crypto/ed25519.rs
@@ -16,10 +16,7 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 /// ed25519-public-key = 32OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Ed25519PublicKey(
@@ -135,10 +132,7 @@ impl std::fmt::Debug for Ed25519PublicKey {
 /// ed25519-signature = 64OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Ed25519Signature(

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -80,10 +80,7 @@ impl MultisigMemberPublicKey {
 ///                          u8     ; weight
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MultisigMember {
@@ -131,10 +128,7 @@ impl MultisigMember {
 ///                             u16     ; threshold
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MultisigCommittee {
@@ -340,28 +334,28 @@ mod serialization {
         crypto::SignatureFromBytesError,
     };
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     pub struct Multisig {
         signatures: Vec<MultisigMemberSignature>,
         bitmap: BitmapUnit,
         committee: MultisigCommittee,
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     pub struct MultisigRef<'a> {
         signatures: &'a [MultisigMemberSignature],
         bitmap: BitmapUnit,
         committee: &'a MultisigCommittee,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ReadableMultisigAggregatedSignature {
         signatures: Vec<MultisigMemberSignature>,
         bitmap: BitmapUnit,
         committee: MultisigCommittee,
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct ReadableMultisigAggregatedSignatureRef<'a> {
         signatures: &'a [MultisigMemberSignature],
         bitmap: BitmapUnit,
@@ -446,7 +440,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum MemberPublicKey {
         Ed25519(Ed25519PublicKey),
         Secp256k1(Secp256k1PublicKey),
@@ -454,7 +448,7 @@ mod serialization {
         ZkLogin(ZkLoginPublicIdentifier),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
     #[serde(rename = "MultisigMemberPublicKey")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -552,7 +546,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum MemberSignature {
         Ed25519(Ed25519Signature),
         Secp256k1(Secp256k1Signature),
@@ -560,7 +554,7 @@ mod serialization {
         ZkLogin(Box<ZkLoginAuthenticator>),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
     #[serde(rename = "MultisigMemberSignature")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/iota-sdk-types/src/crypto/secp256k1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256k1.rs
@@ -16,10 +16,7 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 /// secp256k1-public-key = 33OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Secp256k1PublicKey(
@@ -137,10 +134,7 @@ impl std::fmt::Debug for Secp256k1PublicKey {
 /// secp256k1-signature = 64OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Secp256k1Signature(

--- a/crates/iota-sdk-types/src/crypto/secp256r1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256r1.rs
@@ -16,10 +16,7 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 /// secp256r1-public-key = 33OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Secp256r1PublicKey(
@@ -137,10 +134,7 @@ impl std::fmt::Debug for Secp256r1PublicKey {
 /// secp256r1-signature = 64OCTECT
 /// ```
 #[derive(Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Secp256r1Signature(

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -469,7 +469,7 @@ mod serialization {
         where
             S: serde::Serializer,
         {
-            #[derive(serde_derive::Serialize)]
+            #[derive(serde::Serialize)]
             #[serde(tag = "scheme")]
             #[serde(rename_all = "lowercase")]
             enum Sig<'a> {
@@ -564,7 +564,7 @@ mod serialization {
         where
             D: serde::Deserializer<'de>,
         {
-            #[derive(serde_derive::Deserialize)]
+            #[derive(serde::Deserialize)]
             #[serde(tag = "scheme")]
             #[serde(rename_all = "lowercase")]
             enum Sig {
@@ -677,7 +677,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
     enum ReadableUserSignatureRef<'a> {
         Ed25519 {
@@ -697,7 +697,7 @@ mod serialization {
         Passkey(&'a PasskeyAuthenticator),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
     #[serde(rename = "UserSignature")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/iota-sdk-types/src/crypto/zklogin.rs
+++ b/crates/iota-sdk-types/src/crypto/zklogin.rs
@@ -188,10 +188,7 @@ impl proptest::arbitrary::Arbitrary for ZkLoginInputs {
 /// zklogin-claim = string u8
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ZkLoginClaim {
@@ -362,7 +359,7 @@ impl JwtHeader {
     fn from_base64(s: &str) -> Result<Self, InvalidZkLoginAuthenticatorError> {
         use base64ct::{Base64UrlUnpadded, Encoding};
 
-        #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+        #[derive(serde::Serialize, serde::Deserialize)]
         struct Header {
             alg: String,
             kid: String,
@@ -393,10 +390,7 @@ impl JwtHeader {
 /// zklogin-proof = circom-g1 circom-g2 circom-g1
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ZkLoginProof {
@@ -531,10 +525,7 @@ impl ZkLoginPublicIdentifier {
 /// jwk = string string string string
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Jwk {
@@ -558,10 +549,7 @@ pub struct Jwk {
 /// jwk-id = string string
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct JwkId {
@@ -717,7 +705,7 @@ mod serialization {
             S: Serializer,
         {
             if serializer.is_human_readable() {
-                #[derive(serde_derive::Serialize)]
+                #[derive(serde::Serialize)]
                 struct Readable<'a> {
                     iss: &'a str,
                     address_seed: &'a Bn254FieldElement,
@@ -746,7 +734,7 @@ mod serialization {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                #[derive(serde_derive::Deserialize)]
+                #[derive(serde::Deserialize)]
                 struct Readable {
                     iss: String,
                     address_seed: Bn254FieldElement,
@@ -778,7 +766,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct AuthenticatorRef<'a> {
         inputs: &'a ZkLoginInputs,
         #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
@@ -786,7 +774,7 @@ mod serialization {
         signature: &'a SimpleSignature,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct Authenticator {
         inputs: ZkLoginInputs,
         #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
@@ -884,7 +872,7 @@ mod serialization {
         where
             S: Serializer,
         {
-            #[derive(serde_derive::Serialize)]
+            #[derive(serde::Serialize)]
             struct Inputs<'a> {
                 proof_points: &'a ZkLoginProof,
                 iss_base64_details: &'a ZkLoginClaim,
@@ -907,7 +895,7 @@ mod serialization {
         where
             D: Deserializer<'de>,
         {
-            #[derive(serde_derive::Deserialize)]
+            #[derive(serde::Deserialize)]
             struct Inputs {
                 proof_points: ZkLoginProof,
                 iss_base64_details: ZkLoginClaim,

--- a/crates/iota-sdk-types/src/digest.rs
+++ b/crates/iota-sdk-types/src/digest.rs
@@ -17,10 +17,7 @@
 /// meaning its serialized binary form (in bcs) is 33 bytes long vs a more
 /// compact 32 bytes.
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Digest(

--- a/crates/iota-sdk-types/src/effects/mod.rs
+++ b/crates/iota-sdk-types/src/effects/mod.rs
@@ -148,26 +148,26 @@ mod serialization {
 
     use super::{TransactionEffects, TransactionEffectsV1};
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "version")]
     enum ReadableEffectsRef<'a> {
         #[serde(rename = "1")]
         V1(&'a TransactionEffectsV1),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "version")]
     pub enum ReadableEffects {
         #[serde(rename = "1")]
         V1(Box<TransactionEffectsV1>),
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum BinaryEffectsRef<'a> {
         V1(&'a TransactionEffectsV1),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     pub enum BinaryEffects {
         V1(Box<TransactionEffectsV1>),
     }

--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -98,10 +98,7 @@ impl TransactionEffectsV1 {
 /// changed-object = object-id object-in object-out id-operation
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ChangedObject {
@@ -127,10 +124,7 @@ pub struct ChangedObject {
 /// unchanged-shared-object = object-id unchanged-shared-object-kind
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct UnchangedSharedObject {
@@ -385,7 +379,7 @@ impl ObjectOut {
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "lowercase")
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -407,7 +401,7 @@ mod serialization {
 
     use super::*;
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct ReadableTransactionEffectsV1Ref<'a> {
         #[serde(flatten)]
         status: &'a ExecutionStatus,
@@ -425,7 +419,7 @@ mod serialization {
         auxiliary_data_digest: &'a Option<Digest>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct ReadableTransactionEffectsV1 {
         #[serde(flatten)]
         status: ExecutionStatus,
@@ -443,7 +437,7 @@ mod serialization {
         auxiliary_data_digest: Option<Digest>,
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct BinaryTransactionEffectsV1Ref<'a> {
         status: &'a ExecutionStatus,
         epoch: &'a EpochId,
@@ -458,7 +452,7 @@ mod serialization {
         auxiliary_data_digest: &'a Option<Digest>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct BinaryTransactionEffectsV1 {
         status: ExecutionStatus,
         epoch: EpochId,
@@ -588,7 +582,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableUnchangedSharedKind {
         ReadOnlyRoot {
@@ -611,7 +605,7 @@ mod serialization {
         PerEpochConfig,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryUnchangedSharedKind {
         ReadOnlyRoot { version: Version, digest: Digest },
         MutateDeleted { version: Version },
@@ -708,7 +702,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "state", rename_all = "snake_case")]
     enum ReadableObjectIn {
         Missing,
@@ -720,7 +714,7 @@ mod serialization {
         },
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryObjectIn {
         Missing,
         Data {
@@ -802,7 +796,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "state", rename_all = "snake_case")]
     enum ReadableObjectOut {
         Missing,
@@ -817,7 +811,7 @@ mod serialization {
         },
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryObjectOut {
         Missing,
         ObjectWrite {

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -14,10 +14,7 @@ use super::{Address, Identifier, ObjectId, StructTag, TypeTag};
 /// transaction-events = vector event
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct TransactionEvents(pub Vec<Event>);
@@ -32,10 +29,7 @@ pub struct TransactionEvents(pub Vec<Event>);
 /// event = object-id identifier address struct-tag bytes
 /// ```
 #[derive(PartialEq, Eq, Debug, Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Event {
@@ -61,10 +55,7 @@ pub struct Event {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct BalanceChange {

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -331,10 +331,7 @@ impl ExecutionError {
 /// move-location = object-id identifier u16 u16 (option identifier)
 /// ```
 #[derive(Eq, PartialEq, Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MoveLocation {
@@ -516,7 +513,7 @@ impl PackageUpgradeError {
 #[derive(Eq, PartialEq, Clone, Copy, Debug)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "snake_case")
 )]
 #[cfg_attr(
@@ -543,7 +540,7 @@ mod serialization {
 
     use super::*;
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "ExecutionStatus")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     struct ReadableExecutionStatus {
@@ -563,7 +560,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     struct FailureStatus {
         error: ExecutionError,
@@ -571,7 +568,7 @@ mod serialization {
         command: Option<u16>,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryExecutionStatus {
         Success,
         Failure {
@@ -644,7 +641,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "error", rename_all = "snake_case")]
     enum ReadableExecutionError {
         InsufficientGas,
@@ -739,7 +736,7 @@ mod serialization {
         InvalidLinkage,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryExecutionError {
         InsufficientGas,
         InvalidGasObject,
@@ -1312,7 +1309,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableCommandArgumentError {
         TypeMismatch,
@@ -1330,7 +1327,7 @@ mod serialization {
         InvalidArgumentArity,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryCommandArgumentError {
         TypeMismatch,
         InvalidBcsBytes,
@@ -1503,7 +1500,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadablePackageUpgradeError {
         UnableToFetchPackage {
@@ -1525,7 +1522,7 @@ mod serialization {
         },
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryPackageUpgradeError {
         UnableToFetchPackage {
             package_id: ObjectId,

--- a/crates/iota-sdk-types/src/gas.rs
+++ b/crates/iota-sdk-types/src/gas.rs
@@ -39,10 +39,7 @@
 ///                    u64 ; non-refundable-storage-fee
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct GasCostSummary {

--- a/crates/iota-sdk-types/src/iota_names/config.rs
+++ b/crates/iota-sdk-types/src/iota_names/config.rs
@@ -8,7 +8,7 @@ use crate::{Address, ObjectId};
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "kebab-case")
 )]
 pub struct IotaNamesConfig {

--- a/crates/iota-sdk-types/src/iota_names/error.rs
+++ b/crates/iota-sdk-types/src/iota_names/error.rs
@@ -4,10 +4,7 @@
 use crate::ObjectId;
 
 #[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IotaNamesError {
     #[error("Name length {0} exceeds maximum length {1}")]
     NameLengthExceeded(usize, usize),

--- a/crates/iota-sdk-types/src/iota_names/mod.rs
+++ b/crates/iota-sdk-types/src/iota_names/mod.rs
@@ -14,10 +14,7 @@ use crate::{Address, ObjectId, StructTag, type_tag::IdentifierRef};
 
 /// An object to manage a second-level name (SLN).
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameRegistration {
     id: ObjectId,
     name: Name,
@@ -38,10 +35,7 @@ impl NameRegistration {
 
 /// An object to manage a subname.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubnameRegistration {
     id: ObjectId,
     nft: NameRegistration,

--- a/crates/iota-sdk-types/src/iota_names/name.rs
+++ b/crates/iota-sdk-types/src/iota_names/name.rs
@@ -16,10 +16,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Name {
     // Labels of the name, in reverse order
     labels: Vec<String>,

--- a/crates/iota-sdk-types/src/iota_names/registry.rs
+++ b/crates/iota-sdk-types/src/iota_names/registry.rs
@@ -13,20 +13,14 @@ use crate::{
 
 /// Rust version of the Move `iota::table::Table` type.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Table {
     pub id: ObjectId,
     pub size: u64,
 }
 
 #[derive(Debug, Clone)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Registry {
     /// The `registry` table maps `Name` to `NameRecord`.
     /// Added / replaced in the `add_record` function.
@@ -37,10 +31,7 @@ pub struct Registry {
 }
 
 #[derive(Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegistryEntry {
     pub id: ObjectId,
     pub name: Name,
@@ -48,10 +39,7 @@ pub struct RegistryEntry {
 }
 
 #[derive(Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReverseRegistryEntry {
     pub id: ObjectId,
     pub address: Address,
@@ -60,10 +48,7 @@ pub struct ReverseRegistryEntry {
 
 /// A single record in the registry.
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameRecord {
     /// The ID of the registration NFT assigned to this record.
     ///

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -20,10 +20,7 @@ pub type Version = u64;
 /// object-ref = object-id u64 digest
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ObjectReference {
@@ -95,7 +92,7 @@ impl ObjectReference {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize),
+    derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "lowercase")
 )]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -146,10 +143,7 @@ impl std::fmt::Display for Owner {
 /// object-data-package = %x01 object-move-package
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(clippy::large_enum_variant)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 // TODO think about hiding this type and not exposing it
@@ -179,10 +173,7 @@ impl ObjectData {
 /// linkage-table = map (object-id upgrade-info)
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MovePackage {
     /// Address or Id of this package
@@ -236,10 +227,7 @@ pub struct MovePackage {
 /// type-origin = identifier identifier object-id
 /// ```
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct TypeOrigin {
@@ -258,10 +246,7 @@ pub struct TypeOrigin {
 /// upgrade-info = object-id u64
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct UpgradeInfo {
@@ -293,10 +278,7 @@ pub struct UpgradeInfo {
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 // TODO hand-roll a Deserialize impl to enforce that an objectid is present
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MoveStruct {
     /// The type of this object
@@ -558,7 +540,7 @@ mod serialization {
     /// to prevent incorrectly constructing an `Other` instead of one of the
     /// specialized variants, e.g. `Other(GasCoin::type_())` instead of
     /// `GasCoin`
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum MoveStructType {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(StructTag),
@@ -576,7 +558,7 @@ mod serialization {
     }
 
     /// See `MoveStructType`
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum MoveStructTypeRef<'a> {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(&'a StructTag),
@@ -696,7 +678,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "Object")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     struct ReadableObject {
@@ -728,7 +710,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(untagged)]
     #[cfg_attr(
         feature = "schemars",
@@ -740,7 +722,7 @@ mod serialization {
         Package(ReadablePackage),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[cfg_attr(
         feature = "schemars",
         derive(schemars::JsonSchema),
@@ -759,7 +741,7 @@ mod serialization {
         linkage_table: BTreeMap<ObjectId, UpgradeInfo>,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[cfg_attr(
         feature = "schemars",
         derive(schemars::JsonSchema),
@@ -889,7 +871,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     struct BinaryObject {
         data: ObjectData,
         owner: Owner,
@@ -897,7 +879,7 @@ mod serialization {
         storage_rebate: u64,
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "GenesisObject")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     struct ReadableGenesisObject {
@@ -925,7 +907,7 @@ mod serialization {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryGenesisObject {
         RawObject { data: ObjectData, owner: Owner },
     }

--- a/crates/iota-sdk-types/src/object_id.rs
+++ b/crates/iota-sdk-types/src/object_id.rs
@@ -23,10 +23,7 @@ use super::Address;
 /// object-id = 32*OCTET
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ObjectId(Address);

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -28,10 +28,7 @@ pub(crate) use serialization::SignedTransactionWithIntentMessage;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Transaction {
     #[cfg_attr(feature = "serde", serde(rename = "1"))]
     V1(TransactionV1),
@@ -52,10 +49,7 @@ impl From<TransactionV1> for Transaction {
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TransactionV1 {
     pub kind: TransactionKind,
     pub sender: Address,
@@ -63,7 +57,7 @@ pub struct TransactionV1 {
     pub expiration: TransactionExpiration,
 }
 
-#[cfg_attr(feature = "serde", derive(serde_derive::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct SenderSignedTransaction(
     #[cfg_attr(
         feature = "serde",
@@ -73,10 +67,7 @@ pub struct SenderSignedTransaction(
 );
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SignedTransaction {
@@ -124,10 +115,7 @@ impl TransactionExpiration {
 ///               u64                 ; budget
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct GasPayment {
@@ -157,10 +145,7 @@ pub struct GasPayment {
 /// randomness-state-update = u64 u64 bytes u64
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct RandomnessStateUpdate {
@@ -305,10 +290,7 @@ impl EndOfEpochTransactionKind {
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExecutionTimeObservations {
     V1(Vec<ExecutionTimeObservation>),
 }
@@ -320,10 +302,7 @@ impl ExecutionTimeObservations {
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExecutionTimeObservation {
     pub key: ExecutionTimeObservationKey,
     pub observations: Vec<ValidatorExecutionTimeObservation>,
@@ -343,10 +322,7 @@ pub struct ExecutionTimeObservation {
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidatorExecutionTimeObservation {
     pub validator: crate::Bls12381PublicKey,
     pub duration: std::time::Duration,
@@ -372,10 +348,7 @@ pub struct ValidatorExecutionTimeObservation {
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ExecutionTimeObservationKey {
     // Contains all the fields from `ProgrammableMoveCall` besides `arguments`.
     MoveEntryPoint {
@@ -419,10 +392,7 @@ impl ExecutionTimeObservationKey {
 /// authenticator-state-expire = u64 u64
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct AuthenticatorStateExpire {
@@ -449,10 +419,7 @@ pub struct AuthenticatorStateExpire {
 ///                              u64 ; initial version of the authenticator object
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct AuthenticatorStateUpdateV1 {
@@ -482,10 +449,7 @@ pub struct AuthenticatorStateUpdateV1 {
 /// active-jwk = jwk-id jwk u64
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ActiveJwk {
@@ -535,10 +499,7 @@ impl ConsensusDeterminedVersionAssignments {
 /// cancelled-transaction = digest (vector version-assignment)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CancelledTransaction {
@@ -557,10 +518,7 @@ pub struct CancelledTransaction {
 /// version-assignment = object-id u64
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct VersionAssignment {
@@ -581,10 +539,7 @@ pub struct VersionAssignment {
 ///                                consensus-determined-version-assignments
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ConsensusCommitPrologueV1 {
@@ -631,10 +586,7 @@ pub struct ConsensusCommitPrologueV1 {
 ///                (vector system-package)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ChangeEpoch {
@@ -694,10 +646,7 @@ pub struct ChangeEpoch {
 ///                (vector system-package)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ChangeEpochV2 {
@@ -744,10 +693,7 @@ pub struct ChangeEpochV2 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ChangeEpochV3 {
@@ -797,10 +743,7 @@ pub struct ChangeEpochV3 {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SystemPackage {
@@ -829,10 +772,7 @@ pub struct SystemPackage {
 /// genesis-transaction = (vector genesis-object)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct GenesisTransaction {
@@ -855,10 +795,7 @@ pub struct GenesisTransaction {
 /// ptb = (vector input) (vector command)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ProgrammableTransaction {
@@ -1010,10 +947,7 @@ impl Command {
 /// transfer-objects = (vector argument) argument
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct TransferObjects {
@@ -1034,10 +968,7 @@ pub struct TransferObjects {
 /// split-coins = argument (vector argument)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SplitCoins {
@@ -1058,10 +989,7 @@ pub struct SplitCoins {
 /// merge-coins = argument (vector argument)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MergeCoins {
@@ -1085,10 +1013,7 @@ pub struct MergeCoins {
 ///           (vector object-id)    ; the set of package dependencies
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Publish {
@@ -1115,10 +1040,7 @@ pub struct Publish {
 /// make-move-vector = (option type-tag) (vector argument)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MakeMoveVector {
@@ -1146,10 +1068,7 @@ pub struct MakeMoveVector {
 ///           argument              ; upgrade ticket
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct Upgrade {
@@ -1272,10 +1191,7 @@ impl Argument {
 ///             (vector argument)   ; input arguments
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MoveCall {

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -15,7 +15,7 @@ mod transaction_kind {
         GenesisTransaction, ProgrammableTransaction, RandomnessStateUpdate, TransactionKind,
     };
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableTransactionKindRef<'a> {
         ProgrammableTransaction(&'a ProgrammableTransaction),
@@ -28,7 +28,7 @@ mod transaction_kind {
         RandomnessStateUpdate(&'a RandomnessStateUpdate),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     #[serde(rename = "TransactionKind")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -54,7 +54,7 @@ mod transaction_kind {
         }
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum BinaryTransactionKindRef<'a> {
         ProgrammableTransaction(&'a ProgrammableTransaction),
         Genesis(&'a GenesisTransaction),
@@ -63,7 +63,7 @@ mod transaction_kind {
         EndOfEpoch(&'a Vec<EndOfEpochTransactionKind>),
         RandomnessStateUpdate(&'a RandomnessStateUpdate),
     }
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum BinaryTransactionKind {
         ProgrammableTransaction(ProgrammableTransaction),
         Genesis(GenesisTransaction),
@@ -171,7 +171,7 @@ mod end_of_epoch {
         EndOfEpochTransactionKind,
     };
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
@@ -181,7 +181,7 @@ mod end_of_epoch {
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
@@ -191,7 +191,7 @@ mod end_of_epoch {
         AuthenticatorStateExpire(AuthenticatorStateExpire),
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum BinaryEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
@@ -200,7 +200,7 @@ mod end_of_epoch {
         AuthenticatorStateExpire(&'a AuthenticatorStateExpire),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum BinaryEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),
@@ -296,7 +296,7 @@ mod version_assignments {
     use super::*;
     use crate::transaction::{CancelledTransaction, ConsensusDeterminedVersionAssignments};
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions {
@@ -304,7 +304,7 @@ mod version_assignments {
         },
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
     enum ReadableConsensusDeterminedVersionAssignments {
         CancelledTransactions {
@@ -312,14 +312,14 @@ mod version_assignments {
         },
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions {
             cancelled_transactions: &'a Vec<CancelledTransaction>,
         },
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum BinaryConsensusDeterminedVersionAssignments {
         CancelledTransactions {
             cancelled_transactions: Vec<CancelledTransaction>,
@@ -387,7 +387,7 @@ mod input_argument {
     use super::*;
     use crate::transaction::Input;
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(tag = "type", rename_all = "snake_case")]
     enum ReadableInput {
         Pure {
@@ -404,13 +404,13 @@ mod input_argument {
         Receiving(ObjectReference),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum CallArg {
         Pure(#[serde(with = "::serde_with::As::<::serde_with::Bytes>")] Vec<u8>),
         Object(ObjectArg),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum ObjectArg {
         ImmutableOrOwned(ObjectReference),
         Shared {
@@ -517,7 +517,7 @@ mod input_argument {
 mod argument {
     use super::*;
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "Argument", untagged, rename_all = "lowercase")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     enum ReadableArgument {
@@ -531,7 +531,7 @@ mod argument {
         NestedResult { result: (u16, u16) },
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "lowercase")]
     enum Gas {
         Gas,
@@ -567,7 +567,7 @@ mod argument {
         }
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     enum BinaryArgument {
         Gas,
         Input(u16),
@@ -639,7 +639,7 @@ mod command {
         Upgrade,
     };
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     #[serde(tag = "command", rename_all = "snake_case")]
     enum ReadableCommandRef<'a> {
         MoveCall(&'a MoveCall),
@@ -651,7 +651,7 @@ mod command {
         Upgrade(&'a Upgrade),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     #[serde(tag = "command", rename_all = "snake_case")]
     enum ReadableCommand {
         MoveCall(MoveCall),
@@ -663,7 +663,7 @@ mod command {
         Upgrade(Upgrade),
     }
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     enum BinaryCommandRef<'a> {
         MoveCall(&'a MoveCall),
         TransferObjects(&'a TransferObjects),
@@ -674,7 +674,7 @@ mod command {
         Upgrade(&'a Upgrade),
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     enum BinaryCommand {
         MoveCall(MoveCall),
         TransferObjects(TransferObjects),
@@ -827,14 +827,14 @@ mod signed_transaction {
 
     pub(crate) struct SignedTransactionWithIntentMessage;
 
-    #[derive(serde_derive::Serialize)]
+    #[derive(serde::Serialize)]
     struct BinarySignedTransactionWithIntentMessageRef<'a> {
         #[serde(with = "::serde_with::As::<IntentMessageWrappedTransaction>")]
         transaction: &'a Transaction,
         signatures: &'a Vec<UserSignature>,
     }
 
-    #[derive(serde_derive::Deserialize)]
+    #[derive(serde::Deserialize)]
     struct BinarySignedTransactionWithIntentMessage {
         #[serde(with = "::serde_with::As::<IntentMessageWrappedTransaction>")]
         transaction: Transaction,
@@ -918,7 +918,7 @@ mod transaction_expiration {
 
     use crate::{EpochId, TransactionExpiration};
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "TransactionExpiration")]
     #[serde(rename_all = "lowercase")]
     enum ReadableTransactionExpiration {
@@ -929,7 +929,7 @@ mod transaction_expiration {
         ),
     }
 
-    #[derive(serde_derive::Serialize, serde_derive::Deserialize)]
+    #[derive(serde::Serialize, serde::Deserialize)]
     pub enum BinaryTransactionExpiration {
         /// The transaction has no expiration
         None,

--- a/crates/iota-sdk-types/src/type_tag/serialization.rs
+++ b/crates/iota-sdk-types/src/type_tag/serialization.rs
@@ -185,7 +185,7 @@ impl<'de> Visitor<'de> for TypeTagVisitor {
     }
 }
 
-#[derive(serde_derive::Serialize)]
+#[derive(serde::Serialize)]
 struct BinaryStructTagRef<'a> {
     address: &'a Address,
     module: &'a Identifier,
@@ -212,7 +212,7 @@ impl Serialize for StructTag {
     }
 }
 
-#[derive(serde_derive::Deserialize)]
+#[derive(serde::Deserialize)]
 struct BinaryStructTag {
     address: Address,
     module: Identifier,

--- a/crates/iota-sdk-types/src/validator.rs
+++ b/crates/iota-sdk-types/src/validator.rs
@@ -16,10 +16,7 @@ use crate::checkpoint::{EpochId, StakeUnit};
 ///                       (vector validator-committee-member)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ValidatorCommittee {
@@ -40,10 +37,7 @@ pub struct ValidatorCommittee {
 ///                              u64 ; stake
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ValidatorCommitteeMember {
@@ -73,10 +67,7 @@ pub struct ValidatorCommitteeMember {
 /// See [here](https://github.com/RoaringBitmap/RoaringFormatSpec) for the specification for the
 /// serialized format of RoaringBitmaps.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ValidatorAggregatedSignature {
@@ -145,10 +136,7 @@ impl<'de> serde_with::DeserializeAs<'de, Bls12381PublicKey> for BinaryValidatorP
 ///                       bls-signature
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ValidatorSignature {


### PR DESCRIPTION
## Description

Removes this unnecessary dependency, which is already contained in `serde`.