### PR TITLE
fix(iota-sdk-graphl-client-build): update iotaTotalSupply type from Int to BigInt

### DIFF
--- a/crates/iota-sdk-graphql-client-build/schema.graphql
+++ b/crates/iota-sdk-graphql-client-build/schema.graphql
@@ -1232,7 +1232,7 @@ type Epoch {
 	"""
 	The total IOTA supply.
 	"""
-	iotaTotalSupply: Int
+	iotaTotalSupply: BigInt
 	"""
 	The treasury-cap id.
 	"""


### PR DESCRIPTION
Update iotaTotalSupply type from Int to BigInt as Int was too small to fit the total supply

Fixes https://github.com/iotaledger/iota-rust-sdk/issues/411