### PR TITLE
chore(iota-sdk-types): make `StructTag` fields private

### DIFF
--- a/crates/iota-sdk-ffi/src/types/struct_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/struct_tag.rs
@@ -98,15 +98,15 @@ impl StructTag {
         name: &Identifier,
         type_params: Vec<Arc<TypeTag>>,
     ) -> Self {
-        Self(iota_sdk::types::StructTag {
-            address: address.0,
-            module: module.0.clone(),
-            name: name.0.clone(),
-            type_params: type_params
+        Self(iota_sdk::types::StructTag::new(
+            address.0,
+            module.0.clone(),
+            name.0.clone(),
+            type_params
                 .iter()
                 .map(|type_tag| type_tag.0.clone())
                 .collect(),
-        })
+        ))
     }
 
     #[uniffi::constructor]

--- a/crates/iota-sdk-graphql-client/src/lib.rs
+++ b/crates/iota-sdk-graphql-client/src/lib.rs
@@ -600,11 +600,13 @@ impl Client {
                 coin_type
                     .into()
                     .map(StructTag::new_coin)
-                    .unwrap_or_else(|| StructTag {
-                        address: Address::FRAMEWORK,
-                        module: IdentifierRef::const_new("coin").into(),
-                        name: IdentifierRef::const_new("Coin").into(),
-                        type_params: Default::default(),
+                    .unwrap_or_else(|| {
+                        StructTag::new(
+                            Address::FRAMEWORK,
+                            IdentifierRef::const_new("coin").into(),
+                            IdentifierRef::const_new("Coin").into(),
+                            Default::default(),
+                        )
                     })
                     .to_string(),
             ),

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -587,7 +587,7 @@ mod tests {
         for o in created_objs {
             let obj = client.object(o, None).await.unwrap().unwrap();
             match obj.object_type() {
-                ObjectType::Struct(x) if x.name.to_string() == "UpgradeCap" => {
+                ObjectType::Struct(x) if x.name() == "UpgradeCap" => {
                     upgrade_cap = Some(obj.object_id());
                     break;
                 }

--- a/crates/iota-sdk-types/src/iota_names/mod.rs
+++ b/crates/iota-sdk-types/src/iota_names/mod.rs
@@ -57,12 +57,12 @@ pub trait IotaNamesNft {
     const TYPE_NAME: &IdentifierRef;
 
     fn type_(package_id: Address) -> StructTag {
-        StructTag {
-            address: package_id,
-            module: Self::MODULE.into(),
-            name: Self::TYPE_NAME.into(),
-            type_params: Vec::new(),
-        }
+        StructTag::new(
+            package_id,
+            Self::MODULE.into(),
+            Self::TYPE_NAME.into(),
+            Vec::new(),
+        )
     }
 
     fn name(&self) -> &Name;

--- a/crates/iota-sdk-types/src/iota_names/name.rs
+++ b/crates/iota-sdk-types/src/iota_names/name.rs
@@ -72,12 +72,12 @@ impl Name {
         const IOTA_NAMES_NAME_MODULE: &IdentifierRef = IdentifierRef::const_new("name");
         const IOTA_NAMES_NAME_STRUCT: &IdentifierRef = IdentifierRef::const_new("Name");
 
-        StructTag {
-            address: package_address,
-            module: IOTA_NAMES_NAME_MODULE.to_owned(),
-            name: IOTA_NAMES_NAME_STRUCT.to_owned(),
-            type_params: vec![],
-        }
+        StructTag::new(
+            package_address,
+            IOTA_NAMES_NAME_MODULE.to_owned(),
+            IOTA_NAMES_NAME_STRUCT.to_owned(),
+            vec![],
+        )
     }
 
     /// Derive the parent name for a given name. Only subnames have

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -588,36 +588,22 @@ mod serialization {
 
     impl<'a> MoveStructTypeRef<'a> {
         fn from_struct_tag(s: &'a StructTag) -> Self {
-            let StructTag {
-                address,
-                module,
-                name,
-                type_params,
-            } = s;
-
             if let Some(coin_type) = s.coin_type_opt() {
                 if let TypeTag::Struct(s_inner) = coin_type {
-                    let StructTag {
-                        address,
-                        module,
-                        name,
-                        type_params,
-                    } = s_inner.as_ref();
-
-                    if address == &Address::FRAMEWORK
-                        && module == "iota"
-                        && name == "IOTA"
-                        && type_params.is_empty()
+                    if s_inner.address() == Address::FRAMEWORK
+                        && s_inner.module() == "iota"
+                        && s_inner.name() == "IOTA"
+                        && s_inner.type_params().is_empty()
                     {
                         return Self::GasCoin;
                     }
                 }
 
                 Self::Coin(coin_type)
-            } else if address == &Address::SYSTEM
-                && module == "staking_pool"
-                && name == "StakedIota"
-                && type_params.is_empty()
+            } else if s.address() == Address::SYSTEM
+                && s.module() == "staking_pool"
+                && s.name() == "StakedIota"
+                && s.type_params().is_empty()
             {
                 Self::StakedIota
             } else {
@@ -1021,12 +1007,12 @@ mod serialization {
         fn obj() {
             let o = Object {
                 data: ObjectData::Struct(MoveStruct {
-                    type_: StructTag {
-                        address: Address::FRAMEWORK,
-                        module: Identifier::new("bar").unwrap(),
-                        name: Identifier::new("foo").unwrap(),
-                        type_params: Vec::new(),
-                    },
+                    type_: StructTag::new(
+                        Address::FRAMEWORK,
+                        Identifier::new("bar").unwrap(),
+                        Identifier::new("foo").unwrap(),
+                        Vec::new(),
+                    ),
                     version: 12,
                     contents: ObjectId::ZERO.into(),
                 }),

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -589,14 +589,13 @@ mod serialization {
     impl<'a> MoveStructTypeRef<'a> {
         fn from_struct_tag(s: &'a StructTag) -> Self {
             if let Some(coin_type) = s.coin_type_opt() {
-                if let TypeTag::Struct(s_inner) = coin_type {
-                    if s_inner.address() == Address::FRAMEWORK
-                        && s_inner.module() == "iota"
-                        && s_inner.name() == "IOTA"
-                        && s_inner.type_params().is_empty()
-                    {
-                        return Self::GasCoin;
-                    }
+                if let TypeTag::Struct(s_inner) = coin_type
+                    && s_inner.address() == Address::FRAMEWORK
+                    && s_inner.module() == "iota"
+                    && s_inner.name() == "IOTA"
+                    && s_inner.type_params().is_empty()
+                {
+                    return Self::GasCoin;
                 }
 
                 Self::Coin(coin_type)

--- a/crates/iota-sdk-types/src/type_tag/mod.rs
+++ b/crates/iota-sdk-types/src/type_tag/mod.rs
@@ -501,14 +501,28 @@ macro_rules! add_struct_tag_ctor_from_type_tag {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct StructTag {
-    pub address: Address,
-    pub module: Identifier,
-    pub name: Identifier,
+    address: Address,
+    module: Identifier,
+    name: Identifier,
     #[cfg_attr(feature = "proptest", strategy(proptest::strategy::Just(Vec::new())))]
-    pub type_params: Vec<TypeTag>,
+    type_params: Vec<TypeTag>,
 }
 
 impl StructTag {
+    pub fn new(
+        address: Address,
+        module: Identifier,
+        name: Identifier,
+        type_params: Vec<TypeTag>,
+    ) -> Self {
+        Self {
+            address,
+            module,
+            name,
+            type_params,
+        }
+    }
+
     pub fn new_iota_coin_type() -> Self {
         Self {
             address: Address::FRAMEWORK,

--- a/crates/iota-sdk/examples/dev_inspect.rs
+++ b/crates/iota-sdk/examples/dev_inspect.rs
@@ -30,12 +30,12 @@ async fn main() -> Result<()> {
     builder
         .move_call(iota_names_package_address, "iota_names", "registry")
         .arguments([SharedMut(iota_names_object_id)])
-        .type_tags([TypeTag::Struct(Box::new(StructTag {
-            address: iota_names_package_address,
-            module: Identifier::new("registry")?,
-            name: Identifier::new("Registry")?,
-            type_params: vec![],
-        }))])
+        .type_tags([TypeTag::Struct(Box::new(StructTag::new(
+            iota_names_package_address,
+            Identifier::new("registry")?,
+            Identifier::new("Registry")?,
+            vec![],
+        )))])
         .name("iota_names");
 
     // Step 2: Create the name object from the string
@@ -54,12 +54,12 @@ async fn main() -> Result<()> {
     builder
         .move_call(Address::STD_LIB, "option", "borrow")
         .arguments([res("name_record_opt")])
-        .type_tags([TypeTag::Struct(Box::new(StructTag {
-            address: iota_names_package_address,
-            module: Identifier::new("name_record")?,
-            name: Identifier::new("NameRecord")?,
-            type_params: vec![],
-        }))])
+        .type_tags([TypeTag::Struct(Box::new(StructTag::new(
+            iota_names_package_address,
+            Identifier::new("name_record")?,
+            Identifier::new("NameRecord")?,
+            vec![],
+        )))])
         .name("name_record");
 
     // Step 5: Get the target address from the name record


### PR DESCRIPTION
Based on upstream https://github.com/MystenLabs/sui-rust-sdk/pull/175, I wanted to do it anyway at some point.