### PR TITLE
feat: make sure `iota-sdk` is wasm compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ test-with-localnet: package_test_example_v1.json package_test_example_v2.json ##
 
 .PHONY: wasm
 wasm: ## Build WASM modules
+	$(MAKE) -C crates/iota-sdk wasm
 	$(MAKE) -C crates/iota-sdk-crypto wasm
 	$(MAKE) -C crates/iota-sdk-graphql-client wasm
-	$(MAKE) -C crates/iota-sdk-types wasm
 	$(MAKE) -C crates/iota-sdk-transaction-builder wasm
+	$(MAKE) -C crates/iota-sdk-types wasm
 
 .PHONY: doc
 doc: ## Generate documentation

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -112,13 +112,12 @@ iota-types = { workspace = true, features = ["proptest"] }
 proptest = { workspace = true, features = ["std"] }
 test-strategy.workspace = true
 
-[target.wasm32-unknown-unknown.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 # `getrandom` renamed the WebAssembly support feature from "js" to "wasm_js"
 # Since both versions are in our dependency tree, we need to overwrite them with the proper feature
 getrandom_2 = { version = "0.2", package = "getrandom", features = ["js"] }
 getrandom_3 = { version = "0.3", package = "getrandom", features = ["wasm_js"] }
-test-strategy = "=0.4.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/crates/iota-sdk-transaction-builder/Cargo.toml
+++ b/crates/iota-sdk-transaction-builder/Cargo.toml
@@ -23,7 +23,6 @@ iota-graphql-client.workspace = true
 iota-types = { workspace = true, features = ["serde", "hash"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/iota-sdk-types/Cargo.toml
+++ b/crates/iota-sdk-types/Cargo.toml
@@ -78,7 +78,7 @@ num-bigint = "0.4.6"
 paste.workspace = true
 serde_json.workspace = true
 
-[target.wasm32-unknown-unknown.dev-dependencies]
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -8,6 +8,9 @@ readme = "../../README.md"
 repository = "https://github.com/iotaledger/iota-rust-sdk/"
 description = "The official SDK for IOTA"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [features]
 default = [
   "crypto",
@@ -61,6 +64,9 @@ iota-crypto = { workspace = true, features = ["ed25519"], optional = true }
 iota-graphql-client = { workspace = true, optional = true }
 iota-transaction-builder = { workspace = true, optional = true }
 iota-types = { workspace = true, features = ["rand"], optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 base64ct = { workspace = true, features = ["alloc", "std"] }

--- a/crates/iota-sdk/Makefile
+++ b/crates/iota-sdk/Makefile
@@ -1,0 +1,10 @@
+# Set the default target of this Makefile
+.PHONY: all
+all:: wasm
+
+.PHONY: wasm
+wasm:
+	CC=clang wasm-pack build
+
+%:
+	$(MAKE) -C ../.. $@


### PR DESCRIPTION
Contrary to other crates, we are just wasm-building the library and not tests/examples. Making the examples wasm-compatible is not really interesting for the vast majority of people.