### PR TITLE
feat(transaction-builder): Add `TransactionSigner::address` and use it in `TransactionBuilder::execute` functions

### DIFF
--- a/crates/iota-sdk-ffi/src/transaction_builder/builder.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/builder.rs
@@ -53,8 +53,8 @@ impl TransactionBuilder {
 impl TransactionBuilder {
     /// Create a new transaction builder and initialize its elements to default.
     #[uniffi::constructor]
-    pub fn new(sender: &Address) -> Self {
-        Self(iota_sdk::transaction_builder::TransactionBuilder::new(**sender).into())
+    pub fn new() -> Self {
+        Self(iota_sdk::transaction_builder::TransactionBuilder::new().into())
     }
 
     pub fn with_client(&self, client: Arc<GraphQLClient>) -> ClientTransactionBuilder {
@@ -84,6 +84,14 @@ impl TransactionBuilder {
     pub fn gas_price(self: Arc<Self>, price: u64) -> Arc<Self> {
         self.write(|builder| {
             builder.gas_price(price);
+        });
+        self
+    }
+
+    /// Set the sender of the transaction.
+    pub fn sender(self: Arc<Self>, sender: &Address) -> Arc<Self> {
+        self.write(|builder| {
+            builder.sender(**sender);
         });
         self
     }

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -56,7 +56,7 @@ pub struct TransactionBuilder<C = (), L = ()> {
 }
 
 /// Transaction data used to build a [`Transaction`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 #[repr(C)]
 pub struct TransactionBuildData {
     /// The inputs to the transaction.
@@ -69,7 +69,7 @@ pub struct TransactionBuildData {
     /// The gas price for the transaction.
     gas_price: Option<u64>,
     /// The sender of the transaction.
-    sender: Address,
+    sender: Option<Address>,
     /// The sponsor of the transaction. If None, the sender is also the sponsor.
     sponsor: Option<Address>,
     /// The expiration of the transaction. The default value of this type is no
@@ -135,6 +135,12 @@ impl TransactionBuildData {
         self
     }
 
+    /// Set the sender.
+    pub fn sender(&mut self, sender: Address) -> &mut Self {
+        self.sender = Some(sender);
+        self
+    }
+
     /// Set the sponsor. Optional.
     pub fn sponsor(&mut self, sponsor: Address) -> &mut Self {
         self.sponsor = Some(sponsor);
@@ -188,22 +194,20 @@ impl TransactionBuildData {
 
 impl TransactionBuilder {
     /// Instantiate a new PTB.
-    pub fn new(sender: Address) -> Self {
+    pub fn new() -> Self {
         TransactionBuilder {
-            data: TransactionBuildData {
-                inputs: Default::default(),
-                commands: Default::default(),
-                gas_budget: Default::default(),
-                gas_price: Default::default(),
-                sender,
-                sponsor: Default::default(),
-                expiration: Default::default(),
-                assigned_results: Default::default(),
-                gas_station_data: Default::default(),
-            },
+            data: Default::default(),
             client: (),
             last_command: PhantomData,
         }
+    }
+
+    /// Instantiate a new PTB with the given sender.
+    pub fn new_with_sender(sender: Address) -> Self {
+        let mut builder = Self::new();
+        builder.sender(sender);
+
+        builder
     }
 
     /// Set the client to enable automatic object resolution.
@@ -262,6 +266,15 @@ impl<C, L> TransactionBuilder<C, L> {
     /// Set the gas price. Optional.
     pub fn gas_price(&mut self, gas_price: u64) -> &mut Self {
         self.data.gas_price(gas_price);
+        self
+    }
+
+    /// Set the sender.
+    ///
+    /// If no sender is set, it will be derived from the signer during
+    /// transaction finalization.
+    pub fn sender(&mut self, sender: Address) -> &mut Self {
+        self.data.sender(sender);
         self
     }
 
@@ -348,7 +361,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let sender =
     ///     Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     ///
     /// # builder
     /// #     .split_coins(
@@ -418,7 +431,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let to_address =
     ///     Address::from_hex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
     ///
-    /// let mut builder = TransactionBuilder::new(from_address).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(from_address).with_client(client);
     /// builder.send_iota(to_address, 5000000000u64);
     /// let txn = builder.finish().await?;
     /// # Ok(())
@@ -478,7 +491,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let coin =
     ///     ObjectId::from_hex("0x8ef4259fa2a3499826fa4b8aebeb1d8e478cf5397d05361c96438940b43d28c9")?;
     ///
-    /// let mut builder = TransactionBuilder::new(from_address).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(from_address).with_client(client);
     /// builder.send_coins([coin], to_address, 50000000000u64);
     /// let txn = builder.finish().await?;
     /// #   Ok(())
@@ -552,7 +565,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let coin_1 =
     ///     ObjectId::from_hex("0xd04077fe3b6fad13b3d4ed0d535b7ca92afcac8f0f2a0e0925fb9f4f0b30c699")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     /// builder.merge_coins(coin_0, [coin_1]);
     /// let txn = builder.finish().await?;
     /// # Ok(())
@@ -589,7 +602,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let coin =
     ///     ObjectId::from_hex("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     /// builder
     ///     .split_coins(coin, [1000u64, 2000, 3000])
     ///     .assign(("coin1", "coin2", "coin3"))
@@ -665,7 +678,7 @@ impl<C, L> TransactionBuilder<C, L> {
     ///     .address
     ///     .address;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     /// builder.stake(1000000000u64, validator_address);
     /// let txn = builder.finish().await?;
     /// # Ok(())
@@ -700,7 +713,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let staked_iota =
     ///     ObjectId::from_hex("0x00030af99878926cd11f8bdf4d2f67c4aa753a4afc249d776c8ed2cc88d7b8d5")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     /// builder.unstake(staked_iota);
     /// let txn = builder.finish().await?;
     /// # Ok(())
@@ -735,7 +748,7 @@ impl<C, L> TransactionBuilder<C, L> {
     /// let client = iota_graphql_client::Client::new_devnet();
     /// let sender = "0x71b4b4f171b4355ff691b7c470579cf1a926f96f724e5f9a30efc4b5f75d085e".parse()?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     ///
     /// let address1 =
     ///     Address::from_str("0xde49ea53fbadee67d3e35a097cdbea210b659676fc680a0b0c5f11d0763d375e")?;
@@ -782,7 +795,7 @@ impl<L> TransactionBuilder<(), L> {
     /// let sender =
     ///     Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender);
     ///
     /// let gas_coin1 = ObjectReference {
     ///     object_id: ObjectId::from_str(
@@ -856,15 +869,16 @@ impl<L> TransactionBuilder<(), L> {
             .into_iter()
             .map(|c| c.resolve(&input_map))
             .collect();
+        let sender = self.data.sender.ok_or(Error::MissingSender)?;
         Ok(TransactionV1 {
             kind: iota_types::TransactionKind::ProgrammableTransaction(ProgrammableTransaction {
                 inputs,
                 commands,
             }),
-            sender: self.data.sender,
+            sender,
             gas_payment: GasPayment {
                 objects: gas,
-                owner: self.data.sponsor.unwrap_or(self.data.sender),
+                owner: self.data.sponsor.unwrap_or(sender),
                 price,
                 budget: self.data.gas_budget.unwrap_or(0),
             },
@@ -886,6 +900,7 @@ impl<L> TransactionBuilder<(), L> {
         let gas_station_data = self.data.gas_station_data.take();
 
         Ok(if let Some(gas_station_data) = gas_station_data {
+            self.data.sender = Some(signer.address());
             let mut txn = self.finish()?;
             gas_station_data.execute_txn_json(&mut txn, signer).await?
         } else {
@@ -926,7 +941,7 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
     /// let sender =
     ///     Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
     ///
-    /// let mut builder = TransactionBuilder::new(sender).with_client(client);
+    /// let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
     ///
     /// let gas_coin1 =
     ///     ObjectId::from_str("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")?;
@@ -952,6 +967,11 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
         let mut inputs = Vec::new();
         let mut gas = Vec::new();
         let mut input_map = HashMap::new();
+
+        // Ensure transaction sender has been set before this call.
+        let Some(sender) = self.data.sender else {
+            return Err(Error::MissingSender);
+        };
 
         if default_gas && !self.data.inputs.values().any(|i| i.is_gas) {
             // Some commands have arguments which cannot safely be replaced by
@@ -979,7 +999,7 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
                 .client
                 .objects(
                     Some(StructTag::new_gas_coin().into()),
-                    Some(self.data.sponsor.unwrap_or(self.data.sender)),
+                    Some(self.data.sponsor.unwrap_or(sender)),
                     None,
                     true,
                     None,
@@ -1099,10 +1119,10 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
                 inputs,
                 commands,
             }),
-            sender: self.data.sender,
+            sender,
             gas_payment: GasPayment {
                 objects: gas,
-                owner: self.data.sponsor.unwrap_or(self.data.sender),
+                owner: self.data.sponsor.unwrap_or(sender),
                 price,
                 budget: self.data.gas_budget.unwrap_or(0),
             },
@@ -1165,6 +1185,7 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
     ) -> Result<TransactionEffects, Error> {
         let wait_for = wait_for.into();
         let gas_station_data = self.data.gas_station_data.take();
+        self.sender(signer.address());
         let mut txn = self.finish_internal().await?;
 
         Ok(if let Some(gas_station_data) = gas_station_data {
@@ -1199,6 +1220,8 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
         wait_for: impl Into<Option<WaitForTx>>,
     ) -> Result<TransactionEffects, Error> {
         let wait_for = wait_for.into();
+        self.sender(signer.address());
+        self.sponsor(sponsor_signer.address());
         let txn = self.finish_internal().await?;
 
         let signatures = vec![

--- a/crates/iota-sdk-transaction-builder/src/builder/signer.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/signer.rs
@@ -10,7 +10,7 @@ use iota_crypto::{
     IotaSigner, SignatureError, ed25519::Ed25519PrivateKey, secp256k1::Secp256k1PrivateKey,
     secp256r1::Secp256r1PrivateKey, simple::SimpleKeypair,
 };
-use iota_types::{MoveAuthenticator, Transaction, UserSignature};
+use iota_types::{Address, MoveAuthenticator, Transaction, UserSignature};
 
 /// Defines a type which can sign a transaction asynchronously.
 ///
@@ -20,6 +20,9 @@ use iota_types::{MoveAuthenticator, Transaction, UserSignature};
 pub trait TransactionSigner {
     /// The error that can occur during signing.
     type Error: 'static + std::error::Error + Send + Sync;
+
+    /// Returns the address associated with this signer.
+    fn address(&self) -> Address;
 
     /// Sign a transaction and return a [`UserSignature`].
     fn sign(
@@ -33,6 +36,10 @@ macro_rules! impl_basic_signer {
         $(
         impl TransactionSigner for $signer {
             type Error = SignatureError;
+
+            fn address(&self) -> Address {
+                self.public_key().derive_address()
+            }
 
             async fn sign(&self, transaction: &Transaction) -> Result<UserSignature, Self::Error> {
                 self.sign_transaction(transaction)
@@ -51,6 +58,10 @@ impl_basic_signer!(
 
 impl TransactionSigner for MoveAuthenticator {
     type Error = SignatureError;
+
+    fn address(&self) -> Address {
+        self.address()
+    }
 
     async fn sign(&self, _transaction: &Transaction) -> Result<UserSignature, Self::Error> {
         Ok(UserSignature::MoveAuthenticator(self.clone()))

--- a/crates/iota-sdk-transaction-builder/src/error.rs
+++ b/crates/iota-sdk-transaction-builder/src/error.rs
@@ -35,6 +35,8 @@ pub enum Error {
     MissingGasBudget,
     #[error("Missing gas price")]
     MissingGasPrice,
+    #[error("Missing transaction sender")]
+    MissingSender,
     #[error("Missing object kind for object {0}")]
     MissingObjectKind(ObjectId),
     #[error("Missing initial shared version for object {0}")]

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -35,7 +35,7 @@
 //! let to_address =
 //!     Address::from_str("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
 //!
-//! let mut builder = TransactionBuilder::new(sender).with_client(Client::new_devnet());
+//! let mut builder = TransactionBuilder::new_with_sender(sender).with_client(Client::new_devnet());
 //!
 //! let coin =
 //!     ObjectId::from_str("0x8ef4259fa2a3499826fa4b8aebeb1d8e478cf5397d05361c96438940b43d28c9")?;
@@ -59,7 +59,7 @@
 //! let to_address =
 //!     Address::from_str("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
 //!
-//! let mut builder = TransactionBuilder::new(sender);
+//! let mut builder = TransactionBuilder::new_with_sender(sender);
 //!
 //! let coin = ObjectReference {
 //!     object_id: ObjectId::from_str(
@@ -358,7 +358,7 @@ mod tests {
     ) {
         let (address, pk) = helper_address_pk();
         let client = Client::new_localnet();
-        let mut tx = TransactionBuilder::new(address).with_client(client.clone());
+        let mut tx = TransactionBuilder::new().with_client(client.clone());
         let coins = FaucetClient::new_localnet()
             .request_and_wait(address)
             .await
@@ -394,7 +394,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_finish() {
-        let mut tx = TransactionBuilder::new(
+        let mut tx = TransactionBuilder::new();
+        tx.sender(
             "0xc574ea804d9c1a27c886312e96c0e2c9cfd71923ebaeb3000d04b5e65fca2793"
                 .parse()
                 .unwrap(),
@@ -586,7 +587,7 @@ mod tests {
         check_effects_status_success(effects).await;
 
         let client = Client::new_localnet();
-        let mut tx = TransactionBuilder::new(address).with_client(&client);
+        let mut tx = TransactionBuilder::new().with_client(&client);
         let mut upgrade_cap = None;
         for o in created_objs {
             let obj = client.object(o, None).await.unwrap().unwrap();

--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -236,6 +236,23 @@ impl crate::PasskeyPublicKey {
     }
 }
 
+impl crate::MultisigMemberPublicKey {
+    /// Derive an `Address` from this MultisigMemberPublicKey.
+    ///
+    /// An `Address` can be derived from a `MultisigMemberPublicKey` by
+    /// delegating to the corresponding public key's `derive_address` method.
+    pub fn derive_address(&self) -> Address {
+        use crate::MultisigMemberPublicKey::*;
+
+        match self {
+            Ed25519(p) => p.derive_address(),
+            Secp256k1(p) => p.derive_address(),
+            Secp256r1(p) => p.derive_address(),
+            ZkLogin(p) => p.derive_address_padded(),
+        }
+    }
+}
+
 impl crate::MultisigCommittee {
     /// Derive an `Address` from this MultisigCommittee.
     ///

--- a/crates/iota-sdk/examples/dev_inspect.rs
+++ b/crates/iota-sdk/examples/dev_inspect.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
 
     println!("Looking up name: {name}");
 
-    let mut builder = TransactionBuilder::new(sender).with_client(client);
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
 
     // Step 1: Get the shared registry object
     builder

--- a/crates/iota-sdk/examples/gas_sponsor.rs
+++ b/crates/iota-sdk/examples/gas_sponsor.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let sponsor_address =
         Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
 
-    let mut builder = TransactionBuilder::new(sender_address).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(sender_address).with_client(&client);
     let tx = builder
         .move_call(Address::STD, "u8", "max")
         .arguments((0u8, 1u8))

--- a/crates/iota-sdk/examples/gas_station.rs
+++ b/crates/iota-sdk/examples/gas_station.rs
@@ -14,9 +14,8 @@ async fn main() -> Result<()> {
     let gas_station_url = reqwest::Url::parse("http://0.0.0.0:9527")?;
     let gas_station_auth_token = "test";
     let keypair = Ed25519PrivateKey::generate(rand::thread_rng());
-    let sender = keypair.public_key().derive_address();
 
-    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    let mut builder = TransactionBuilder::new().with_client(&client);
 
     builder
         .move_call(Address::STD, "u64", "sqrt")

--- a/crates/iota-sdk/examples/generic_move_function.rs
+++ b/crates/iota-sdk/examples/generic_move_function.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<()> {
 
     let sender = "0x71b4b4f171b4355ff691b7c470579cf1a926f96f724e5f9a30efc4b5f75d085e".parse()?;
 
-    let mut builder = TransactionBuilder::new(sender).with_client(client);
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client);
 
     let address1 =
         Address::from_str("0xde49ea53fbadee67d3e35a097cdbea210b659676fc680a0b0c5f11d0763d375e")?;

--- a/crates/iota-sdk/examples/prepare_merge_coins.rs
+++ b/crates/iota-sdk/examples/prepare_merge_coins.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     let coin_1 =
         ObjectId::from_str("0xd04077fe3b6fad13b3d4ed0d535b7ca92afcac8f0f2a0e0925fb9f4f0b30c699")?;
 
-    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(&client);
 
     builder.merge_coins(coin_0, [coin_1]);
 

--- a/crates/iota-sdk/examples/prepare_send_coins.rs
+++ b/crates/iota-sdk/examples/prepare_send_coins.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     let coin =
         ObjectId::from_str("0x8ef4259fa2a3499826fa4b8aebeb1d8e478cf5397d05361c96438940b43d28c9")?;
 
-    let mut builder = TransactionBuilder::new(from_address).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(from_address).with_client(&client);
 
     builder.send_coins([coin], to_address, 50000000000u64);
 

--- a/crates/iota-sdk/examples/prepare_send_iota.rs
+++ b/crates/iota-sdk/examples/prepare_send_iota.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let to_address =
         Address::from_str("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
 
-    let mut builder = TransactionBuilder::new(from_address).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(from_address).with_client(&client);
 
     builder.send_iota(to_address, 5000000000u64);
 

--- a/crates/iota-sdk/examples/prepare_send_iota_multi.rs
+++ b/crates/iota-sdk/examples/prepare_send_iota_multi.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
         ),
     ];
 
-    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(&client);
 
     // Extract amounts from recipients
     let amounts: Vec<u64> = recipients.iter().map(|(_, amt)| *amt).collect();

--- a/crates/iota-sdk/examples/prepare_split_coins.rs
+++ b/crates/iota-sdk/examples/prepare_split_coins.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<()> {
     let coin =
         ObjectId::from_str("0x0b0270ee9d27da0db09651e5f7338dfa32c7ee6441ccefa1f6e305735bcfc7ab")?;
 
-    let mut builder = TransactionBuilder::new(sender).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(&client);
 
     builder
         .split_coins(coin, [1000u64, 2000, 3000])

--- a/crates/iota-sdk/examples/prepare_transfer_objects.rs
+++ b/crates/iota-sdk/examples/prepare_transfer_objects.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
         ObjectId::from_str("0x8ef4259fa2a3499826fa4b8aebeb1d8e478cf5397d05361c96438940b43d28c9")?,
     ];
 
-    let mut builder = TransactionBuilder::new(from_address).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(from_address).with_client(&client);
 
     builder.transfer_objects(to_address, objs_to_transfer);
 

--- a/crates/iota-sdk/examples/prepare_transfer_objects_offline.rs
+++ b/crates/iota-sdk/examples/prepare_transfer_objects_offline.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         .object_ref();
     let gas_price = client.reference_gas_price(None).await?.unwrap_or(100);
 
-    let mut builder = TransactionBuilder::new(from_address);
+    let mut builder = TransactionBuilder::new_with_sender(from_address);
 
     builder
         .transfer_objects(to_address, objs_to_transfer)

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<()> {
     let client = Client::new_localnet();
 
     // Build the `publish` PTB
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client.clone());
     builder
         // Publish the package and receive the upgrade cap
         .publish(package_data.clone())
@@ -125,7 +125,7 @@ async fn main() -> Result<()> {
     };
 
     // Build the `upgrade` PTB
-    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+    let mut builder = TransactionBuilder::new_with_sender(sender).with_client(client.clone());
     builder
         // Authorize the upgrade by providing the upgrade cap object id to receive an upgrade
         // ticket

--- a/crates/iota-sdk/examples/sign_send_iota.rs
+++ b/crates/iota-sdk/examples/sign_send_iota.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
 
     let client = Client::new_localnet();
 
-    let mut builder = TransactionBuilder::new(sender_address).with_client(&client);
+    let mut builder = TransactionBuilder::new_with_sender(sender_address).with_client(&client);
     builder.send_iota(recipient_address, amount);
     let tx = builder.finish().await?;
 

--- a/crates/iota-sdk/examples/stake.rs
+++ b/crates/iota-sdk/examples/stake.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         validator.name.as_deref().unwrap_or("with no name")
     );
 
-    let mut builder = TransactionBuilder::new(my_address).with_client(client);
+    let mut builder = TransactionBuilder::new_with_sender(my_address).with_client(client);
 
     builder.stake(1000000000u64, validator.address.address);
 

--- a/crates/iota-sdk/examples/transaction_signer_callback.rs
+++ b/crates/iota-sdk/examples/transaction_signer_callback.rs
@@ -14,6 +14,10 @@ struct AsyncSigner(Ed25519PrivateKey);
 impl TransactionSigner for AsyncSigner {
     type Error = SignatureError;
 
+    fn address(&self) -> Address {
+        self.0.public_key().derive_address()
+    }
+
     async fn sign(&self, transaction: &Transaction) -> Result<UserSignature, Self::Error> {
         self.0.sign_transaction(transaction)
     }
@@ -37,7 +41,7 @@ async fn main() -> Result<()> {
 
     let client = Client::new_localnet();
 
-    let mut builder = TransactionBuilder::new(sender_address).with_client(&client);
+    let mut builder = TransactionBuilder::new().with_client(&client);
     builder.send_iota(recipient_address, amount);
 
     let signer = AsyncSigner(private_key);

--- a/crates/iota-sdk/examples/tx_command_results.rs
+++ b/crates/iota-sdk/examples/tx_command_results.rs
@@ -17,7 +17,8 @@ async fn main() -> Result<()> {
     let sender_address =
         Address::from_str("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")?;
 
-    let mut builder = TransactionBuilder::new(sender_address).with_client(client.clone());
+    let mut builder =
+        TransactionBuilder::new_with_sender(sender_address).with_client(client.clone());
     builder
         .move_call(Address::STD, "u64", "max")
         .arguments((0u64, 1000u64))

--- a/crates/iota-sdk/examples/unstake.rs
+++ b/crates/iota-sdk/examples/unstake.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         .ok_or_eyre("no staked iota found")?;
 
     let mut builder =
-        TransactionBuilder::new(*staked_iota.owner().as_address()).with_client(client);
+        TransactionBuilder::new_with_sender(*staked_iota.owner().as_address()).with_client(client);
 
     builder.unstake(staked_iota.object_id());
 


### PR DESCRIPTION
# Description
- Add method `fn address(&self) -> Address` to trait `TransactionSigner`
- Add `TransactionBuilder::new_with_sender`
- Add `MissingSender` variant to `transaction_builder::Error`
- Change `TransactionBuilder::new(sender: Address)` to `TransactionBuilder::new()`

# Related Issues
Closes #539 
