### PR TITLE
chore(ci): Allow publishing from checked out tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           cargo login ${{ secrets.CRATES_IO_TOKEN }}
 
           echo "Publishing $pkg at version $version"
-          cargo release publish -p "$pkg" --all-features --allow-branch develop --no-confirm --execute
+          cargo release publish -p "$pkg" --all-features --no-confirm --execute
 
           echo "Setting owners of $pkg"
-          cargo release owner -p "$pkg" --allow-branch develop --no-confirm --execute
+          cargo release owner -p "$pkg" --no-confirm --execute


### PR DESCRIPTION
## Description

Allows publishing from the checked out tag rather than develop, which fails.