### PR TITLE
fix(ci): `gen_changelog.sh` nits

### DIFF
--- a/.github/gen_changelog.sh
+++ b/.github/gen_changelog.sh
@@ -8,21 +8,23 @@ ADD=${5:-"false"}
 
 git fetch --tags
 
-echo "Generating changelog for package: $PACKAGE version $VERSION at $PACKAGE_ROOT"
+echo "Generating changelog for package: $PACKAGE version $VERSION at $PACKAGE_ROOT" 1>&2
 
 LATEST_TAG=$(git tag -l "$PACKAGE-v*" --sort=-v:refname | head -n 1)
-echo "Latest tag: $LATEST_TAG"
+echo "Latest tag: $LATEST_TAG" 1>&2
 
-COMMIT_FROM=$(git show-ref $LATEST_TAG | cut -f 1 -d' ')
-echo "Commit from: $COMMIT_FROM"
+if [ -n "$LATEST_TAG" ]; then
+    COMMIT_FROM=$(git show-ref $LATEST_TAG | cut -f 1 -d' ')
+fi
+echo "Commit from: $COMMIT_FROM" 1>&2
 
-echo "Commit to: $COMMIT_TO"
+echo "Commit to: $COMMIT_TO" 1>&2
 
 ENTRY=$(git-cliff $COMMIT_FROM..$COMMIT_TO --tag $VERSION --include-path $PACKAGE_ROOT)
 echo "$ENTRY"
 
 if [ "$ADD" = "true" ]; then
-    echo "git add $PACKAGE_ROOT/CHANGELOG.md"
+    echo "git add $PACKAGE_ROOT/CHANGELOG.md" 1>&2
     echo -e "$ENTRY\n$(cat $PACKAGE_ROOT/CHANGELOG.md)" > $PACKAGE_ROOT/CHANGELOG.md
     git add $PACKAGE_ROOT/CHANGELOG.md
 fi


### PR DESCRIPTION
- Handle the case of a very first release and previous tag can't be found
- Redirect logs to stderr so they are not added to the changelog but still showing in the CI