### PR TITLE
fix(iota-sdk-transaction-builder): always wait for gas station tx to be indexed

### DIFF
--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -1169,12 +1169,10 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
 
         Ok(if let Some(gas_station_data) = gas_station_data {
             let digest = gas_station_data.execute_txn(&mut txn, signer).await?;
-            if let Some(wait_for) = wait_for {
-                self.client
-                    .wait_for_tx(digest, wait_for)
-                    .await
-                    .map_err(Error::client)?;
-            }
+            self.client
+                .wait_for_tx(digest, wait_for.unwrap_or(WaitForTx::Indexed))
+                .await
+                .map_err(Error::client)?;
             self.client
                 .transaction_effects(digest)
                 .await


### PR DESCRIPTION
Otherwise trying to get the effects can result in this error:
Missing transaction for digest 2KZUg8faUSpgtp4MS4dXThbN9MoAn6HcDT7m4q9Fn4h3
Failed here https://github.com/iotaledger/iota-rust-sdk/actions/runs/21392276765/job/61581830799?pr=516
