### PR TITLE
feat(iota-types): Better Address parsing

### DIFF
--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -9437,7 +9437,7 @@ func uniffiCheckChecksums() {
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex()
 	})
-	if checksum != 63442 {
+	if checksum != 38044 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex: UniFFI API checksum mismatch")
 	}
@@ -13118,6 +13118,9 @@ func AddressFromBytes(bytes []byte) (*Address, error) {
 		}
 }
 
+// Parses an Address from a hex string, with or without a `0x` prefix.
+// The string can be of variable length; if it's shorter than 64 hex
+// characters, it will be left-padded with `0`s.
 func AddressFromHex(hex string) (*Address, error) {
 	_uniffiRV, _uniffiErr := rustCallWithError[SdkFfiError](FfiConverterSdkFfiError{},func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
 		return C.uniffi_iota_sdk_ffi_fn_constructor_address_from_hex(FfiConverterStringINSTANCE.Lower(hex),_uniffiStatus)

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -13626,7 +13626,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_bytes() != 58901.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 63442.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 38044.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate() != 48865.toShort()) {
@@ -15704,6 +15704,11 @@ open class Address: Disposable, AutoCloseable, AddressInterface
     
 
         
+    /**
+     * Parses an Address from a hex string, with or without a `0x` prefix.
+     * The string can be of variable length; if it's shorter than 64 hex
+     * characters, it will be left-padded with `0`s.
+     */
     @Throws(SdkFfiException::class) fun `fromHex`(`hex`: kotlin.String): Address {
             return FfiConverterTypeAddress.lift(
     uniffiRustCallWithError(SdkFfiException) { _status ->

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -2477,7 +2477,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_bytes() != 58901:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 63442:
+    if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 38044:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_constructor_address_generate() != 48865:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -31878,6 +31878,12 @@ class Address():
 
     @classmethod
     def from_hex(cls, hex: "str"):
+        """
+        Parses an Address from a hex string, with or without a `0x` prefix.
+        The string can be of variable length; if it's shorter than 64 hex
+        characters, it will be left-padded with `0`s.
+        """
+
         _UniffiConverterString.check_lower(hex)
         
         # Call the (fallible) function before creating any half-baked object instances.

--- a/crates/iota-sdk-ffi/src/types/address.rs
+++ b/crates/iota-sdk-ffi/src/types/address.rs
@@ -66,6 +66,9 @@ impl Address {
     }
 
     #[uniffi::constructor]
+    /// Parses an Address from a hex string, with or without a `0x` prefix.
+    /// The string can be of variable length; if it's shorter than 64 hex
+    /// characters, it will be left-padded with `0`s.
     pub fn from_hex(hex: &str) -> Result<Self> {
         Ok(Self(iota_sdk::types::Address::from_hex(hex)?))
     }

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -161,7 +161,7 @@ impl Address {
     pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, AddressParseError> {
         let bytes = bytes.as_ref();
         <[u8; Self::LENGTH]>::try_from(bytes)
-            .map_err(|_| AddressParseError::InvalidLength {
+            .map_err(|_| AddressParseError::InvalidByteLength {
                 actual: bytes.len(),
             })
             .map(Self)
@@ -263,7 +263,7 @@ pub enum AddressParseError {
         "invalid address byte length: expected {}, got {actual}",
         Address::LENGTH
     )]
-    InvalidLength { actual: usize },
+    InvalidByteLength { actual: usize },
 }
 
 #[cfg(feature = "schemars")]
@@ -305,11 +305,119 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hex_parsing() {
-        let actual = Address::from_hex("0x2").unwrap();
-        let expected = "0x0000000000000000000000000000000000000000000000000000000000000002";
+    fn parse_address_with_0x_prefix() {
+        let hex = "0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331";
+        let address = Address::from_hex(hex).unwrap();
+        assert_eq!(address.to_string(), hex);
+    }
 
-        assert_eq!(actual.to_string(), expected);
+    #[test]
+    fn parse_address_without_0x_prefix() {
+        let hex = "02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331";
+        let address = Address::from_hex(hex).unwrap();
+        assert_eq!(
+            address.to_string(),
+            "0x02a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331"
+        );
+    }
+
+    #[test]
+    fn parse_short_address_single_digit() {
+        let address = Address::from_hex("0x1").unwrap();
+        assert_eq!(address, Address::STD);
+        assert_eq!(
+            address.to_string(),
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
+    }
+
+    #[test]
+    fn parse_short_address_without_prefix() {
+        let address = Address::from_hex("3").unwrap();
+        assert_eq!(address, Address::SYSTEM);
+    }
+
+    #[test]
+    fn parse_zero_address() {
+        let address = Address::from_hex("0x0").unwrap();
+        assert_eq!(address, Address::ZERO);
+
+        let address = Address::from_hex("0").unwrap();
+        assert_eq!(address, Address::ZERO);
+
+        let address =
+            Address::from_hex("0x0000000000000000000000000000000000000000000000000000000000000000")
+                .unwrap();
+        assert_eq!(address, Address::ZERO);
+    }
+
+    #[test]
+    fn parse_address_invalid_hex_char() {
+        let result = Address::from_hex("0xGGGG");
+        assert!(result.is_err());
+        assert!(matches!(result, Err(AddressParseError::FromHex(_))));
+    }
+
+    #[test]
+    fn parse_address_too_long() {
+        // 65 hex chars (one more than allowed 64)
+        let result = Address::from_hex(
+            "0x002a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331",
+        );
+        assert!(matches!(
+            result,
+            Err(AddressParseError::FromHex(
+                hex::FromHexError::InvalidStringLength
+            ))
+        ));
+    }
+
+    #[test]
+    fn from_bytes_valid() {
+        let bytes = [0u8; 32];
+        let address = Address::from_bytes(bytes).unwrap();
+        assert_eq!(address, Address::ZERO);
+    }
+
+    #[test]
+    fn from_bytes_invalid_length() {
+        let bytes = [0u8; 31];
+        let result = Address::from_bytes(bytes);
+        assert!(matches!(
+            result,
+            Err(AddressParseError::InvalidByteLength { actual: 31 })
+        ));
+
+        let bytes = [0u8; 33];
+        let result = Address::from_bytes(bytes);
+        assert!(matches!(
+            result,
+            Err(AddressParseError::InvalidByteLength { actual: 33 })
+        ));
+    }
+
+    #[test]
+    fn to_short_string_formats() {
+        let address = Address::from_hex("0x2").unwrap();
+        assert_eq!(address.to_short_string(true), "0x2");
+        assert_eq!(address.to_short_string(false), "2");
+
+        let zero = Address::ZERO;
+        assert_eq!(zero.to_short_string(true), "0x0");
+        assert_eq!(zero.to_short_string(false), "0");
+    }
+
+    #[test]
+    fn to_canonical_string_formats() {
+        let address = Address::from_hex("0x2").unwrap();
+        assert_eq!(
+            address.to_canonical_string(true),
+            "0x0000000000000000000000000000000000000000000000000000000000000002"
+        );
+        assert_eq!(
+            address.to_canonical_string(false),
+            "0000000000000000000000000000000000000000000000000000000000000002"
+        );
     }
 
     #[test]

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -355,7 +355,12 @@ mod tests {
     fn parse_address_invalid_hex_char() {
         let result = Address::from_hex("0xGGGG");
         assert!(result.is_err());
-        assert!(matches!(result, Err(AddressParseError::FromHex(_))));
+        assert!(matches!(
+            result,
+            Err(AddressParseError::FromHex(
+                hex::FromHexError::InvalidHexCharacter { .. }
+            ))
+        ));
     }
 
     #[test]
@@ -363,6 +368,15 @@ mod tests {
         // 65 hex chars (one more than allowed 64)
         let result = Address::from_hex(
             "0x002a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f331",
+        );
+        assert!(matches!(
+            result,
+            Err(AddressParseError::FromHex(hex::FromHexError::OddLength))
+        ));
+
+        // 66 hex chars (two more than allowed 64)
+        let result = Address::from_hex(
+            "0x002a212de6a9dfa3a69e22387acfbafbb1a9e591bd9d636e7895dcfc8de05f3316",
         );
         assert!(matches!(
             result,

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -254,7 +254,8 @@ impl<'de> serde_with::DeserializeAs<'de, [u8; Address::LENGTH]> for ReadableAddr
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error, PartialEq)]
+#[non_exhaustive]
 pub enum AddressParseError {
     #[error("address must be hex string of length {}", Address::LENGTH * 2)]
     FromHex(#[from] hex::FromHexError),

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -109,12 +109,11 @@ impl Address {
 
     pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, AddressParseError> {
         let hex = hex.as_ref();
-
-        if !hex.starts_with(b"0x") {
-            return Err(AddressParseError);
-        }
-
-        let hex = &hex[2..];
+        let hex = if hex.starts_with(b"0x") {
+            &hex[2..]
+        } else {
+            hex
+        };
 
         // If the string is too short we'll need to pad with 0's
         if hex.len() < Self::LENGTH * 2 {
@@ -128,8 +127,7 @@ impl Address {
             <[u8; Self::LENGTH] as hex::FromHex>::from_hex(hex)
         }
         .map(Self)
-        // TODO fix error to contain hex parse error
-        .map_err(|_| AddressParseError)
+        .map_err(AddressParseError::FromHex)
     }
 
     pub fn to_hex(&self) -> String {
@@ -161,8 +159,11 @@ impl Address {
     }
 
     pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, AddressParseError> {
-        <[u8; Self::LENGTH]>::try_from(bytes.as_ref())
-            .map_err(|_| AddressParseError)
+        let bytes = bytes.as_ref();
+        <[u8; Self::LENGTH]>::try_from(bytes)
+            .map_err(|_| AddressParseError::InvalidLength {
+                actual: bytes.len(),
+            })
             .map(Self)
     }
 }
@@ -253,20 +254,16 @@ impl<'de> serde_with::DeserializeAs<'de, [u8; Address::LENGTH]> for ReadableAddr
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct AddressParseError;
-
-impl std::fmt::Display for AddressParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "Unable to parse Address (must be hex string of length {})",
-            2 * Address::LENGTH
-        )
-    }
+#[derive(Debug, thiserror::Error)]
+pub enum AddressParseError {
+    #[error("address must be hex string of length {}", Address::LENGTH * 2)]
+    FromHex(#[from] hex::FromHexError),
+    #[error(
+        "invalid address byte length: expected {}, got {actual}",
+        Address::LENGTH
+    )]
+    InvalidLength { actual: usize },
 }
-
-impl std::error::Error for AddressParseError {}
 
 #[cfg(feature = "schemars")]
 impl schemars::JsonSchema for Address {

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -107,6 +107,9 @@ impl Address {
         &self.0
     }
 
+    /// Parses an Address from a hex string, with or without a `0x` prefix.
+    /// The string can be of variable length; if it's shorter than 64 hex
+    /// characters, it will be left-padded with `0`s.
     pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, AddressParseError> {
         let hex = hex.as_ref();
         let hex = if hex.starts_with(b"0x") {

--- a/crates/iota-sdk-types/src/iota_names/error.rs
+++ b/crates/iota-sdk-types/src/iota_names/error.rs
@@ -3,7 +3,7 @@
 
 use crate::{ObjectId, address::AddressParseError};
 
-#[derive(thiserror::Error, Debug, Clone, Eq, PartialEq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum IotaNamesError {
     #[error("Name length {0} exceeds maximum length {1}")]


### PR DESCRIPTION
## Description

Improves address parsing by allowing hex strings with or without the `0x` prefix, and improves the `AddressParseError`.