### PR TITLE
chore: lower `roaring` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proptest = { version = "1.6.0", default-features = false }
 rand = "0.8.5"
 rand_core = "0.6.4"
 reqwest = { version = "0.12", default-features = false }
-roaring = { version = "0.11.2", default-features = false }
+roaring = { version = "0.10.6", default-features = false }
 serde = "1.0.210"
 serde_json = "1.0.128"
 strum = "0.27.2"


### PR DESCRIPTION
To make it match the monorepo version