### PR TITLE
chore(ci): Use the latest commit as the release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ env.TAG }}
           PKG: ${{ env.PKG }}
-        run: gh release create "$TAG" --title "$TAG" --draft --notes-file "crates/$PKG/CHANGELOG.md"
+        run: gh release create "$TAG" --title "$TAG" --target ${{ github.sha }} --draft --notes-file "crates/$PKG/CHANGELOG.md"


### PR DESCRIPTION
## Description

Use the latest commit rather than the branch as the release target