### PR TITLE
feat(iota-sdk-types)!: use camelCase for GasCostSummary serialization

### DIFF
--- a/crates/iota-sdk-types/src/gas.rs
+++ b/crates/iota-sdk-types/src/gas.rs
@@ -39,7 +39,11 @@
 ///                    u64 ; non-refundable-storage-fee
 /// ```
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct GasCostSummary {


### PR DESCRIPTION
Was like that in the monorepo and makes test fail without