### PR TITLE
feat(iota-sdk-types): extend intent.rs from shared-crypto

### DIFF
--- a/crates/iota-sdk-types/Cargo.toml
+++ b/crates/iota-sdk-types/Cargo.toml
@@ -31,6 +31,7 @@ serde = [
   "dep:serde_json",
   "roaring/std",
   "dep:itertools",
+  "dep:serde_repr",
 ]
 schemars = ["serde", "dep:schemars", "dep:serde_json"]
 rand = ["dep:rand_core"]
@@ -54,6 +55,7 @@ bcs = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
+serde_repr = { version = "0.1", optional = true }
 serde_with = { version = "3.9", default-features = false, features = ["alloc"], optional = true }
 
 # JsonSchema definitions for types, useful for generating an OpenAPI Specificaiton.

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -179,14 +179,9 @@ impl TryFrom<u8> for IntentScope {
 
 /// Byte signifying the version of an [`Intent`]
 ///
-/// An intent is a compact struct serves as the domain separator for a message
-/// that a signature commits to. It consists of three parts: [enum IntentScope]
-/// (what the type of the message is), [enum IntentVersion], [enum IntentAppId]
-/// (what application that the signature refers to). It is used to construct
-/// [struct IntentMessage] that what a signature commits to.
-///
-/// The serialization of an Intent is a 3-byte array where each field is
-/// represented by a byte.
+/// The version here is to distinguish between signing different versions of the
+/// struct or enum. Serialized output between two different versions of the same
+/// struct/enum might accidentally (or maliciously on purpose) match.
 ///
 /// # BCS
 ///

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -295,3 +295,8 @@ pub enum HashingIntentScope {
     ChildObjectId = 0xf0,
     RegularObjectId = 0xf1,
 }
+
+/// A person message that wraps around a byte array.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -120,7 +120,7 @@ impl FromStr for Intent {
 
 /// Byte signifying the scope of an [`Intent`]
 ///
-/// This enums specifies the intent scope. Two intents for different scope
+/// This enum specifies the intent scope. Two intents for different scope
 /// should never collide, so no signature provided for one intent scope can be
 /// used for another, even when the serialized data itself may be the same.
 ///

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -6,11 +6,7 @@
 use std::str::FromStr;
 
 #[cfg(feature = "serde")]
-use bcs;
-#[cfg(feature = "serde")]
 use eyre::eyre;
-#[cfg(feature = "serde")]
-use hex;
 
 pub const INTENT_PREFIX_LENGTH: usize = 3;
 
@@ -131,7 +127,10 @@ impl FromStr for Intent {
 /// intent-scope = u8
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
+)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentScope {
@@ -182,7 +181,10 @@ impl TryFrom<u8> for IntentScope {
 /// intent-version = u8
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
+)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentVersion {
@@ -211,7 +213,10 @@ impl TryFrom<u8> for IntentVersion {
 /// intent-app-id = u8
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
+)]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentAppId {
@@ -257,7 +262,10 @@ impl<T> IntentMessage<T> {
 /// derived as the hash of `flag || pubkey`. See
 /// `iota_types::crypto::SignatureScheme::flag()`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
+)]
 #[repr(u8)]
 pub enum HashingIntentScope {
     ChildObjectId = 0xf0,

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -12,11 +12,11 @@ pub const INTENT_PREFIX_LENGTH: usize = 3;
 
 /// A Signing Intent
 ///
-/// An intent is a compact struct serves as the domain separator for a message
-/// that a signature commits to. It consists of three parts:
+/// An intent is a compact struct that serves as the domain separator for a
+/// message that a signature commits to. It consists of three parts:
 ///     1. [enum IntentScope] (what the type of the message is)
 ///     2. [enum IntentVersion]
-///     3. [enum IntentAppId] (what application that the signature refers to).
+///     3. [enum IntentAppId] (what application the signature refers to).
 ///
 /// The serialization of an Intent is a 3-byte array where each field is
 /// represented by a byte and it is prepended onto a message before it is signed
@@ -120,7 +120,7 @@ impl FromStr for Intent {
 
 /// Byte signifying the scope of an [`Intent`]
 ///
-/// This enum specifies the intent scope. Two intents for different scope
+/// This enum specifies the intent scope. Two intents for different scopes
 /// should never collide, so no signature provided for one intent scope can be
 /// used for another, even when the serialized data itself may be the same.
 ///
@@ -216,7 +216,7 @@ impl TryFrom<u8> for IntentVersion {
 
 /// Byte signifying the application id of an [`Intent`]
 ///
-/// This enums specifies the application ID. Two intents in two different
+/// This enum specifies the application ID. Two intents in two different
 /// applications (i.e., IOTA, Ethereum etc) should never collide, so
 /// that even when a signing key is reused, nobody can take a signature
 /// designated for app_1 and present it as a valid signature for an (any) intent
@@ -275,7 +275,7 @@ impl<T> IntentMessage<T> {
     }
 }
 
-/// A 1-byte domain separator for hashing Object ID in IOTA. It is starting from
+/// A 1-byte domain separator for hashing Object ID in IOTA. It starts from
 /// 0xf0 to ensure no hashing collision for any ObjectID vs IotaAddress which is
 /// derived as the hash of `flag || pubkey`. See
 /// `iota_types::crypto::SignatureScheme::flag()`.

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -60,8 +60,8 @@ impl Intent {
 
     pub fn iota_app(scope: IntentScope) -> Self {
         Self {
-            version: IntentVersion::V0,
             scope,
+            version: IntentVersion::V0,
             app_id: IntentAppId::Iota,
         }
     }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -3,9 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "serde")]
+use std::str::FromStr;
+
+#[cfg(feature = "serde")]
 use bcs;
 #[cfg(feature = "serde")]
 use eyre::eyre;
+#[cfg(feature = "serde")]
+use hex;
 
 pub const INTENT_PREFIX_LENGTH: usize = 3;
 
@@ -103,6 +108,15 @@ impl Intent {
             version: IntentVersion::V0,
             app_id: IntentAppId::Consensus,
         }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl FromStr for Intent {
+    type Err = eyre::Report;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes: Vec<u8> = hex::decode(s).map_err(|_| eyre!("Invalid Intent"))?;
+        Self::from_bytes(bytes.as_slice())
     }
 }
 
@@ -235,4 +249,16 @@ impl<T> IntentMessage<T> {
     pub fn new(intent: Intent, value: T) -> Self {
         Self { intent, value }
     }
+}
+
+/// A 1-byte domain separator for hashing Object ID in IOTA. It is starting from
+/// 0xf0 to ensure no hashing collision for any ObjectID vs IotaAddress which is
+/// derived as the hash of `flag || pubkey`. See
+/// `iota_types::crypto::SignatureScheme::flag()`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[repr(u8)]
+pub enum HashingIntentScope {
+    ChildObjectId = 0xf0,
+    RegularObjectId = 0xf1,
 }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -260,7 +260,7 @@ impl TryFrom<u8> for IntentAppId {
 /// any intent message signed in the system cannot collide with another since
 /// they are domain separated by intent.
 ///
-/// The serialization of an IntentMessage is compact: it only appends three
+/// The serialization of an IntentMessage is compact: it only prepends three
 /// bytes to the message itself.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -2,6 +2,13 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "serde")]
+use bcs;
+#[cfg(feature = "serde")]
+use eyre::eyre;
+
+pub const INTENT_PREFIX_LENGTH: usize = 3;
+
 /// A Signing Intent
 ///
 /// An intent is a compact struct serves as the domain separator for a message
@@ -21,7 +28,8 @@
 /// ```text
 /// intent = intent-scope intent-version intent-app-id
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Intent {
     pub scope: IntentScope,
     pub version: IntentVersion,
@@ -37,8 +45,20 @@ impl Intent {
         }
     }
 
-    pub fn to_bytes(self) -> [u8; 3] {
+    pub fn to_bytes(self) -> [u8; INTENT_PREFIX_LENGTH] {
         [self.scope as u8, self.version as u8, self.app_id as u8]
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, eyre::Report> {
+        if bytes.len() != INTENT_PREFIX_LENGTH {
+            return Err(eyre!("Invalid Intent"));
+        }
+        Ok(Self {
+            scope: bytes[0].try_into()?,
+            version: bytes[1].try_into()?,
+            app_id: bytes[2].try_into()?,
+        })
     }
 
     pub fn scope(self) -> IntentScope {
@@ -52,6 +72,38 @@ impl Intent {
     pub fn app_id(self) -> IntentAppId {
         self.app_id
     }
+
+    pub fn iota_app(scope: IntentScope) -> Self {
+        Self {
+            version: IntentVersion::V0,
+            scope,
+            app_id: IntentAppId::Iota,
+        }
+    }
+
+    pub const fn iota_transaction() -> Self {
+        Self {
+            scope: IntentScope::TransactionData,
+            version: IntentVersion::V0,
+            app_id: IntentAppId::Iota,
+        }
+    }
+
+    pub const fn personal_message() -> Self {
+        Self {
+            scope: IntentScope::PersonalMessage,
+            version: IntentVersion::V0,
+            app_id: IntentAppId::Iota,
+        }
+    }
+
+    pub const fn consensus_app(scope: IntentScope) -> Self {
+        Self {
+            scope,
+            version: IntentVersion::V0,
+            app_id: IntentAppId::Consensus,
+        }
+    }
 }
 
 /// Byte signifying the scope of an [`Intent`]
@@ -63,7 +115,8 @@ impl Intent {
 /// ```text
 /// intent-scope = u8
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentScope {
@@ -73,10 +126,12 @@ pub enum IntentScope {
     PersonalMessage = 3,         // Used for a user signature on a personal message.
     SenderSignedTransaction = 4, // Used for an authority signature on a user signed transaction.
     ProofOfPossession = 5,       /* Used as a signature representing an authority's proof of
-                                  * possession of its authority protocol key. */
-    HeaderDigest = 6,      // Used for narwhal authority signature on header digest.
-    BridgeEventUnused = 7, // for bridge purposes but it's currently not included in messages.
-    ConsensusBlock = 8,    // Used for consensus authority signature on block's digest
+                                  * possession of its authority key. */
+    BridgeEventDeprecated = 6, /* Deprecated. Should not be reused. Introduced for bridge
+                                * purposes but was never included in messages. */
+    ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
+    DiscoveryPeers = 8, // Used for reporting peer addresses in discovery
+    AuthorityCapabilities = 9, // Used for authority capabilities from non-committee authorities.
 }
 
 impl IntentScope {
@@ -87,10 +142,19 @@ impl IntentScope {
         PersonalMessage,
         SenderSignedTransaction,
         ProofOfPossession,
-        HeaderDigest,
-        BridgeEventUnused,
+        BridgeEventDeprecated,
         ConsensusBlock,
+        DiscoveryPeers,
+        AuthorityCapabilities,
     );
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<u8> for IntentScope {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentScope"))
+    }
 }
 
 /// Byte signifying the version of an [`Intent`]
@@ -102,7 +166,8 @@ impl IntentScope {
 /// ```text
 /// intent-version = u8
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentVersion {
@@ -111,6 +176,14 @@ pub enum IntentVersion {
 
 impl IntentVersion {
     crate::def_is!(V0);
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<u8> for IntentVersion {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentVersion"))
+    }
 }
 
 /// Byte signifying the application id of an [`Intent`]
@@ -122,7 +195,8 @@ impl IntentVersion {
 /// ```text
 /// intent-app-id = u8
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[repr(u8)]
 #[non_exhaustive]
 pub enum IntentAppId {
@@ -132,4 +206,33 @@ pub enum IntentAppId {
 
 impl IntentAppId {
     crate::def_is!(Iota, Consensus);
+}
+
+#[cfg(feature = "serde")]
+impl TryFrom<u8> for IntentAppId {
+    type Error = eyre::Report;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentAppId"))
+    }
+}
+
+/// Intent Message is a wrapper around a message with its intent. The message
+/// can be any type that implements [trait Serialize]. *ALL* signatures in IOTA
+/// must commits to the intent message, not the message itself. This guarantees
+/// any intent message signed in the system cannot collide with another since
+/// they are domain separated by intent.
+///
+/// The serialization of an IntentMessage is compact: it only appends three
+/// bytes to the message itself.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct IntentMessage<T> {
+    pub intent: Intent,
+    pub value: T,
+}
+
+impl<T> IntentMessage<T> {
+    pub fn new(intent: Intent, value: T) -> Self {
+        Self { intent, value }
+    }
 }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -256,7 +256,7 @@ impl TryFrom<u8> for IntentAppId {
 
 /// Intent Message is a wrapper around a message with its intent. The message
 /// can be any type that implements [trait Serialize]. *ALL* signatures in IOTA
-/// must commits to the intent message, not the message itself. This guarantees
+/// must commit to the intent message, not the message itself. This guarantees
 /// any intent message signed in the system cannot collide with another since
 /// they are domain separated by intent.
 ///
@@ -291,7 +291,7 @@ pub enum HashingIntentScope {
     RegularObjectId = 0xf1,
 }
 
-/// A person message that wraps around a byte array.
+/// A personal message that wraps around a byte array.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -115,7 +115,8 @@ impl Intent {
 impl FromStr for Intent {
     type Err = eyre::Report;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes: Vec<u8> = hex::decode(s).map_err(|_| eyre!("Invalid Intent"))?;
+        let bytes: Vec<u8> =
+            hex::decode(s.strip_prefix("0x").unwrap_or(s)).map_err(|_| eyre!("Invalid Intent"))?;
         Self::from_bytes(bytes.as_slice())
     }
 }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -171,6 +171,7 @@ impl IntentScope {
 #[cfg(feature = "serde")]
 impl TryFrom<u8> for IntentScope {
     type Error = eyre::Report;
+
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentScope"))
     }
@@ -212,6 +213,7 @@ impl IntentVersion {
 #[cfg(feature = "serde")]
 impl TryFrom<u8> for IntentVersion {
     type Error = eyre::Report;
+
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentVersion"))
     }
@@ -251,6 +253,7 @@ impl IntentAppId {
 #[cfg(feature = "serde")]
 impl TryFrom<u8> for IntentAppId {
     type Error = eyre::Report;
+
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         bcs::from_bytes(&[value]).map_err(|_| eyre!("Invalid IntentAppId"))
     }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -16,7 +16,7 @@ pub const INTENT_PREFIX_LENGTH: usize = 3;
 /// that a signature commits to. It consists of three parts:
 ///     1. [enum IntentScope] (what the type of the message is)
 ///     2. [enum IntentVersion]
-///     3. [enum AppId] (what application that the signature refers to).
+///     3. [enum IntentAppId] (what application that the signature refers to).
 ///
 /// The serialization of an Intent is a 3-byte array where each field is
 /// represented by a byte and it is prepended onto a message before it is signed
@@ -44,22 +44,6 @@ impl Intent {
             version,
             app_id,
         }
-    }
-
-    pub fn to_bytes(self) -> [u8; INTENT_PREFIX_LENGTH] {
-        [self.scope as u8, self.version as u8, self.app_id as u8]
-    }
-
-    #[cfg(feature = "serde")]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, eyre::Report> {
-        if bytes.len() != INTENT_PREFIX_LENGTH {
-            return Err(eyre!("Invalid Intent"));
-        }
-        Ok(Self {
-            scope: bytes[0].try_into()?,
-            version: bytes[1].try_into()?,
-            app_id: bytes[2].try_into()?,
-        })
     }
 
     pub fn scope(self) -> IntentScope {
@@ -105,11 +89,28 @@ impl Intent {
             app_id: IntentAppId::Consensus,
         }
     }
+
+    pub fn to_bytes(self) -> [u8; INTENT_PREFIX_LENGTH] {
+        [self.scope as u8, self.version as u8, self.app_id as u8]
+    }
+
+    #[cfg(feature = "serde")]
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, eyre::Report> {
+        if bytes.len() != INTENT_PREFIX_LENGTH {
+            return Err(eyre!("Invalid Intent"));
+        }
+        Ok(Self {
+            scope: bytes[0].try_into()?,
+            version: bytes[1].try_into()?,
+            app_id: bytes[2].try_into()?,
+        })
+    }
 }
 
 #[cfg(feature = "serde")]
 impl FromStr for Intent {
     type Err = eyre::Report;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let bytes: Vec<u8> =
             hex::decode(s.strip_prefix("0x").unwrap_or(s)).map_err(|_| eyre!("Invalid Intent"))?;
@@ -118,6 +119,10 @@ impl FromStr for Intent {
 }
 
 /// Byte signifying the scope of an [`Intent`]
+///
+/// This enums specifies the intent scope. Two intents for different scope
+/// should never collide, so no signature provided for one intent scope can be
+/// used for another, even when the serialized data itself may be the same.
 ///
 /// # BCS
 ///
@@ -173,6 +178,15 @@ impl TryFrom<u8> for IntentScope {
 
 /// Byte signifying the version of an [`Intent`]
 ///
+/// An intent is a compact struct serves as the domain separator for a message
+/// that a signature commits to. It consists of three parts: [enum IntentScope]
+/// (what the type of the message is), [enum IntentVersion], [enum IntentAppId]
+/// (what application that the signature refers to). It is used to construct
+/// [struct IntentMessage] that what a signature commits to.
+///
+/// The serialization of an Intent is a 3-byte array where each field is
+/// represented by a byte.
+///
 /// # BCS
 ///
 /// The BCS serialized form for this type is defined by the following ABNF:
@@ -204,6 +218,12 @@ impl TryFrom<u8> for IntentVersion {
 }
 
 /// Byte signifying the application id of an [`Intent`]
+///
+/// This enums specifies the application ID. Two intents in two different
+/// applications (i.e., IOTA, Ethereum etc) should never collide, so
+/// that even when a signing key is reused, nobody can take a signature
+/// designated for app_1 and present it as a valid signature for an (any) intent
+/// in app_2.
 ///
 /// # BCS
 ///
@@ -267,6 +287,7 @@ impl<T> IntentMessage<T> {
     derive(serde_repr::Serialize_repr, serde_repr::Deserialize_repr)
 )]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum HashingIntentScope {
     ChildObjectId = 0xf0,
     RegularObjectId = 0xf1,

--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -14,7 +14,7 @@ mod zklogin;
 
 pub use bls12381::{Bls12381PublicKey, Bls12381Signature};
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature};
-pub use intent::{Intent, IntentAppId, IntentScope, IntentVersion};
+pub use intent::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion};
 pub use multisig::{
     MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
     MultisigMemberSignature,

--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -16,7 +16,7 @@ pub use bls12381::{Bls12381PublicKey, Bls12381Signature};
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature};
 pub use intent::{
     HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage, IntentScope,
-    IntentVersion,
+    IntentVersion, PersonalMessage,
 };
 pub use multisig::{
     MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,

--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -14,7 +14,10 @@ mod zklogin;
 
 pub use bls12381::{Bls12381PublicKey, Bls12381Signature};
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature};
-pub use intent::{Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion};
+pub use intent::{
+    HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage, IntentScope,
+    IntentVersion,
+};
 pub use multisig::{
     MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
     MultisigMemberSignature,

--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -400,11 +400,7 @@ mod signing_message {
 
     impl Transaction {
         pub fn signing_digest(&self) -> SigningDigest {
-            const INTENT: Intent = Intent {
-                scope: IntentScope::TransactionData,
-                version: IntentVersion::V0,
-                app_id: IntentAppId::Iota,
-            };
+            const INTENT: Intent = Intent::iota_transaction();
             let digest = signing_digest(INTENT, self);
             digest.into_inner()
         }
@@ -416,11 +412,7 @@ mod signing_message {
 
     impl TransactionV1 {
         pub fn signing_digest(&self) -> SigningDigest {
-            const INTENT: Intent = Intent {
-                scope: IntentScope::TransactionData,
-                version: IntentVersion::V0,
-                app_id: IntentAppId::Iota,
-            };
+            const INTENT: Intent = Intent::iota_transaction();
             let digest = signing_digest(INTENT, &Transaction::V1(self.clone()));
             digest.into_inner()
         }
@@ -439,11 +431,7 @@ mod signing_message {
 
     impl PersonalMessage<'_> {
         pub fn signing_digest(&self) -> SigningDigest {
-            const INTENT: Intent = Intent {
-                scope: IntentScope::PersonalMessage,
-                version: IntentVersion::V0,
-                app_id: IntentAppId::Iota,
-            };
+            const INTENT: Intent = Intent::personal_message();
             let digest = signing_digest(INTENT, &self.0);
             digest.into_inner()
         }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -136,9 +136,9 @@ pub use checkpoint::{
 };
 pub use crypto::{
     Bls12381PublicKey, Bls12381Signature, Bn254FieldElement, CircomG1, CircomG2, Ed25519PublicKey,
-    Ed25519Signature, Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion,
-    InvalidSignatureScheme, InvalidZkLoginAuthenticatorError, Jwk, JwkId,
-    MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
+    Ed25519Signature, HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage,
+    IntentScope, IntentVersion, InvalidSignatureScheme, InvalidZkLoginAuthenticatorError, Jwk,
+    JwkId, MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
     MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PublicKeyExt,
     Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey, Secp256r1Signature,
     SignatureScheme, SimpleSignature, UserSignature, ZkLoginAuthenticator, ZkLoginClaim,
@@ -185,6 +185,7 @@ pub use validator::{
 mod serialization_proptests;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);
 
 #[macro_export]

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -139,7 +139,7 @@ pub use crypto::{
     Ed25519Signature, HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage,
     IntentScope, IntentVersion, InvalidSignatureScheme, InvalidZkLoginAuthenticatorError, Jwk,
     JwkId, MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
-    MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PublicKeyExt,
+    MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PersonalMessage, PublicKeyExt,
     Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey, Secp256r1Signature,
     SignatureScheme, SimpleSignature, UserSignature, ZkLoginAuthenticator, ZkLoginClaim,
     ZkLoginInputs, ZkLoginProof, ZkLoginPublicIdentifier,
@@ -183,10 +183,6 @@ pub use validator::{
 
 #[cfg(all(test, feature = "serde", feature = "proptest"))]
 mod serialization_proptests;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);
 
 #[macro_export]
 macro_rules! def_is {

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -136,12 +136,13 @@ pub use checkpoint::{
 };
 pub use crypto::{
     Bls12381PublicKey, Bls12381Signature, Bn254FieldElement, CircomG1, CircomG2, Ed25519PublicKey,
-    Ed25519Signature, Intent, IntentAppId, IntentScope, IntentVersion, InvalidSignatureScheme,
-    InvalidZkLoginAuthenticatorError, Jwk, JwkId, MultisigAggregatedSignature, MultisigCommittee,
-    MultisigMember, MultisigMemberPublicKey, MultisigMemberSignature, PasskeyAuthenticator,
-    PasskeyPublicKey, PublicKeyExt, Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey,
-    Secp256r1Signature, SignatureScheme, SimpleSignature, UserSignature, ZkLoginAuthenticator,
-    ZkLoginClaim, ZkLoginInputs, ZkLoginProof, ZkLoginPublicIdentifier,
+    Ed25519Signature, Intent, IntentAppId, IntentMessage, IntentScope, IntentVersion,
+    InvalidSignatureScheme, InvalidZkLoginAuthenticatorError, Jwk, JwkId,
+    MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
+    MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PublicKeyExt,
+    Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey, Secp256r1Signature,
+    SignatureScheme, SimpleSignature, UserSignature, ZkLoginAuthenticator, ZkLoginClaim,
+    ZkLoginInputs, ZkLoginProof, ZkLoginPublicIdentifier,
 };
 pub use digest::{Digest, DigestParseError, SigningDigest};
 pub use effects::{

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -763,16 +763,7 @@ mod signed_transaction {
     /// struct Intent {
     ///     scope: IntentScope,
     ///     version: IntentVersion,
-    ///     app_id: AppId,
-    /// }
-    ///
-    /// enum IntentVersion {
-    ///     V0 = 0,
-    /// }
-    ///
-    /// enum AppId {
-    ///     Iota = 0,
-    ///     Consensus = 1,
+    ///     app_id: IntendAppId,
     /// }
     ///
     /// enum IntentScope {
@@ -788,6 +779,15 @@ mod signed_transaction {
     ///     ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
     ///     DiscoveryPeers = 8, // Used for reporting peer addresses in discovery
     ///     AuthorityCapabilities = 9, // Used for authority capabilities from non-committee authorities.
+    /// }
+    ///
+    /// enum IntentVersion {
+    ///     V0 = 0,
+    /// }
+    ///
+    /// enum IntendAppId {
+    ///     Iota = 0,
+    ///     Consensus = 1,
     /// }
     /// ```
     struct IntentMessageWrappedTransaction;

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -772,8 +772,7 @@ mod signed_transaction {
     ///
     /// enum AppId {
     ///     Iota = 0,
-    ///     Narwhal = 1,
-    ///     Consensus = 2,
+    ///     Consensus = 1,
     /// }
     ///
     /// enum IntentScope {
@@ -782,9 +781,13 @@ mod signed_transaction {
     ///     CheckpointSummary = 2,       // Used for an authority signature on a checkpoint summary.
     ///     PersonalMessage = 3,         // Used for a user signature on a personal message.
     ///     SenderSignedTransaction = 4, // Used for an authority signature on a user signed transaction.
-    ///     ProofOfPossession = 5, // Used as a signature representing an authority's proof of possession of its authority protocol key.
-    ///     BridgeEventDeprecated = 6, // Deprecated. Should not be reused. Introduced for bridge purposes but was never included in messages.
-    ///     ConsensusBlock = 7,    // Used for consensus authority signature on block's digest
+    ///     ProofOfPossession = 5,       /* Used as a signature representing an authority's proof of
+    ///                                   * possession of its authority key. */
+    ///     BridgeEventDeprecated = 6, /* Deprecated. Should not be reused. Introduced for bridge
+    ///                                 * purposes but was never included in messages. */
+    ///     ConsensusBlock = 7, // Used for consensus authority signature on block's digest.
+    ///     DiscoveryPeers = 8, // Used for reporting peer addresses in discovery
+    ///     AuthorityCapabilities = 9, // Used for authority capabilities from non-committee authorities.
     /// }
     /// ```
     struct IntentMessageWrappedTransaction;


### PR DESCRIPTION
Extend intent.rs with things from shared-crypto from the monorepo https://github.com/iotaledger/iota/blob/develop/crates/shared-crypto/src/intent.rs

Fixes https://github.com/iotaledger/iota-rust-sdk/issues/428