### PR TITLE
fix(faucet): fix request_and_wait()

### DIFF
--- a/crates/iota-sdk-graphql-client/src/faucet.rs
+++ b/crates/iota-sdk-graphql-client/src/faucet.rs
@@ -215,6 +215,8 @@ impl FaucetClient {
                 );
                 FaucetError::TimedOut
             })??;
+            // Wait some extra time for the indexer to process the objects
+            tokio::time::sleep(Duration::from_millis(250)).await;
             Ok(status_response.transferred_gas_objects)
         } else {
             Ok(None)


### PR DESCRIPTION
Currently when the response is returned, the indexer might have not processed the objects and using the client will then result in errors if it's assumed that the objects are available already, adding a small sleep fixes this
Alternative would be to accept the Client as parameter to the function and use it to actually check if a new created object is available, however I think it's not worth it since the request would also take some time and the function is only used for testing