### PR TITLE
chore: rename `Address::STD_LIB` to `Address::STD`

### DIFF
--- a/bindings/go/examples/dev_inspect/main.go
+++ b/bindings/go/examples/dev_inspect/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	iotaNamesObjectId := objIdFromHex("0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342")
 
-	stdlibAddress := iota_sdk.AddressStdLib()
+	stdAddress := iota_sdk.AddressStd()
 
 	name := "name.iota"
 	fmt.Printf("Looking up name: %s\n", name)
@@ -99,7 +99,7 @@ func main() {
 
 	// 4. Borrow name record from option
 	builder.MoveCall(
-		stdlibAddress,
+		stdAddress,
 		optionModule,
 		borrowFn,
 		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentRes("name_record_opt")},
@@ -119,7 +119,7 @@ func main() {
 
 	// 6. Borrow address from option
 	builder.MoveCall(
-		stdlibAddress,
+		stdAddress,
 		optionModule,
 		borrowFn,
 		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentRes("target_address_opt")},

--- a/bindings/go/examples/gas_sponsor/main.go
+++ b/bindings/go/examples/gas_sponsor/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
 
-	packageAddr := iota_sdk.AddressStdLib()
+	packageAddr := iota_sdk.AddressStd()
 	moduleName := identifier("u8")
 	functionName := identifier("max")
 

--- a/bindings/go/examples/gas_station/main.go
+++ b/bindings/go/examples/gas_station/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
 
-	package_id := iota_sdk.AddressStdLib()
+	package_id := iota_sdk.AddressStd()
 	module_name := identifier("u64")
 	function_name := identifier("sqrt")
 

--- a/bindings/go/examples/tx_command_results/main.go
+++ b/bindings/go/examples/tx_command_results/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
 
-	packageAddr := iota_sdk.AddressStdLib()
+	packageAddr := iota_sdk.AddressStd()
 	moduleName := identifier("u64")
 	functionName := identifier("max")
 	builder.MoveCall(

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -7347,11 +7347,11 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-		return C.uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib()
+		return C.uniffi_iota_sdk_ffi_checksum_constructor_address_std()
 	})
-	if checksum != 35825 {
+	if checksum != 28998 {
 		// If this happens try cleaning and rebuilding your project
-		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib: UniFFI API checksum mismatch")
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_address_std: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -10787,9 +10787,9 @@ func AddressGenerate() *Address {
 	}))
 }
 
-func AddressStdLib() *Address {
+func AddressStd() *Address {
 	return FfiConverterAddressINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
-		return C.uniffi_iota_sdk_ffi_fn_constructor_address_std_lib(_uniffiStatus)
+		return C.uniffi_iota_sdk_ffi_fn_constructor_address_std(_uniffiStatus)
 	}))
 }
 

--- a/bindings/go/iota_sdk/iota_sdk.h
+++ b/bindings/go/iota_sdk/iota_sdk.h
@@ -432,9 +432,9 @@ void* uniffi_iota_sdk_ffi_fn_constructor_address_generate(RustCallStatus *out_st
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STD_LIB
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STD_LIB
-void* uniffi_iota_sdk_ffi_fn_constructor_address_std_lib(RustCallStatus *out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STD
+void* uniffi_iota_sdk_ffi_fn_constructor_address_std(RustCallStatus *out_status
     
 );
 #endif
@@ -12056,9 +12056,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_generate(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STD_LIB
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STD_LIB
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STD
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_std(void
     
 );
 #endif

--- a/bindings/kotlin/examples/DevInspect.kt
+++ b/bindings/kotlin/examples/DevInspect.kt
@@ -15,7 +15,7 @@ fun main() = runBlocking {
             Address.fromHex("0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba")
         val iotaNamesObjectId =
             ObjectId.fromHex("0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342")
-        val stdlibAddress = Address.stdLib()
+        val stdAddress = Address.std()
 
         val name = "name.iota"
         println("Looking up name: $name")
@@ -63,7 +63,7 @@ fun main() = runBlocking {
 
         // 4. Borrow name record from option
         builder.moveCall(
-            stdlibAddress,
+            stdAddress,
             Identifier("option"),
             Identifier("borrow"),
             listOf(PtbArgument.res("name_record_opt")),
@@ -91,7 +91,7 @@ fun main() = runBlocking {
 
         // 6. Borrow address from option
         builder.moveCall(
-            stdlibAddress,
+            stdAddress,
             Identifier("option"),
             Identifier("borrow"),
             listOf(PtbArgument.res("target_address_opt")),

--- a/bindings/kotlin/examples/GasSponsor.kt
+++ b/bindings/kotlin/examples/GasSponsor.kt
@@ -15,7 +15,7 @@ fun main() = runBlocking {
 
         val builder = TransactionBuilder(sender).withClient(client)
 
-        val packageAddr = Address.stdLib()
+        val packageAddr = Address.std()
         val moduleName = Identifier("u8")
         val functionName = Identifier("max")
 

--- a/bindings/kotlin/examples/GasStation.kt
+++ b/bindings/kotlin/examples/GasStation.kt
@@ -16,7 +16,7 @@ fun main() = runBlocking {
         val builder = TransactionBuilder(sender).withClient(client)
 
         builder.moveCall(
-            Address.stdLib(),
+            Address.std(),
             Identifier("u64"),
             Identifier("sqrt"),
             listOf(PtbArgument.u64(64uL)),

--- a/bindings/kotlin/examples/TxCommandResults.kt
+++ b/bindings/kotlin/examples/TxCommandResults.kt
@@ -13,7 +13,7 @@ fun main() = runBlocking {
 
         val builder = TransactionBuilder(sender).withClient(client)
 
-        val packageAddr = Address.stdLib()
+        val packageAddr = Address.std()
         val moduleName = Identifier("u64")
         val functionName = Identifier("max")
 

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk_ffi.kt
@@ -4730,7 +4730,7 @@ fun uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_address_generate(
 ): Short
-fun uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib(
+fun uniffi_iota_sdk_ffi_checksum_constructor_address_std(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_constructor_address_system(
 ): Short
@@ -5434,7 +5434,7 @@ fun uniffi_iota_sdk_ffi_fn_constructor_address_from_hex(`hex`: RustBuffer.ByValu
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_address_generate(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_constructor_address_std_lib(uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_constructor_address_std(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_address_system(uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -10532,7 +10532,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate() != 48865.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib() != 35825.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_std() != 28998.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_system() != 4297.toShort()) {
@@ -12508,10 +12508,10 @@ open class Address: Disposable, AutoCloseable, AddressInterface
     }
     
 
-         fun `stdLib`(): Address {
+         fun `std`(): Address {
             return FfiConverterTypeAddress.lift(
     uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_address_std_lib(
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_constructor_address_std(
         _status)
 }
     )

--- a/bindings/python/examples/dev_inspect.py
+++ b/bindings/python/examples/dev_inspect.py
@@ -15,7 +15,7 @@ async def main():
         "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba")
     iota_names_object_id = ObjectId.from_hex(
         "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342")
-    stdlib_address = Address.std_lib()
+    std_address = Address.std()
 
     name = "name.iota"
     print(f"Looking up name: {name}")
@@ -60,7 +60,7 @@ async def main():
 
     # 4. Borrow name record from option
     builder.move_call(
-        stdlib_address,
+        std_address,
         Identifier("option"),
         Identifier("borrow"),
         [PtbArgument.res("name_record_opt")],
@@ -86,7 +86,7 @@ async def main():
 
     # 6. Borrow address from option
     builder.move_call(
-        stdlib_address,
+        std_address,
         Identifier("option"),
         Identifier("borrow"),
         [PtbArgument.res("target_address_opt")],

--- a/bindings/python/examples/gas_sponsor.py
+++ b/bindings/python/examples/gas_sponsor.py
@@ -16,7 +16,7 @@ async def main():
 
     builder = TransactionBuilder(sender).with_client(client)
 
-    package_addr = Address.std_lib()
+    package_addr = Address.std()
     module_name = Identifier("u8")
     function_name = Identifier("max")
 

--- a/bindings/python/examples/gas_station.py
+++ b/bindings/python/examples/gas_station.py
@@ -17,7 +17,7 @@ async def main():
     builder = TransactionBuilder(sender).with_client(client)
 
     builder.move_call(
-        Address.std_lib(),
+        Address.std(),
         Identifier("u64"),
         Identifier("sqrt"),
         [PtbArgument.u64(64)],

--- a/bindings/python/examples/tx_command_results.py
+++ b/bindings/python/examples/tx_command_results.py
@@ -14,7 +14,7 @@ async def main():
 
     builder = TransactionBuilder(sender).with_client(client)
 
-    package_addr = Address.std_lib()
+    package_addr = Address.std()
     module_name = Identifier("u64")
     function_name = Identifier("max")
 

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -2013,7 +2013,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate() != 48865:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib() != 35825:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_std() != 28998:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_system() != 4297:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -2796,10 +2796,10 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_generate.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_generate.restype = ctypes.c_void_p
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std_lib.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
-_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std_lib.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std.restype = ctypes.c_void_p
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_system.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
@@ -12266,9 +12266,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex.restype = c
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate.restype = ctypes.c_uint16
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_std.argtypes = (
 )
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_std_lib.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_std.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_system.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_constructor_address_system.restype = ctypes.c_uint16
@@ -27055,9 +27055,9 @@ class Address():
         return cls._make_instance_(pointer)
 
     @classmethod
-    def std_lib(cls, ):
+    def std(cls, ):
         # Call the (fallible) function before creating any half-baked object instances.
-        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std_lib,)
+        pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_address_std,)
         return cls._make_instance_(pointer)
 
     @classmethod

--- a/crates/iota-sdk-ffi/src/types/address.rs
+++ b/crates/iota-sdk-ffi/src/types/address.rs
@@ -104,6 +104,6 @@ macro_rules! named_address {
     }
 }
 
-named_address!(ZERO, STD_LIB, FRAMEWORK, SYSTEM);
+named_address!(ZERO, STD, FRAMEWORK, SYSTEM);
 
 crate::export_iota_types_objects_bcs_conversion!(Address);

--- a/crates/iota-sdk-graphql-client/src/lib.rs
+++ b/crates/iota-sdk-graphql-client/src/lib.rs
@@ -1701,7 +1701,7 @@ mod tests {
     async fn test_balance_query() {
         let client = test_client();
         client
-            .balance(Address::STD_LIB, None)
+            .balance(Address::STD, None)
             .await
             .map_err(|e| {
                 format!(
@@ -2011,7 +2011,7 @@ mod tests {
     async fn test_coins_query() {
         let client = test_client();
         client
-            .coins(Address::STD_LIB, None, PaginationFilter::default())
+            .coins(Address::STD, None, PaginationFilter::default())
             .await
             .map_err(|e| {
                 format!(

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -452,7 +452,7 @@ mod tests {
         // set up the sender, gas object, gas budget, and gas price and return the pk to
         // sign
         let (mut tx, _, pk, _) = helper_setup().await;
-        tx.move_call(Address::STD_LIB, "option", "is_none")
+        tx.move_call(Address::STD, "option", "is_none")
             .generics::<u64>()
             .arguments([Some(1u64)]);
 

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -69,7 +69,7 @@ pub struct Address(
 impl Address {
     pub const LENGTH: usize = 32;
     pub const ZERO: Self = Self([0u8; Self::LENGTH]);
-    pub const STD_LIB: Self = Self::from_u8(1);
+    pub const STD: Self = Self::from_u8(1);
     pub const FRAMEWORK: Self = Self::from_u8(2);
     pub const SYSTEM: Self = Self::from_u8(3);
 

--- a/crates/iota-sdk-types/src/type_tag/mod.rs
+++ b/crates/iota-sdk-types/src/type_tag/mod.rs
@@ -573,8 +573,8 @@ impl StructTag {
     add_struct_tag_ctor!(SYSTEM, "staking_pool", "StakedIota");
     add_struct_tag_ctor!(SYSTEM, "timelocked_staking", "TimelockedStakedIota");
     add_struct_tag_ctor!(SYSTEM, "iota_system_state_inner", "SystemEpochInfoEvent");
-    add_struct_tag_ctor!(STD_LIB, "ascii", "String", "with-module");
-    add_struct_tag_ctor!(STD_LIB, "string", "String");
+    add_struct_tag_ctor!(STD, "ascii", "String", "with-module");
+    add_struct_tag_ctor!(STD, "string", "String");
     add_struct_tag_ctor_from_struct_tag!(FRAMEWORK, "coin", "CoinMetadata");
     add_struct_tag_ctor_from_struct_tag!(FRAMEWORK, "coin", "TreasuryCap");
     add_struct_tag_ctor_from_struct_tag!(FRAMEWORK, "coin_manager", "CoinManager");

--- a/crates/iota-sdk/examples/dev_inspect.rs
+++ b/crates/iota-sdk/examples/dev_inspect.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
 
     // Step 4: Borrow the name record from the option
     builder
-        .move_call(Address::STD_LIB, "option", "borrow")
+        .move_call(Address::STD, "option", "borrow")
         .arguments([res("name_record_opt")])
         .type_tags([TypeTag::Struct(Box::new(StructTag {
             address: iota_names_package_address,
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
     // Step 6: Borrow the address from the option (this returns the resolved
     // address)
     builder
-        .move_call(Address::STD_LIB, "option", "borrow")
+        .move_call(Address::STD, "option", "borrow")
         .arguments([res("target_address_opt")])
         .generics::<Address>()
         .name("target_address");

--- a/crates/iota-sdk/examples/gas_sponsor.rs
+++ b/crates/iota-sdk/examples/gas_sponsor.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
 
     let mut builder = TransactionBuilder::new(sender_address).with_client(&client);
     let tx = builder
-        .move_call(Address::STD_LIB, "u8", "max")
+        .move_call(Address::STD, "u8", "max")
         .arguments((0u8, 1u8))
         .sponsor(sponsor_address)
         .to_owned()

--- a/crates/iota-sdk/examples/gas_station.rs
+++ b/crates/iota-sdk/examples/gas_station.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let mut builder = TransactionBuilder::new(sender).with_client(&client);
 
     builder
-        .move_call(Address::STD_LIB, "u64", "sqrt")
+        .move_call(Address::STD, "u64", "sqrt")
         .arguments([64_u64])
         .gas_station_sponsor(gas_station_url)
         .add_gas_station_header(

--- a/crates/iota-sdk/examples/tx_command_results.rs
+++ b/crates/iota-sdk/examples/tx_command_results.rs
@@ -19,12 +19,12 @@ async fn main() -> Result<()> {
 
     let mut builder = TransactionBuilder::new(sender_address).with_client(client.clone());
     builder
-        .move_call(Address::STD_LIB, "u64", "max")
+        .move_call(Address::STD, "u64", "max")
         .arguments((0u64, 1000u64))
         // Assign a name to the result of this command
         .name("res0");
     builder
-        .move_call(Address::STD_LIB, "u64", "max")
+        .move_call(Address::STD, "u64", "max")
         .arguments((1000u64, 2000u64))
         .name("res1");
 


### PR DESCRIPTION
It's just more consistent, framework and system are also libraries and don't have a suffix.