### PR TITLE
chore(ci): Use `head_ref` instead of `base_ref` for release branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   create-release:
-    if: github.event.pull_request == null || (github.event.pull_request.merged == true && startsWith(github.base_ref, 'release/'))
+    if: github.event.pull_request == null || (github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           PKG: ${{ env.PKG }}
           VERSION: ${{ env.VERSION }}
         run: |
-          if [ "$VERSION" =~ ".*-alpha\..*"  ] || [ "$VERSION" =~ ".*-beta\..*"  ] || [ "$VERSION" =~ ".*-rc\..*"  ]; then
+          if [ "$VERSION" =~ .*-alpha\..*  ] || [ "$VERSION" =~ .*-beta\..*  ] || [ "$VERSION" =~ .*-rc\..*  ]; then
             gh release create "$TAG" --title "$TAG" --target ${{ github.sha }} --draft --prerelease --notes-file "crates/$PKG/CHANGELOG.md"
           else
             gh release create "$TAG" --title "$TAG" --target ${{ github.sha }} --draft --notes-file "crates/$PKG/CHANGELOG.md"


### PR DESCRIPTION
## Description

Use `head_ref` instead of `base_ref` for release branch condition.