### PR TITLE
fix(iota-sdk-types): Fix feature compatability

### DIFF
--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -15,8 +15,8 @@ mod zklogin;
 pub use bls12381::{Bls12381PublicKey, Bls12381Signature};
 pub use ed25519::{Ed25519PublicKey, Ed25519Signature};
 pub use intent::{
-    HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage, IntentScope,
-    IntentVersion, PersonalMessage,
+    HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentError, IntentMessage,
+    IntentScope, IntentVersion, PersonalMessage,
 };
 pub use multisig::{
     MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -136,13 +136,13 @@ pub use checkpoint::{
 };
 pub use crypto::{
     Bls12381PublicKey, Bls12381Signature, Bn254FieldElement, CircomG1, CircomG2, Ed25519PublicKey,
-    Ed25519Signature, HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentMessage,
-    IntentScope, IntentVersion, InvalidSignatureScheme, InvalidZkLoginAuthenticatorError, Jwk,
-    JwkId, MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
-    MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PersonalMessage, PublicKeyExt,
-    Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey, Secp256r1Signature,
-    SignatureScheme, SimpleSignature, UserSignature, ZkLoginAuthenticator, ZkLoginClaim,
-    ZkLoginInputs, ZkLoginProof, ZkLoginPublicIdentifier,
+    Ed25519Signature, HashingIntentScope, INTENT_PREFIX_LENGTH, Intent, IntentAppId, IntentError,
+    IntentMessage, IntentScope, IntentVersion, InvalidSignatureScheme,
+    InvalidZkLoginAuthenticatorError, Jwk, JwkId, MultisigAggregatedSignature, MultisigCommittee,
+    MultisigMember, MultisigMemberPublicKey, MultisigMemberSignature, PasskeyAuthenticator,
+    PasskeyPublicKey, PersonalMessage, PublicKeyExt, Secp256k1PublicKey, Secp256k1Signature,
+    Secp256r1PublicKey, Secp256r1Signature, SignatureScheme, SimpleSignature, UserSignature,
+    ZkLoginAuthenticator, ZkLoginClaim, ZkLoginInputs, ZkLoginProof, ZkLoginPublicIdentifier,
 };
 pub use digest::{Digest, DigestParseError, SigningDigest};
 pub use effects::{


### PR DESCRIPTION
## Description

Fixes the feature compatability of the types crate which was failing because of an unused type when the `serde` feature flag wasn't enabled.