### PR TITLE
chore: explicit workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,14 @@
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = [
+  "crates/iota-sdk",
+  "crates/iota-sdk-crypto",
+  "crates/iota-sdk-ffi",
+  "crates/iota-sdk-graphql-client",
+  "crates/iota-sdk-graphql-client-build",
+  "crates/iota-sdk-transaction-builder",
+  "crates/iota-sdk-types",
+]
 
 [workspace.dependencies]
 base64ct = "1.6.0"
@@ -29,5 +37,6 @@ tokio = "1.40.0"
 iota-crypto = { version = "0.0.1-alpha.1", package = "iota-sdk-crypto", path = "crates/iota-sdk-crypto", default-features = false }
 iota-graphql-client = { version = "0.0.1-alpha.1", package = "iota-sdk-graphql-client", path = "crates/iota-sdk-graphql-client", default-features = false }
 iota-graphql-client-build = { version = "0.0.1-alpha.1", package = "iota-sdk-graphql-client-build", path = "crates/iota-sdk-graphql-client-build", default-features = false }
+iota-sdk = { version = "3.0.0-alpha.1", package = "iota-sdk", path = "crates/iota-sdk", default-features = false }
 iota-transaction-builder = { version = "0.0.1-alpha.1", package = "iota-sdk-transaction-builder", path = "crates/iota-sdk-transaction-builder", default-features = false }
 iota-types = { version = "0.0.1-alpha.1", package = "iota-sdk-types", path = "crates/iota-sdk-types", default-features = false }


### PR DESCRIPTION
Like in the monorepo, a more fine-grained control of what is being compiled. Me and others encountered issues with rust-analyser sometimes leaving traces in the crates folder, making later compilations to fail.