### PR TITLE
feat(iota-sdk-crypto): add generate_mnemonic()

### DIFF
--- a/bindings/go/examples/generate_mnemonic/main.go
+++ b/bindings/go/examples/generate_mnemonic/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	mnemonic := iota_sdk.GenerateMnemonic(nil)
 	fmt.Println("24 word mnemonic:", mnemonic)
-	wordCount := iota_sdk.MnemonicWordCountWords12
+	wordCount := iota_sdk.MnemonicLengthWords12
 	mnemonic = iota_sdk.GenerateMnemonic(&wordCount)
 	fmt.Println("12 word mnemonic:", mnemonic)
 }

--- a/bindings/go/examples/generate_mnemonic/main.go
+++ b/bindings/go/examples/generate_mnemonic/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	mnemonic := iota_sdk.GenerateMnemonic(nil)
 	fmt.Println("24 word mnemonic:", mnemonic)
-	wordCount := iota_sdk.MnemonicWordCountTwelve
+	wordCount := iota_sdk.MnemonicWordCountWords12
 	mnemonic = iota_sdk.GenerateMnemonic(&wordCount)
 	fmt.Println("12 word mnemonic:", mnemonic)
 }

--- a/bindings/go/examples/generate_mnemonic/main.go
+++ b/bindings/go/examples/generate_mnemonic/main.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func main() {
+	mnemonic, err := iota_sdk.GenerateMnemonic(nil)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("Mnemonic:", mnemonic)
+}

--- a/bindings/go/examples/generate_mnemonic/main.go
+++ b/bindings/go/examples/generate_mnemonic/main.go
@@ -11,5 +11,8 @@ import (
 
 func main() {
 	mnemonic := iota_sdk.GenerateMnemonic(nil)
-	fmt.Println("Mnemonic:", mnemonic)
+	fmt.Println("24 word mnemonic:", mnemonic)
+	wordCount := iota_sdk.MnemonicWordCountTwelve
+	mnemonic = iota_sdk.GenerateMnemonic(&wordCount)
+	fmt.Println("12 word mnemonic:", mnemonic)
 }

--- a/bindings/go/examples/generate_mnemonic/main.go
+++ b/bindings/go/examples/generate_mnemonic/main.go
@@ -10,9 +10,6 @@ import (
 )
 
 func main() {
-	mnemonic, err := iota_sdk.GenerateMnemonic(nil)
-	if err != nil {
-		panic(err)
-	}
+	mnemonic := iota_sdk.GenerateMnemonic(nil)
 	fmt.Println("Mnemonic:", mnemonic)
 }

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -35252,8 +35252,8 @@ func (_ FfiDestroyerIdOperation) Destroy(value IdOperation) {
 type MnemonicWordCount uint
 
 const (
-	MnemonicWordCountTwelve MnemonicWordCount = 1
-	MnemonicWordCountTwentyFour MnemonicWordCount = 2
+	MnemonicWordCountWords12 MnemonicWordCount = 1
+	MnemonicWordCountWords24 MnemonicWordCount = 2
 )
 
 type FfiConverterMnemonicWordCount struct {}

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -1010,7 +1010,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic()
 	})
-	if checksum != 27063 {
+	if checksum != 58427 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic: UniFFI API checksum mismatch")
 	}
@@ -43002,6 +43002,8 @@ func GasPaymentToBcs(data GasPayment) ([]byte, error) {
 		}
 }
 
+// Generate a new BIP-39 mnemonic in English.
+// Supported word counts are 12, 15, 18, 21, and 24 (default).
 func GenerateMnemonic(wordCount *uint32) (string, error) {
 	_uniffiRV, _uniffiErr := rustCallWithError[SdkFfiError](FfiConverterSdkFfiError{},func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer {

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -1010,7 +1010,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic()
 	})
-	if checksum != 54158 {
+	if checksum != 15726 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic: UniFFI API checksum mismatch")
 	}
@@ -35249,36 +35249,36 @@ func (_ FfiDestroyerIdOperation) Destroy(value IdOperation) {
 }
 
 
-type MnemonicWordCount uint
+type MnemonicLength uint
 
 const (
-	MnemonicWordCountWords12 MnemonicWordCount = 1
-	MnemonicWordCountWords24 MnemonicWordCount = 2
+	MnemonicLengthWords12 MnemonicLength = 1
+	MnemonicLengthWords24 MnemonicLength = 2
 )
 
-type FfiConverterMnemonicWordCount struct {}
+type FfiConverterMnemonicLength struct {}
 
-var FfiConverterMnemonicWordCountINSTANCE = FfiConverterMnemonicWordCount{}
+var FfiConverterMnemonicLengthINSTANCE = FfiConverterMnemonicLength{}
 
-func (c FfiConverterMnemonicWordCount) Lift(rb RustBufferI) MnemonicWordCount {
-	return LiftFromRustBuffer[MnemonicWordCount](c, rb)
+func (c FfiConverterMnemonicLength) Lift(rb RustBufferI) MnemonicLength {
+	return LiftFromRustBuffer[MnemonicLength](c, rb)
 }
 
-func (c FfiConverterMnemonicWordCount) Lower(value MnemonicWordCount) C.RustBuffer {
-	return LowerIntoRustBuffer[MnemonicWordCount](c, value)
+func (c FfiConverterMnemonicLength) Lower(value MnemonicLength) C.RustBuffer {
+	return LowerIntoRustBuffer[MnemonicLength](c, value)
 }
-func (FfiConverterMnemonicWordCount) Read(reader io.Reader) MnemonicWordCount {
+func (FfiConverterMnemonicLength) Read(reader io.Reader) MnemonicLength {
 	id := readInt32(reader)
-	return MnemonicWordCount(id)
+	return MnemonicLength(id)
 }
 
-func (FfiConverterMnemonicWordCount) Write(writer io.Writer, value MnemonicWordCount) {
+func (FfiConverterMnemonicLength) Write(writer io.Writer, value MnemonicLength) {
 	writeInt32(writer, int32(value))
 }
 
-type FfiDestroyerMnemonicWordCount struct {}
+type FfiDestroyerMnemonicLength struct {}
 
-func (_ FfiDestroyerMnemonicWordCount) Destroy(value MnemonicWordCount) {
+func (_ FfiDestroyerMnemonicLength) Destroy(value MnemonicLength) {
 }
 
 
@@ -38326,40 +38326,40 @@ func (_ FfiDestroyerOptionalValidatorSet) Destroy(value *ValidatorSet) {
 	}
 }
 
-type FfiConverterOptionalMnemonicWordCount struct{}
+type FfiConverterOptionalMnemonicLength struct{}
 
-var FfiConverterOptionalMnemonicWordCountINSTANCE = FfiConverterOptionalMnemonicWordCount{}
+var FfiConverterOptionalMnemonicLengthINSTANCE = FfiConverterOptionalMnemonicLength{}
 
-func (c FfiConverterOptionalMnemonicWordCount) Lift(rb RustBufferI) *MnemonicWordCount {
-	return LiftFromRustBuffer[*MnemonicWordCount](c, rb)
+func (c FfiConverterOptionalMnemonicLength) Lift(rb RustBufferI) *MnemonicLength {
+	return LiftFromRustBuffer[*MnemonicLength](c, rb)
 }
 
-func (_ FfiConverterOptionalMnemonicWordCount) Read(reader io.Reader) *MnemonicWordCount {
+func (_ FfiConverterOptionalMnemonicLength) Read(reader io.Reader) *MnemonicLength {
 	if readInt8(reader) == 0 {
 		return nil
 	}
-	temp := FfiConverterMnemonicWordCountINSTANCE.Read(reader)
+	temp := FfiConverterMnemonicLengthINSTANCE.Read(reader)
 	return &temp
 }
 
-func (c FfiConverterOptionalMnemonicWordCount) Lower(value *MnemonicWordCount) C.RustBuffer {
-	return LowerIntoRustBuffer[*MnemonicWordCount](c, value)
+func (c FfiConverterOptionalMnemonicLength) Lower(value *MnemonicLength) C.RustBuffer {
+	return LowerIntoRustBuffer[*MnemonicLength](c, value)
 }
 
-func (_ FfiConverterOptionalMnemonicWordCount) Write(writer io.Writer, value *MnemonicWordCount) {
+func (_ FfiConverterOptionalMnemonicLength) Write(writer io.Writer, value *MnemonicLength) {
 	if value == nil {
 		writeInt8(writer, 0)
 	} else {
 		writeInt8(writer, 1)
-		FfiConverterMnemonicWordCountINSTANCE.Write(writer, *value)
+		FfiConverterMnemonicLengthINSTANCE.Write(writer, *value)
 	}
 }
 
-type FfiDestroyerOptionalMnemonicWordCount struct {}
+type FfiDestroyerOptionalMnemonicLength struct {}
 
-func (_ FfiDestroyerOptionalMnemonicWordCount) Destroy(value *MnemonicWordCount) {
+func (_ FfiDestroyerOptionalMnemonicLength) Destroy(value *MnemonicLength) {
 	if value != nil {
-		FfiDestroyerMnemonicWordCount{}.Destroy(*value)
+		FfiDestroyerMnemonicLength{}.Destroy(*value)
 	}
 }
 
@@ -43074,10 +43074,10 @@ func GasPaymentToBcs(data GasPayment) ([]byte, error) {
 
 // Generate a new BIP-39 mnemonic in English.
 // Supported word counts are 12 and 24 (default).
-func GenerateMnemonic(wordCount *MnemonicWordCount) string {
+func GenerateMnemonic(wordCount *MnemonicLength) string {
 	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer {
-		inner: C.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(FfiConverterOptionalMnemonicWordCountINSTANCE.Lower(wordCount),_uniffiStatus),
+		inner: C.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(FfiConverterOptionalMnemonicLengthINSTANCE.Lower(wordCount),_uniffiStatus),
 	}
 	}))
 }

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -1008,6 +1008,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic()
+	})
+	if checksum != 27063 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs()
 	})
 	if checksum != 15482 {
@@ -42990,6 +42999,20 @@ func GasPaymentToBcs(data GasPayment) ([]byte, error) {
 			return _uniffiDefaultValue, _uniffiErr
 		} else {
 			return FfiConverterBytesINSTANCE.Lift(_uniffiRV), nil
+		}
+}
+
+func GenerateMnemonic(wordCount *uint32) (string, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError[SdkFfiError](FfiConverterSdkFfiError{},func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer {
+		inner: C.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(FfiConverterOptionalUint32INSTANCE.Lower(wordCount),_uniffiStatus),
+	}
+	})
+		if _uniffiErr != nil {
+			var _uniffiDefaultValue string
+			return _uniffiDefaultValue, _uniffiErr
+		} else {
+			return FfiConverterStringINSTANCE.Lift(_uniffiRV), nil
 		}
 }
 

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -35249,11 +35249,11 @@ func (_ FfiDestroyerIdOperation) Destroy(value IdOperation) {
 }
 
 
-type MnemonicWordCount uint8
+type MnemonicWordCount uint
 
 const (
-	MnemonicWordCountTwelve MnemonicWordCount = 12
-	MnemonicWordCountTwentyFour MnemonicWordCount = 24
+	MnemonicWordCountTwelve MnemonicWordCount = 1
+	MnemonicWordCountTwentyFour MnemonicWordCount = 2
 )
 
 type FfiConverterMnemonicWordCount struct {}

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -1010,7 +1010,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic()
 	})
-	if checksum != 58427 {
+	if checksum != 54158 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic: UniFFI API checksum mismatch")
 	}
@@ -35249,6 +35249,39 @@ func (_ FfiDestroyerIdOperation) Destroy(value IdOperation) {
 }
 
 
+type MnemonicWordCount uint8
+
+const (
+	MnemonicWordCountTwelve MnemonicWordCount = 12
+	MnemonicWordCountTwentyFour MnemonicWordCount = 24
+)
+
+type FfiConverterMnemonicWordCount struct {}
+
+var FfiConverterMnemonicWordCountINSTANCE = FfiConverterMnemonicWordCount{}
+
+func (c FfiConverterMnemonicWordCount) Lift(rb RustBufferI) MnemonicWordCount {
+	return LiftFromRustBuffer[MnemonicWordCount](c, rb)
+}
+
+func (c FfiConverterMnemonicWordCount) Lower(value MnemonicWordCount) C.RustBuffer {
+	return LowerIntoRustBuffer[MnemonicWordCount](c, value)
+}
+func (FfiConverterMnemonicWordCount) Read(reader io.Reader) MnemonicWordCount {
+	id := readInt32(reader)
+	return MnemonicWordCount(id)
+}
+
+func (FfiConverterMnemonicWordCount) Write(writer io.Writer, value MnemonicWordCount) {
+	writeInt32(writer, int32(value))
+}
+
+type FfiDestroyerMnemonicWordCount struct {}
+
+func (_ FfiDestroyerMnemonicWordCount) Destroy(value MnemonicWordCount) {
+}
+
+
 type MoveAbility uint
 
 const (
@@ -38290,6 +38323,43 @@ type FfiDestroyerOptionalValidatorSet struct {}
 func (_ FfiDestroyerOptionalValidatorSet) Destroy(value *ValidatorSet) {
 	if value != nil {
 		FfiDestroyerValidatorSet{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalMnemonicWordCount struct{}
+
+var FfiConverterOptionalMnemonicWordCountINSTANCE = FfiConverterOptionalMnemonicWordCount{}
+
+func (c FfiConverterOptionalMnemonicWordCount) Lift(rb RustBufferI) *MnemonicWordCount {
+	return LiftFromRustBuffer[*MnemonicWordCount](c, rb)
+}
+
+func (_ FfiConverterOptionalMnemonicWordCount) Read(reader io.Reader) *MnemonicWordCount {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterMnemonicWordCountINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalMnemonicWordCount) Lower(value *MnemonicWordCount) C.RustBuffer {
+	return LowerIntoRustBuffer[*MnemonicWordCount](c, value)
+}
+
+func (_ FfiConverterOptionalMnemonicWordCount) Write(writer io.Writer, value *MnemonicWordCount) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterMnemonicWordCountINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalMnemonicWordCount struct {}
+
+func (_ FfiDestroyerOptionalMnemonicWordCount) Destroy(value *MnemonicWordCount) {
+	if value != nil {
+		FfiDestroyerMnemonicWordCount{}.Destroy(*value)
 	}
 }
 
@@ -43003,19 +43073,13 @@ func GasPaymentToBcs(data GasPayment) ([]byte, error) {
 }
 
 // Generate a new BIP-39 mnemonic in English.
-// Supported word counts are 12, 15, 18, 21, and 24 (default).
-func GenerateMnemonic(wordCount *uint32) (string, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[SdkFfiError](FfiConverterSdkFfiError{},func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+// Supported word counts are 12 and 24 (default).
+func GenerateMnemonic(wordCount *MnemonicWordCount) string {
+	return FfiConverterStringINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer {
-		inner: C.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(FfiConverterOptionalUint32INSTANCE.Lower(wordCount),_uniffiStatus),
+		inner: C.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(FfiConverterOptionalMnemonicWordCountINSTANCE.Lower(wordCount),_uniffiStatus),
 	}
-	})
-		if _uniffiErr != nil {
-			var _uniffiDefaultValue string
-			return _uniffiDefaultValue, _uniffiErr
-		} else {
-			return FfiConverterStringINSTANCE.Lift(_uniffiRV), nil
-		}
+	}))
 }
 
 // Create this type from BCS encoded bytes.

--- a/bindings/go/iota_sdk/iota_sdk.h
+++ b/bindings/go/iota_sdk/iota_sdk.h
@@ -6163,6 +6163,11 @@ RustBuffer uniffi_iota_sdk_ffi_fn_func_gas_payment_from_bcs(RustBuffer bcs, Rust
 RustBuffer uniffi_iota_sdk_ffi_fn_func_gas_payment_to_bcs(RustBuffer data, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FUNC_GENERATE_MNEMONIC
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FUNC_GENERATE_MNEMONIC
+RustBuffer uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(RustBuffer word_count, RustCallStatus *out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FUNC_GENESIS_OBJECT_FROM_BCS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FUNC_GENESIS_OBJECT_FROM_BCS
 void* uniffi_iota_sdk_ffi_fn_func_genesis_object_from_bcs(RustBuffer bcs, RustCallStatus *out_status
@@ -7622,6 +7627,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_func_gas_payment_from_bcs(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_FUNC_GAS_PAYMENT_TO_BCS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_FUNC_GAS_PAYMENT_TO_BCS
 uint16_t uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_FUNC_GENERATE_MNEMONIC
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_FUNC_GENERATE_MNEMONIC
+uint16_t uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic(void
     
 );
 #endif

--- a/bindings/kotlin/examples/GenerateMnemonic.kt
+++ b/bindings/kotlin/examples/GenerateMnemonic.kt
@@ -1,10 +1,13 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+import iota_sdk.MnemonicWordCount
 import iota_sdk.generateMnemonic
 import kotlin.io.println
 
 fun main() {
     val mnemonic = generateMnemonic(null)
-    println("Mnemonic: $mnemonic")
+    println("24 word mnemonic: $mnemonic")
+    val mnemonic12 = generateMnemonic(MnemonicWordCount.TWELVE)
+    println("12 word mnemonic: $mnemonic12")
 }

--- a/bindings/kotlin/examples/GenerateMnemonic.kt
+++ b/bindings/kotlin/examples/GenerateMnemonic.kt
@@ -8,6 +8,6 @@ import kotlin.io.println
 fun main() {
     val mnemonic = generateMnemonic(null)
     println("24 word mnemonic: $mnemonic")
-    val mnemonic12 = generateMnemonic(MnemonicWordCount.TWELVE)
+    val mnemonic12 = generateMnemonic(MnemonicWordCount.WORDS12)
     println("12 word mnemonic: $mnemonic12")
 }

--- a/bindings/kotlin/examples/GenerateMnemonic.kt
+++ b/bindings/kotlin/examples/GenerateMnemonic.kt
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.generateMnemonic
+import kotlin.io.println
+
+fun main() {
+    val mnemonic = generateMnemonic(null)
+    println("Mnemonic: $mnemonic")
+}

--- a/bindings/kotlin/examples/GenerateMnemonic.kt
+++ b/bindings/kotlin/examples/GenerateMnemonic.kt
@@ -1,13 +1,13 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import iota_sdk.MnemonicWordCount
+import iota_sdk.MnemonicLength
 import iota_sdk.generateMnemonic
 import kotlin.io.println
 
 fun main() {
     val mnemonic = generateMnemonic(null)
     println("24 word mnemonic: $mnemonic")
-    val mnemonic12 = generateMnemonic(MnemonicWordCount.WORDS12)
+    val mnemonic12 = generateMnemonic(MnemonicLength.WORDS12)
     println("12 word mnemonic: $mnemonic12")
 }

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -8205,7 +8205,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 27063.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 58427.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482.toShort()) {
@@ -64099,6 +64099,10 @@ public typealias FfiConverterTypeValue = FfiConverterString
     }
     
 
+        /**
+         * Generate a new BIP-39 mnemonic in English.
+         * Supported word counts are 12, 15, 18, 21, and 24 (default).
+         */
     @Throws(SdkFfiException::class) fun `generateMnemonic`(`wordCount`: kotlin.UInt?): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCallWithError(SdkFfiException) { _status ->

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -57649,8 +57649,8 @@ public object FfiConverterTypeIdOperation: FfiConverterRustBuffer<IdOperation> {
 
 enum class MnemonicWordCount {
     
-    TWELVE,
-    TWENTY_FOUR;
+    WORDS12,
+    WORDS24;
     companion object
 }
 

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -57647,10 +57647,10 @@ public object FfiConverterTypeIdOperation: FfiConverterRustBuffer<IdOperation> {
 
 
 
-enum class MnemonicWordCount(val value: kotlin.UByte) {
+enum class MnemonicWordCount {
     
-    TWELVE(12u),
-    TWENTY_FOUR(24u);
+    TWELVE,
+    TWENTY_FOUR;
     companion object
 }
 

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -8205,7 +8205,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 54158.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 15726.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482.toShort()) {
@@ -57647,7 +57647,7 @@ public object FfiConverterTypeIdOperation: FfiConverterRustBuffer<IdOperation> {
 
 
 
-enum class MnemonicWordCount {
+enum class MnemonicLength {
     
     WORDS12,
     WORDS24;
@@ -57658,16 +57658,16 @@ enum class MnemonicWordCount {
 /**
  * @suppress
  */
-public object FfiConverterTypeMnemonicWordCount: FfiConverterRustBuffer<MnemonicWordCount> {
+public object FfiConverterTypeMnemonicLength: FfiConverterRustBuffer<MnemonicLength> {
     override fun read(buf: ByteBuffer) = try {
-        MnemonicWordCount.values()[buf.getInt() - 1]
+        MnemonicLength.values()[buf.getInt() - 1]
     } catch (e: IndexOutOfBoundsException) {
         throw RuntimeException("invalid enum value, something is very wrong!!", e)
     }
 
-    override fun allocationSize(value: MnemonicWordCount) = 4UL
+    override fun allocationSize(value: MnemonicLength) = 4UL
 
-    override fun write(value: MnemonicWordCount, buf: ByteBuffer) {
+    override fun write(value: MnemonicLength, buf: ByteBuffer) {
         buf.putInt(value.ordinal + 1)
     }
 }
@@ -60645,28 +60645,28 @@ public object FfiConverterOptionalTypeValidatorSet: FfiConverterRustBuffer<Valid
 /**
  * @suppress
  */
-public object FfiConverterOptionalTypeMnemonicWordCount: FfiConverterRustBuffer<MnemonicWordCount?> {
-    override fun read(buf: ByteBuffer): MnemonicWordCount? {
+public object FfiConverterOptionalTypeMnemonicLength: FfiConverterRustBuffer<MnemonicLength?> {
+    override fun read(buf: ByteBuffer): MnemonicLength? {
         if (buf.get().toInt() == 0) {
             return null
         }
-        return FfiConverterTypeMnemonicWordCount.read(buf)
+        return FfiConverterTypeMnemonicLength.read(buf)
     }
 
-    override fun allocationSize(value: MnemonicWordCount?): ULong {
+    override fun allocationSize(value: MnemonicLength?): ULong {
         if (value == null) {
             return 1UL
         } else {
-            return 1UL + FfiConverterTypeMnemonicWordCount.allocationSize(value)
+            return 1UL + FfiConverterTypeMnemonicLength.allocationSize(value)
         }
     }
 
-    override fun write(value: MnemonicWordCount?, buf: ByteBuffer) {
+    override fun write(value: MnemonicLength?, buf: ByteBuffer) {
         if (value == null) {
             buf.put(0)
         } else {
             buf.put(1)
-            FfiConverterTypeMnemonicWordCount.write(value, buf)
+            FfiConverterTypeMnemonicLength.write(value, buf)
         }
     }
 }
@@ -64164,11 +64164,11 @@ public typealias FfiConverterTypeValue = FfiConverterString
         /**
          * Generate a new BIP-39 mnemonic in English.
          * Supported word counts are 12 and 24 (default).
-         */ fun `generateMnemonic`(`wordCount`: MnemonicWordCount?): kotlin.String {
+         */ fun `generateMnemonic`(`wordCount`: MnemonicLength?): kotlin.String {
             return FfiConverterString.lift(
     uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(
-        FfiConverterOptionalTypeMnemonicWordCount.lower(`wordCount`),_status)
+        FfiConverterOptionalTypeMnemonicLength.lower(`wordCount`),_status)
 }
     )
     }

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -8205,7 +8205,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 58427.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 54158.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482.toShort()) {
@@ -57647,6 +57647,36 @@ public object FfiConverterTypeIdOperation: FfiConverterRustBuffer<IdOperation> {
 
 
 
+enum class MnemonicWordCount(val value: kotlin.UByte) {
+    
+    TWELVE(12u),
+    TWENTY_FOUR(24u);
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeMnemonicWordCount: FfiConverterRustBuffer<MnemonicWordCount> {
+    override fun read(buf: ByteBuffer) = try {
+        MnemonicWordCount.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: MnemonicWordCount) = 4UL
+
+    override fun write(value: MnemonicWordCount, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
+
 enum class MoveAbility {
     
     COPY,
@@ -60605,6 +60635,38 @@ public object FfiConverterOptionalTypeValidatorSet: FfiConverterRustBuffer<Valid
         } else {
             buf.put(1)
             FfiConverterTypeValidatorSet.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterOptionalTypeMnemonicWordCount: FfiConverterRustBuffer<MnemonicWordCount?> {
+    override fun read(buf: ByteBuffer): MnemonicWordCount? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeMnemonicWordCount.read(buf)
+    }
+
+    override fun allocationSize(value: MnemonicWordCount?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeMnemonicWordCount.allocationSize(value)
+        }
+    }
+
+    override fun write(value: MnemonicWordCount?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeMnemonicWordCount.write(value, buf)
         }
     }
 }
@@ -64101,13 +64163,12 @@ public typealias FfiConverterTypeValue = FfiConverterString
 
         /**
          * Generate a new BIP-39 mnemonic in English.
-         * Supported word counts are 12, 15, 18, 21, and 24 (default).
-         */
-    @Throws(SdkFfiException::class) fun `generateMnemonic`(`wordCount`: kotlin.UInt?): kotlin.String {
+         * Supported word counts are 12 and 24 (default).
+         */ fun `generateMnemonic`(`wordCount`: MnemonicWordCount?): kotlin.String {
             return FfiConverterString.lift(
-    uniffiRustCallWithError(SdkFfiException) { _status ->
+    uniffiRustCall() { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(
-        FfiConverterOptionalUInt.lower(`wordCount`),_status)
+        FfiConverterOptionalTypeMnemonicWordCount.lower(`wordCount`),_status)
 }
     )
     }

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -3077,6 +3077,8 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -3235,6 +3237,8 @@ fun uniffi_iota_sdk_ffi_checksum_func_gas_cost_summary_to_bcs(
 fun uniffi_iota_sdk_ffi_checksum_func_gas_payment_from_bcs(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs(
+): Short
+fun uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs(
 ): Short
@@ -7557,6 +7561,8 @@ fun uniffi_iota_sdk_ffi_fn_func_gas_payment_from_bcs(`bcs`: RustBuffer.ByValue,u
 ): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_func_gas_payment_to_bcs(`data`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
+fun uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(`wordCount`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_func_genesis_object_from_bcs(`bcs`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_func_genesis_object_to_bcs(`data`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -8197,6 +8203,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 27063.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482.toShort()) {
@@ -64085,6 +64094,16 @@ public typealias FfiConverterTypeValue = FfiConverterString
     uniffiRustCallWithError(SdkFfiException) { _status ->
     UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_func_gas_payment_to_bcs(
         FfiConverterTypeGasPayment.lower(`data`),_status)
+}
+    )
+    }
+    
+
+    @Throws(SdkFfiException::class) fun `generateMnemonic`(`wordCount`: kotlin.UInt?): kotlin.String {
+            return FfiConverterString.lift(
+    uniffiRustCallWithError(SdkFfiException) { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic(
+        FfiConverterOptionalUInt.lower(`wordCount`),_status)
 }
     )
     }

--- a/bindings/python/examples/generate_mnemonic.py
+++ b/bindings/python/examples/generate_mnemonic.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2025 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-from lib.iota_sdk_ffi import generate_mnemonic
+from lib.iota_sdk_ffi import generate_mnemonic, MnemonicWordCount
 
 
 def main():
     mnemonic = generate_mnemonic(None)
-    print("Mnemonic:", mnemonic)
+    print("24 word mnemonic:", mnemonic)
+    mnemonic = generate_mnemonic(MnemonicWordCount.TWELVE)
+    print("12 word mnemonic:", mnemonic)
 
 
 if __name__ == "__main__":

--- a/bindings/python/examples/generate_mnemonic.py
+++ b/bindings/python/examples/generate_mnemonic.py
@@ -7,7 +7,7 @@ from lib.iota_sdk_ffi import generate_mnemonic, MnemonicWordCount
 def main():
     mnemonic = generate_mnemonic(None)
     print("24 word mnemonic:", mnemonic)
-    mnemonic = generate_mnemonic(MnemonicWordCount.TWELVE)
+    mnemonic = generate_mnemonic(MnemonicWordCount.WORDS12)
     print("12 word mnemonic:", mnemonic)
 
 

--- a/bindings/python/examples/generate_mnemonic.py
+++ b/bindings/python/examples/generate_mnemonic.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2025 IOTA Stiftung
 # SPDX-License-Identifier: Apache-2.0
 
-from lib.iota_sdk_ffi import generate_mnemonic, MnemonicWordCount
+from lib.iota_sdk_ffi import generate_mnemonic, MnemonicLength
 
 
 def main():
     mnemonic = generate_mnemonic(None)
     print("24 word mnemonic:", mnemonic)
-    mnemonic = generate_mnemonic(MnemonicWordCount.WORDS12)
+    mnemonic = generate_mnemonic(MnemonicLength.WORDS12)
     print("12 word mnemonic:", mnemonic)
 
 

--- a/bindings/python/examples/generate_mnemonic.py
+++ b/bindings/python/examples/generate_mnemonic.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk_ffi import generate_mnemonic
+
+
+def main():
+    mnemonic = generate_mnemonic(None)
+    print("Mnemonic:", mnemonic)
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -605,6 +605,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 27063:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_to_bcs() != 63349:
@@ -8652,6 +8654,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_func_gas_payment_to_bcs.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_func_gas_payment_to_bcs.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic.argtypes = (
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_iota_sdk_ffi_fn_func_genesis_object_from_bcs.argtypes = (
     _UniffiRustBuffer,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -9886,6 +9893,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_from_bcs.restype = ctyp
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs.restype = ctypes.c_uint16
@@ -48448,6 +48458,13 @@ def gas_payment_to_bcs(data: "GasPayment") -> "bytes":
         _UniffiConverterTypeGasPayment.lower(data)))
 
 
+def generate_mnemonic(word_count: "typing.Optional[int]") -> "str":
+    _UniffiConverterOptionalUInt32.check_lower(word_count)
+    
+    return _UniffiConverterString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeSdkFfiError,_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic,
+        _UniffiConverterOptionalUInt32.lower(word_count)))
+
+
 def genesis_object_from_bcs(bcs: "bytes") -> "GenesisObject":
     """
     Create this type from BCS encoded bytes.
@@ -50264,6 +50281,7 @@ __all__ = [
     "gas_cost_summary_to_bcs",
     "gas_payment_from_bcs",
     "gas_payment_to_bcs",
+    "generate_mnemonic",
     "genesis_object_from_bcs",
     "genesis_object_to_bcs",
     "genesis_transaction_from_bcs",

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -605,7 +605,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 27063:
+    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 58427:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -48459,6 +48459,11 @@ def gas_payment_to_bcs(data: "GasPayment") -> "bytes":
 
 
 def generate_mnemonic(word_count: "typing.Optional[int]") -> "str":
+    """
+    Generate a new BIP-39 mnemonic in English.
+    Supported word counts are 12, 15, 18, 21, and 24 (default).
+    """
+
     _UniffiConverterOptionalUInt32.check_lower(word_count)
     
     return _UniffiConverterString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeSdkFfiError,_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic,

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -605,7 +605,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 54158:
+    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 15726:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -20915,36 +20915,36 @@ class _UniffiConverterTypeIdOperation(_UniffiConverterRustBuffer):
 
 
 
-class MnemonicWordCount(enum.Enum):
+class MnemonicLength(enum.Enum):
     WORDS12 = 12
     
     WORDS24 = 24
     
 
 
-class _UniffiConverterTypeMnemonicWordCount(_UniffiConverterRustBuffer):
+class _UniffiConverterTypeMnemonicLength(_UniffiConverterRustBuffer):
     @staticmethod
     def read(buf):
         variant = buf.read_i32()
         if variant == 1:
-            return MnemonicWordCount.WORDS12
+            return MnemonicLength.WORDS12
         if variant == 2:
-            return MnemonicWordCount.WORDS24
+            return MnemonicLength.WORDS24
         raise InternalError("Raw enum value doesn't match any cases")
 
     @staticmethod
     def check_lower(value):
-        if value == MnemonicWordCount.WORDS12:
+        if value == MnemonicLength.WORDS12:
             return
-        if value == MnemonicWordCount.WORDS24:
+        if value == MnemonicLength.WORDS24:
             return
         raise ValueError(value)
 
     @staticmethod
     def write(value, buf):
-        if value == MnemonicWordCount.WORDS12:
+        if value == MnemonicLength.WORDS12:
             buf.write_i32(1)
-        if value == MnemonicWordCount.WORDS24:
+        if value == MnemonicLength.WORDS24:
             buf.write_i32(2)
 
 
@@ -23998,11 +23998,11 @@ class _UniffiConverterOptionalTypeValidatorSet(_UniffiConverterRustBuffer):
 
 
 
-class _UniffiConverterOptionalTypeMnemonicWordCount(_UniffiConverterRustBuffer):
+class _UniffiConverterOptionalTypeMnemonicLength(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
         if value is not None:
-            _UniffiConverterTypeMnemonicWordCount.check_lower(value)
+            _UniffiConverterTypeMnemonicLength.check_lower(value)
 
     @classmethod
     def write(cls, value, buf):
@@ -24011,7 +24011,7 @@ class _UniffiConverterOptionalTypeMnemonicWordCount(_UniffiConverterRustBuffer):
             return
 
         buf.write_u8(1)
-        _UniffiConverterTypeMnemonicWordCount.write(value, buf)
+        _UniffiConverterTypeMnemonicLength.write(value, buf)
 
     @classmethod
     def read(cls, buf):
@@ -24019,7 +24019,7 @@ class _UniffiConverterOptionalTypeMnemonicWordCount(_UniffiConverterRustBuffer):
         if flag == 0:
             return None
         elif flag == 1:
-            return _UniffiConverterTypeMnemonicWordCount.read(buf)
+            return _UniffiConverterTypeMnemonicLength.read(buf)
         else:
             raise InternalError("Unexpected flag byte for optional type")
 
@@ -48523,16 +48523,16 @@ def gas_payment_to_bcs(data: "GasPayment") -> "bytes":
         _UniffiConverterTypeGasPayment.lower(data)))
 
 
-def generate_mnemonic(word_count: "typing.Optional[MnemonicWordCount]") -> "str":
+def generate_mnemonic(word_count: "typing.Optional[MnemonicLength]") -> "str":
     """
     Generate a new BIP-39 mnemonic in English.
     Supported word counts are 12 and 24 (default).
     """
 
-    _UniffiConverterOptionalTypeMnemonicWordCount.check_lower(word_count)
+    _UniffiConverterOptionalTypeMnemonicLength.check_lower(word_count)
     
     return _UniffiConverterString.lift(_uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic,
-        _UniffiConverterOptionalTypeMnemonicWordCount.lower(word_count)))
+        _UniffiConverterOptionalTypeMnemonicLength.lower(word_count)))
 
 
 def genesis_object_from_bcs(bcs: "bytes") -> "GenesisObject":
@@ -50186,7 +50186,7 @@ __all__ = [
     "ExecutionStatus",
     "Feature",
     "IdOperation",
-    "MnemonicWordCount",
+    "MnemonicLength",
     "MoveAbility",
     "MoveVisibility",
     "NameFormat",

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -605,7 +605,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_gas_payment_to_bcs() != 2681:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 58427:
+    if lib.uniffi_iota_sdk_ffi_checksum_func_generate_mnemonic() != 54158:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_func_genesis_object_from_bcs() != 15482:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -20915,6 +20915,44 @@ class _UniffiConverterTypeIdOperation(_UniffiConverterRustBuffer):
 
 
 
+class MnemonicWordCount(enum.Enum):
+    TWELVE = 12
+    
+    TWENTY_FOUR = 24
+    
+
+
+class _UniffiConverterTypeMnemonicWordCount(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        variant = buf.read_i32()
+        if variant == 1:
+            return MnemonicWordCount.TWELVE
+        if variant == 2:
+            return MnemonicWordCount.TWENTY_FOUR
+        raise InternalError("Raw enum value doesn't match any cases")
+
+    @staticmethod
+    def check_lower(value):
+        if value == MnemonicWordCount.TWELVE:
+            return
+        if value == MnemonicWordCount.TWENTY_FOUR:
+            return
+        raise ValueError(value)
+
+    @staticmethod
+    def write(value, buf):
+        if value == MnemonicWordCount.TWELVE:
+            buf.write_i32(1)
+        if value == MnemonicWordCount.TWENTY_FOUR:
+            buf.write_i32(2)
+
+
+
+
+
+
+
 class MoveAbility(enum.Enum):
     COPY = 0
     
@@ -23955,6 +23993,33 @@ class _UniffiConverterOptionalTypeValidatorSet(_UniffiConverterRustBuffer):
             return None
         elif flag == 1:
             return _UniffiConverterTypeValidatorSet.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
+class _UniffiConverterOptionalTypeMnemonicWordCount(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeMnemonicWordCount.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeMnemonicWordCount.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeMnemonicWordCount.read(buf)
         else:
             raise InternalError("Unexpected flag byte for optional type")
 
@@ -48458,16 +48523,16 @@ def gas_payment_to_bcs(data: "GasPayment") -> "bytes":
         _UniffiConverterTypeGasPayment.lower(data)))
 
 
-def generate_mnemonic(word_count: "typing.Optional[int]") -> "str":
+def generate_mnemonic(word_count: "typing.Optional[MnemonicWordCount]") -> "str":
     """
     Generate a new BIP-39 mnemonic in English.
-    Supported word counts are 12, 15, 18, 21, and 24 (default).
+    Supported word counts are 12 and 24 (default).
     """
 
-    _UniffiConverterOptionalUInt32.check_lower(word_count)
+    _UniffiConverterOptionalTypeMnemonicWordCount.check_lower(word_count)
     
-    return _UniffiConverterString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeSdkFfiError,_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic,
-        _UniffiConverterOptionalUInt32.lower(word_count)))
+    return _UniffiConverterString.lift(_uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_func_generate_mnemonic,
+        _UniffiConverterOptionalTypeMnemonicWordCount.lower(word_count)))
 
 
 def genesis_object_from_bcs(bcs: "bytes") -> "GenesisObject":
@@ -50121,6 +50186,7 @@ __all__ = [
     "ExecutionStatus",
     "Feature",
     "IdOperation",
+    "MnemonicWordCount",
     "MoveAbility",
     "MoveVisibility",
     "NameFormat",

--- a/bindings/python/lib/iota_sdk_ffi.py
+++ b/bindings/python/lib/iota_sdk_ffi.py
@@ -20916,9 +20916,9 @@ class _UniffiConverterTypeIdOperation(_UniffiConverterRustBuffer):
 
 
 class MnemonicWordCount(enum.Enum):
-    TWELVE = 12
+    WORDS12 = 12
     
-    TWENTY_FOUR = 24
+    WORDS24 = 24
     
 
 
@@ -20927,24 +20927,24 @@ class _UniffiConverterTypeMnemonicWordCount(_UniffiConverterRustBuffer):
     def read(buf):
         variant = buf.read_i32()
         if variant == 1:
-            return MnemonicWordCount.TWELVE
+            return MnemonicWordCount.WORDS12
         if variant == 2:
-            return MnemonicWordCount.TWENTY_FOUR
+            return MnemonicWordCount.WORDS24
         raise InternalError("Raw enum value doesn't match any cases")
 
     @staticmethod
     def check_lower(value):
-        if value == MnemonicWordCount.TWELVE:
+        if value == MnemonicWordCount.WORDS12:
             return
-        if value == MnemonicWordCount.TWENTY_FOUR:
+        if value == MnemonicWordCount.WORDS24:
             return
         raise ValueError(value)
 
     @staticmethod
     def write(value, buf):
-        if value == MnemonicWordCount.TWELVE:
+        if value == MnemonicWordCount.WORDS12:
             buf.write_i32(1)
-        if value == MnemonicWordCount.TWENTY_FOUR:
+        if value == MnemonicWordCount.WORDS24:
             buf.write_i32(2)
 
 

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -98,7 +98,7 @@ bech32 = { version = "0.11.0", optional = true }
 
 # mnemonic support
 bip32 = { version = "0.5.3", optional = true }
-bip39 = { version = "2.0.0", optional = true }
+bip39 = { version = "2.0.0", features = ["rand"], optional = true }
 slip10_ed25519 = { version = "0.1.3", optional = true }
 
 [dev-dependencies]

--- a/crates/iota-sdk-crypto/src/lib.rs
+++ b/crates/iota-sdk-crypto/src/lib.rs
@@ -43,6 +43,10 @@ pub mod validator;
 #[cfg_attr(doc_cfg, doc(cfg(feature = "ed25519")))]
 pub mod ed25519;
 
+#[cfg(feature = "mnemonic")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "mnemonic")))]
+pub mod mnemonic;
+
 #[cfg(feature = "secp256k1")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -12,8 +12,8 @@ pub enum MnemonicWordCount {
 
 /// Generate a new BIP-39 mnemonic in English.
 /// Supported word counts are 12 and 24 (default).
-pub fn generate_mnemonic(word_count: Option<MnemonicWordCount>) -> String {
-    let count = word_count.unwrap_or(MnemonicWordCount::TwentyFour) as usize;
+pub fn generate_mnemonic(word_count: impl Into<Option<MnemonicWordCount>>) -> String {
+    let count = word_count.into().unwrap_or(MnemonicWordCount::TwentyFour) as usize;
     Mnemonic::generate(count)
         .expect("mnemonic generation failed") // Safe to unwrap since the word count is controlled
         .to_string()

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use bip39::Mnemonic;
+
+use crate::PrivateKeyError;
+
+const DEFAULT_WORD_COUNT: usize = 24;
+
+/// Generate a new BIP-39 mnemonic in English.
+/// Supported word counts are 12, 15, 18, 21, and 24 (default).
+pub fn generate_mnemonic(word_count: Option<usize>) -> Result<String, PrivateKeyError> {
+    Ok(Mnemonic::generate(word_count.unwrap_or(DEFAULT_WORD_COUNT))?.to_string())
+}

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -5,15 +5,15 @@ use bip39::Mnemonic;
 
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
-pub enum MnemonicWordCount {
+pub enum MnemonicLength {
     Words12 = 12,
     Words24 = 24,
 }
 
 /// Generate a new BIP-39 mnemonic in English.
 /// Supported word counts are 12 and 24 (default).
-pub fn generate_mnemonic(word_count: impl Into<Option<MnemonicWordCount>>) -> String {
-    let count = word_count.into().unwrap_or(MnemonicWordCount::Words24) as usize;
+pub fn generate_mnemonic(word_count: impl Into<Option<MnemonicLength>>) -> String {
+    let count = word_count.into().unwrap_or(MnemonicLength::Words24) as usize;
     Mnemonic::generate(count)
         .expect("mnemonic generation failed") // Safe to unwrap since the word count is controlled
         .to_string()

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -3,12 +3,17 @@
 
 use bip39::Mnemonic;
 
-use crate::PrivateKeyError;
-
-const DEFAULT_WORD_COUNT: usize = 24;
+#[derive(Debug, Clone, Copy)]
+pub enum MnemonicWordCount {
+    Twelve = 12,
+    TwentyFour = 24,
+}
 
 /// Generate a new BIP-39 mnemonic in English.
-/// Supported word counts are 12, 15, 18, 21, and 24 (default).
-pub fn generate_mnemonic(word_count: Option<usize>) -> Result<String, PrivateKeyError> {
-    Ok(Mnemonic::generate(word_count.unwrap_or(DEFAULT_WORD_COUNT))?.to_string())
+/// Supported word counts are 12 and 24 (default).
+pub fn generate_mnemonic(word_count: Option<MnemonicWordCount>) -> String {
+    let count = word_count.unwrap_or(MnemonicWordCount::TwentyFour) as usize;
+    Mnemonic::generate(count)
+        .expect("mnemonic generation failed") // Safe to unwrap since the word count is controlled
+        .to_string()
 }

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -6,14 +6,14 @@ use bip39::Mnemonic;
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub enum MnemonicWordCount {
-    Twelve = 12,
-    TwentyFour = 24,
+    Words12 = 12,
+    Words24 = 24,
 }
 
 /// Generate a new BIP-39 mnemonic in English.
 /// Supported word counts are 12 and 24 (default).
 pub fn generate_mnemonic(word_count: impl Into<Option<MnemonicWordCount>>) -> String {
-    let count = word_count.into().unwrap_or(MnemonicWordCount::TwentyFour) as usize;
+    let count = word_count.into().unwrap_or(MnemonicWordCount::Words24) as usize;
     Mnemonic::generate(count)
         .expect("mnemonic generation failed") // Safe to unwrap since the word count is controlled
         .to_string()

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -4,6 +4,7 @@
 use bip39::Mnemonic;
 
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum MnemonicWordCount {
     Twelve = 12,
     TwentyFour = 24,

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -6,7 +6,7 @@ use iota_sdk::crypto::mnemonic::MnemonicWordCount;
 use crate::error::Result;
 
 #[uniffi::remote(Enum)]
-#[repr(u8)]
+#[non_exhaustive]
 pub enum MnemonicWordCount {
     Twelve = 12,
     TwentyFour = 24,

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -3,6 +3,8 @@
 
 use crate::error::Result;
 
+/// Generate a new BIP-39 mnemonic in English.
+/// Supported word counts are 12, 15, 18, 21, and 24 (default).
 #[uniffi::export]
 pub fn generate_mnemonic(word_count: Option<u32>) -> Result<String> {
     let word_count = word_count.map(|w| w as usize);

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -8,8 +8,8 @@ use crate::error::Result;
 #[uniffi::remote(Enum)]
 #[non_exhaustive]
 pub enum MnemonicWordCount {
-    Twelve = 12,
-    TwentyFour = 24,
+    Words12 = 12,
+    Words24 = 24,
 }
 
 /// Generate a new BIP-39 mnemonic in English.

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -1,12 +1,20 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use iota_sdk::crypto::mnemonic::MnemonicWordCount;
+
 use crate::error::Result;
 
+#[uniffi::remote(Enum)]
+#[repr(u8)]
+pub enum MnemonicWordCount {
+    Twelve = 12,
+    TwentyFour = 24,
+}
+
 /// Generate a new BIP-39 mnemonic in English.
-/// Supported word counts are 12, 15, 18, 21, and 24 (default).
+/// Supported word counts are 12 and 24 (default).
 #[uniffi::export]
-pub fn generate_mnemonic(word_count: Option<u32>) -> Result<String> {
-    let word_count = word_count.map(|w| w as usize);
-    Ok(iota_sdk::crypto::mnemonic::generate_mnemonic(word_count)?)
+pub fn generate_mnemonic(word_count: Option<MnemonicWordCount>) -> String {
+    iota_sdk::crypto::mnemonic::generate_mnemonic(word_count)
 }

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::Result;
+
+#[uniffi::export]
+pub fn generate_mnemonic(word_count: Option<u32>) -> Result<String> {
+    let word_count = word_count.map(|w| w as usize);
+    Ok(iota_sdk::crypto::mnemonic::generate_mnemonic(word_count)?)
+}

--- a/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mnemonic.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk::crypto::mnemonic::MnemonicWordCount;
+use iota_sdk::crypto::mnemonic::MnemonicLength;
 
 use crate::error::Result;
 
 #[uniffi::remote(Enum)]
 #[non_exhaustive]
-pub enum MnemonicWordCount {
+pub enum MnemonicLength {
     Words12 = 12,
     Words24 = 24,
 }
@@ -15,6 +15,6 @@ pub enum MnemonicWordCount {
 /// Generate a new BIP-39 mnemonic in English.
 /// Supported word counts are 12 and 24 (default).
 #[uniffi::export]
-pub fn generate_mnemonic(word_count: Option<MnemonicWordCount>) -> String {
+pub fn generate_mnemonic(word_count: Option<MnemonicLength>) -> String {
     iota_sdk::crypto::mnemonic::generate_mnemonic(word_count)
 }

--- a/crates/iota-sdk-ffi/src/crypto/mod.rs
+++ b/crates/iota-sdk-ffi/src/crypto/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod bls12381;
 pub mod ed25519;
+pub mod mnemonic;
 pub mod multisig;
 pub mod passkey;
 pub mod secp256k1;

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_crypto::mnemonic::{MnemonicWordCount, generate_mnemonic};
+use iota_crypto::mnemonic::{MnemonicLength, generate_mnemonic};
 
 fn main() {
     let mnemonic = generate_mnemonic(None);
     println!("24 word mnemonic: {mnemonic}");
-    let mnemonic = generate_mnemonic(MnemonicWordCount::Words12);
+    let mnemonic = generate_mnemonic(MnemonicLength::Words12);
     println!("12 word mnemonic: {mnemonic}");
 }

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -3,9 +3,7 @@
 
 use iota_crypto::mnemonic::generate_mnemonic;
 
-fn main() -> eyre::Result<()> {
-    let mnemonic = generate_mnemonic(None)?;
+fn main() -> () {
+    let mnemonic = generate_mnemonic(None);
     println!("Mnemonic: {mnemonic}");
-
-    Ok(())
 }

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -6,6 +6,6 @@ use iota_crypto::mnemonic::{MnemonicWordCount, generate_mnemonic};
 fn main() {
     let mnemonic = generate_mnemonic(None);
     println!("24 word mnemonic: {mnemonic}");
-    let mnemonic = generate_mnemonic(Some(MnemonicWordCount::Twelve));
+    let mnemonic = generate_mnemonic(MnemonicWordCount::Twelve);
     println!("12 word mnemonic: {mnemonic}");
 }

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -3,7 +3,7 @@
 
 use iota_crypto::mnemonic::{MnemonicWordCount, generate_mnemonic};
 
-fn main() -> () {
+fn main() {
     let mnemonic = generate_mnemonic(None);
     println!("24 word mnemonic: {mnemonic}");
     let mnemonic = generate_mnemonic(Some(MnemonicWordCount::Twelve));

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_crypto::mnemonic::generate_mnemonic;
+
+fn main() -> eyre::Result<()> {
+    let mnemonic = generate_mnemonic(None)?;
+    println!("Mnemonic: {mnemonic}");
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_crypto::mnemonic::generate_mnemonic;
+use iota_crypto::mnemonic::{MnemonicWordCount, generate_mnemonic};
 
 fn main() -> () {
     let mnemonic = generate_mnemonic(None);
-    println!("Mnemonic: {mnemonic}");
+    println!("24 word mnemonic: {mnemonic}");
+    let mnemonic = generate_mnemonic(Some(MnemonicWordCount::Twelve));
+    println!("12 word mnemonic: {mnemonic}");
 }

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -6,6 +6,6 @@ use iota_crypto::mnemonic::{MnemonicWordCount, generate_mnemonic};
 fn main() {
     let mnemonic = generate_mnemonic(None);
     println!("24 word mnemonic: {mnemonic}");
-    let mnemonic = generate_mnemonic(MnemonicWordCount::Twelve);
+    let mnemonic = generate_mnemonic(MnemonicWordCount::Words12);
     println!("12 word mnemonic: {mnemonic}");
 }


### PR DESCRIPTION
Add generate_mnemonic() so one can generate a mnemonic and can use that later.

Fixes https://github.com/iotaledger/iota-rust-sdk/issues/354

Tested by running the examples:
```
24 word mnemonic: speed trick unique category check chef save rose blanket keep crush version divorce head paper drip lake what audit problem paddle leg away flat
12 word mnemonic: above audit want boost mammal balance dry rifle pride flush know filter
```