### PR TITLE
chore(examples): import through `iota-sdk`

### DIFF
--- a/crates/iota-sdk/examples/address_from_mnemonic.rs
+++ b/crates/iota-sdk/examples/address_from_mnemonic.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64ct::{Base64, Encoding};
-use iota_crypto::{
-    DERIVATION_PATH_COIN_TYPE, DERIVATION_PATH_PURPOSE_SECP256R1, FromMnemonic, ToFromBech32,
-    ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
+use iota_sdk::{
+    crypto::{
+        DERIVATION_PATH_COIN_TYPE, DERIVATION_PATH_PURPOSE_SECP256R1, FromMnemonic, ToFromBech32,
+        ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey, secp256r1::Secp256r1PrivateKey,
+    },
+    types::PublicKeyExt,
 };
-use iota_types::PublicKeyExt;
 
 const MNEMONIC: &str = "round attack kitchen wink winter music trip tiny nephew hire orange what";
 

--- a/crates/iota-sdk/examples/chain_id.rs
+++ b/crates/iota-sdk/examples/chain_id.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{Client, error::Result};
+use iota_sdk::graphql_client::{Client, error::Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/coin_balances.rs
+++ b/crates/iota-sdk/examples/coin_balances.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{Client, error::Result};
+use iota_sdk::graphql_client::{Client, error::Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/custom_query.rs
+++ b/crates/iota-sdk/examples/custom_query.rs
@@ -4,7 +4,7 @@
 
 use cynic::QueryBuilder;
 use eyre::Result;
-use iota_graphql_client::{
+use iota_sdk::graphql_client::{
     Client,
     query_types::{BigInt, schema},
 };

--- a/crates/iota-sdk/examples/dev_inspect.rs
+++ b/crates/iota-sdk/examples/dev_inspect.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::{SharedMut, TransactionBuilder, res};
-use iota_types::{Address, Identifier, ObjectId, StructTag, TypeTag};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{SharedMut, TransactionBuilder, res},
+    types::{Address, Identifier, ObjectId, StructTag, TypeTag},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/dry_run_bytes.rs
+++ b/crates/iota-sdk/examples/dry_run_bytes.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_types::Transaction;
+use iota_sdk::{graphql_client::Client, types::Transaction};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/dynamic_fields.rs
+++ b/crates/iota-sdk/examples/dynamic_fields.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::Client;
+use iota_sdk::graphql_client::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/epoch.rs
+++ b/crates/iota-sdk/examples/epoch.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{Client, error::Result};
+use iota_sdk::graphql_client::{Client, error::Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/faucet.rs
+++ b/crates/iota-sdk/examples/faucet.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::faucet::FaucetClient;
-use iota_types::Address;
+use iota_sdk::{graphql_client::faucet::FaucetClient, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/gas_sponsor.rs
+++ b/crates/iota-sdk/examples/gas_sponsor.rs
@@ -4,9 +4,7 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{graphql_client::Client, transaction_builder::TransactionBuilder, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/gas_station.rs
+++ b/crates/iota-sdk/examples/gas_station.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_crypto::ed25519::Ed25519PrivateKey;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{
+    crypto::ed25519::Ed25519PrivateKey, graphql_client::Client,
+    transaction_builder::TransactionBuilder, types::Address,
+};
 use reqwest::header::HeaderValue;
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/generate_ed25519_address.rs
+++ b/crates/iota-sdk/examples/generate_ed25519_address.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use base64ct::{Base64, Encoding};
-use iota_crypto::{ToFromBech32, ed25519::Ed25519PrivateKey};
-use iota_types::PublicKeyExt;
+use iota_sdk::{
+    crypto::{ToFromBech32, ed25519::Ed25519PrivateKey},
+    types::PublicKeyExt,
+};
 use rand::rngs::OsRng;
 
 fn main() {

--- a/crates/iota-sdk/examples/generate_mnemonic.rs
+++ b/crates/iota-sdk/examples/generate_mnemonic.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_crypto::mnemonic::{MnemonicLength, generate_mnemonic};
+use iota_sdk::crypto::mnemonic::{MnemonicLength, generate_mnemonic};
 
 fn main() {
     let mnemonic = generate_mnemonic(None);

--- a/crates/iota-sdk/examples/generic_move_function.rs
+++ b/crates/iota-sdk/examples/generic_move_function.rs
@@ -4,9 +4,7 @@
 use core::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{graphql_client::Client, transaction_builder::TransactionBuilder, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/get_object.rs
+++ b/crates/iota-sdk/examples/get_object.rs
@@ -4,8 +4,7 @@
 use std::str::FromStr;
 
 use eyre::{OptionExt, Result};
-use iota_graphql_client::Client;
-use iota_types::ObjectId;
+use iota_sdk::{graphql_client::Client, types::ObjectId};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/get_transaction.rs
+++ b/crates/iota-sdk/examples/get_transaction.rs
@@ -1,8 +1,10 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{Client, error::Result};
-use iota_types::Digest;
+use iota_sdk::{
+    graphql_client::{Client, error::Result},
+    types::Digest,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/json_query.rs
+++ b/crates/iota-sdk/examples/json_query.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::Client;
+use iota_sdk::graphql_client::Client;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/move_functions.rs
+++ b/crates/iota-sdk/examples/move_functions.rs
@@ -4,8 +4,7 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_types::Address;
+use iota_sdk::{graphql_client::Client, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/objects_by_type.rs
+++ b/crates/iota-sdk/examples/objects_by_type.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{Client, error::Result, query_types::ObjectFilter};
+use iota_sdk::graphql_client::{Client, error::Result, query_types::ObjectFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/owned_objects.rs
+++ b/crates/iota-sdk/examples/owned_objects.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter};
-use iota_types::Address;
+use iota_sdk::{
+    graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter},
+    types::Address,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/package_events.rs
+++ b/crates/iota-sdk/examples/package_events.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{
+use iota_sdk::graphql_client::{
     Client, error::Result, pagination::PaginationFilter, query_types::EventFilter,
 };
 

--- a/crates/iota-sdk/examples/pagination.rs
+++ b/crates/iota-sdk/examples/pagination.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter};
-use iota_types::Address;
+use iota_sdk::{
+    graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter},
+    types::Address,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_merge_coins.rs
+++ b/crates/iota-sdk/examples/prepare_merge_coins.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::TransactionBuilder,
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_send_coins.rs
+++ b/crates/iota-sdk/examples/prepare_send_coins.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::TransactionBuilder,
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_send_iota.rs
+++ b/crates/iota-sdk/examples/prepare_send_iota.rs
@@ -4,9 +4,7 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{graphql_client::Client, transaction_builder::TransactionBuilder, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_send_iota_multi.rs
+++ b/crates/iota-sdk/examples/prepare_send_iota_multi.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res};
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{TransactionBuilder, res},
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_split_coins.rs
+++ b/crates/iota-sdk/examples/prepare_split_coins.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res};
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{TransactionBuilder, res},
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_transfer_objects.rs
+++ b/crates/iota-sdk/examples/prepare_transfer_objects.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::TransactionBuilder,
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/prepare_transfer_objects_offline.rs
+++ b/crates/iota-sdk/examples/prepare_transfer_objects_offline.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::{OptionExt, Result};
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::{Address, ObjectId};
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::TransactionBuilder,
+    types::{Address, ObjectId},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -24,10 +24,12 @@
 use std::env::var;
 
 use eyre::{Result, bail};
-use iota_crypto::{IotaSigner, ed25519::Ed25519PrivateKey};
-use iota_graphql_client::{Client, WaitForTx, faucet::FaucetClient};
-use iota_transaction_builder::{TransactionBuilder, res};
-use iota_types::{Address, MovePackageData, ObjectId, ObjectOut, StructTag, UpgradePolicy};
+use iota_sdk::{
+    crypto::{IotaSigner, ed25519::Ed25519PrivateKey},
+    graphql_client::{Client, WaitForTx, faucet::FaucetClient},
+    transaction_builder::{TransactionBuilder, res},
+    types::{Address, MovePackageData, ObjectId, ObjectOut, StructTag, UpgradePolicy},
+};
 use rand::rngs::OsRng;
 
 #[tokio::main]

--- a/crates/iota-sdk/examples/sign_send_iota.rs
+++ b/crates/iota-sdk/examples/sign_send_iota.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_crypto::{IotaSigner, ed25519::Ed25519PrivateKey};
-use iota_graphql_client::{Client, faucet::FaucetClient};
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{
+    crypto::{IotaSigner, ed25519::Ed25519PrivateKey},
+    graphql_client::{Client, faucet::FaucetClient},
+    transaction_builder::TransactionBuilder,
+    types::Address,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/stake.rs
+++ b/crates/iota-sdk/examples/stake.rs
@@ -4,9 +4,7 @@
 use std::str::FromStr;
 
 use eyre::{OptionExt, Result};
-use iota_graphql_client::Client;
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::Address;
+use iota_sdk::{graphql_client::Client, transaction_builder::TransactionBuilder, types::Address};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/transaction_signer_callback.rs
+++ b/crates/iota-sdk/examples/transaction_signer_callback.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::Result;
-use iota_crypto::{IotaSigner, SignatureError, ed25519::Ed25519PrivateKey};
-use iota_graphql_client::{Client, WaitForTx, faucet::FaucetClient};
-use iota_transaction_builder::{TransactionBuilder, TransactionSigner};
-use iota_types::{Address, Transaction, UserSignature};
+use iota_sdk::{
+    crypto::{IotaSigner, SignatureError, ed25519::Ed25519PrivateKey},
+    graphql_client::{Client, WaitForTx, faucet::FaucetClient},
+    transaction_builder::{TransactionBuilder, TransactionSigner},
+    types::{Address, Transaction, UserSignature},
+};
 
 struct AsyncSigner(Ed25519PrivateKey);
 

--- a/crates/iota-sdk/examples/transactions_with_function.rs
+++ b/crates/iota-sdk/examples/transactions_with_function.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_graphql_client::{
+use iota_sdk::graphql_client::{
     Client, error::Result, pagination::PaginationFilter, query_types::TransactionsFilter,
 };
 

--- a/crates/iota-sdk/examples/transactions_with_shared.rs
+++ b/crates/iota-sdk/examples/transactions_with_shared.rs
@@ -3,8 +3,10 @@
 
 use std::str::FromStr;
 
-use iota_graphql_client::{Client, error::Result, query_types::TransactionsFilter};
-use iota_types::ObjectId;
+use iota_sdk::{
+    graphql_client::{Client, error::Result, query_types::TransactionsFilter},
+    types::ObjectId,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/tx_command_results.rs
+++ b/crates/iota-sdk/examples/tx_command_results.rs
@@ -4,9 +4,11 @@
 use std::str::FromStr;
 
 use eyre::Result;
-use iota_graphql_client::Client;
-use iota_transaction_builder::{TransactionBuilder, res, unresolved::Argument};
-use iota_types::Address;
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{TransactionBuilder, res, unresolved::Argument},
+    types::Address,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/crates/iota-sdk/examples/unstake.rs
+++ b/crates/iota-sdk/examples/unstake.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use eyre::{OptionExt, Result};
-use iota_graphql_client::{Client, query_types::ObjectFilter};
-use iota_transaction_builder::TransactionBuilder;
-use iota_types::StructTag;
+use iota_sdk::{
+    graphql_client::{Client, query_types::ObjectFilter},
+    transaction_builder::TransactionBuilder,
+    types::StructTag,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
This is closer to how developers are actually going to use the SDK, most probably having a single dependency in `iota-sdk`. It then makes the examples easier to copy-paste.