### PR TITLE
feat(transaction-builder): Add `set_sender` method

### DIFF
--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -5160,6 +5160,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender()
+	})
+	if checksum != 20194 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins()
 	})
 	if checksum != 2932 {
@@ -8477,6 +8486,15 @@ func uniffiCheckChecksums() {
 	if checksum != 2185 {
 		// If this happens try cleaning and rebuilding your project
 		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender()
+	})
+	if checksum != 37952 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -16257,6 +16275,8 @@ type ClientTransactionBuilderInterface interface {
 	// equals 1_000_000_000 NANOS. That amount is split from the gas coin and
 	// sent.
 	SendIota(recipient *Address, amount *PtbArgument) *ClientTransactionBuilder
+	// Set the sender address.
+	SetSender(sender *Address) 
 	// Split a coin into many.
 	SplitCoins(coin *PtbArgument, amounts []*PtbArgument, names []string) *ClientTransactionBuilder
 	// Set the sponsor of the transaction.
@@ -16559,6 +16579,17 @@ func (_self *ClientTransactionBuilder) SendIota(recipient *Address, amount *PtbA
 		return C.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_iota(
 		_pointer,FfiConverterAddressINSTANCE.Lower(recipient), FfiConverterPtbArgumentINSTANCE.Lower(amount),_uniffiStatus)
 	}))
+}
+
+// Set the sender address.
+func (_self *ClientTransactionBuilder) SetSender(sender *Address)  {
+	_pointer := _self.ffiObject.incrementPointer("*ClientTransactionBuilder")
+	defer _self.ffiObject.decrementPointer()
+	rustCall(func(_uniffiStatus *C.RustCallStatus) bool {
+		C.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender(
+		_pointer,FfiConverterAddressINSTANCE.Lower(sender),_uniffiStatus)
+		return false
+	})
 }
 
 // Split a coin into many.
@@ -32479,6 +32510,8 @@ type TransactionBuilderInterface interface {
 	// equals 1_000_000_000 NANOS. That amount is split from the gas coin and
 	// sent.
 	SendIota(recipient *Address, amount *PtbArgument) *TransactionBuilder
+	// Set the sender address.
+	SetSender(sender *Address) 
 	// Split a coin by the provided amounts.
 	SplitCoins(coin *PtbArgument, amounts []*PtbArgument, names []string) *TransactionBuilder
 	// Set the sponsor of the transaction.
@@ -32719,6 +32752,17 @@ func (_self *TransactionBuilder) SendIota(recipient *Address, amount *PtbArgumen
 		return C.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(
 		_pointer,FfiConverterAddressINSTANCE.Lower(recipient), FfiConverterPtbArgumentINSTANCE.Lower(amount),_uniffiStatus)
 	}))
+}
+
+// Set the sender address.
+func (_self *TransactionBuilder) SetSender(sender *Address)  {
+	_pointer := _self.ffiObject.incrementPointer("*TransactionBuilder")
+	defer _self.ffiObject.decrementPointer()
+	rustCall(func(_uniffiStatus *C.RustCallStatus) bool {
+		C.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender(
+		_pointer,FfiConverterAddressINSTANCE.Lower(sender),_uniffiStatus)
+		return false
+	})
 }
 
 // Split a coin by the provided amounts.

--- a/bindings/go/iota_sdk/iota_sdk.h
+++ b/bindings/go/iota_sdk/iota_sdk.h
@@ -1404,6 +1404,11 @@ void* uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_coins(void* pt
 void* uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_iota(void* ptr, void* recipient, void* amount, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_CLIENTTRANSACTIONBUILDER_SET_SENDER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_CLIENTTRANSACTIONBUILDER_SET_SENDER
+void uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender(void* ptr, void* sender, RustCallStatus *out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_CLIENTTRANSACTIONBUILDER_SPLIT_COINS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_CLIENTTRANSACTIONBUILDER_SPLIT_COINS
 void* uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_split_coins(void* ptr, void* coin, RustBuffer amounts, RustBuffer names, RustCallStatus *out_status
@@ -6287,6 +6292,11 @@ void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_coins(void* ptr, Rus
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SEND_IOTA
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SEND_IOTA
 void* uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(void* ptr, void* recipient, void* amount, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SET_SENDER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SET_SENDER
+void uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender(void* ptr, void* sender, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_TRANSACTIONBUILDER_SPLIT_COINS
@@ -13277,6 +13287,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota(
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_CLIENTTRANSACTIONBUILDER_SET_SENDER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_CLIENTTRANSACTIONBUILDER_SET_SENDER
+uint16_t uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_CLIENTTRANSACTIONBUILDER_SPLIT_COINS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_CLIENTTRANSACTIONBUILDER_SPLIT_COINS
 uint16_t uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins(void
@@ -15488,6 +15504,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_TRANSACTIONBUILDER_SEND_IOTA
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_TRANSACTIONBUILDER_SEND_IOTA
 uint16_t uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_TRANSACTIONBUILDER_SET_SENDER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_TRANSACTIONBUILDER_SET_SENDER
+uint16_t uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender(void
     
 );
 #endif

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -3959,6 +3959,10 @@ internal open class UniffiVTableCallbackInterfaceTransactionSignerFn(
 
 
 
+
+
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -5040,6 +5044,8 @@ fun uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_coins(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota(
 ): Short
+fun uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender(
+): Short
 fun uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_sponsor(
@@ -5777,6 +5783,8 @@ fun uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_publish(
 fun uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota(
+): Short
+fun uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins(
 ): Short
@@ -7138,6 +7146,8 @@ fun uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_coins(`ptr`: Poi
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_iota(`ptr`: Pointer,`recipient`: Pointer,`amount`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
+fun uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender(`ptr`: Pointer,`sender`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 fun uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_split_coins(`ptr`: Pointer,`coin`: Pointer,`amounts`: RustBuffer.ByValue,`names`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_sponsor(`ptr`: Pointer,`sponsor`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -9068,6 +9078,8 @@ fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_coins(`ptr`: Pointer,`
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota(`ptr`: Pointer,`recipient`: Pointer,`amount`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
+fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender(`ptr`: Pointer,`sender`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): Unit
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_split_coins(`ptr`: Pointer,`coin`: Pointer,`amounts`: RustBuffer.ByValue,`names`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_transactionbuilder_sponsor(`ptr`: Pointer,`sponsor`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -12201,6 +12213,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota() != 65011.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender() != 20194.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins() != 2932.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
@@ -13306,6 +13321,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 2185.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender() != 37952.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins() != 17747.toShort()) {
@@ -21994,6 +22012,11 @@ public interface ClientTransactionBuilderInterface {
     fun `sendIota`(`recipient`: Address, `amount`: PtbArgument): ClientTransactionBuilder
     
     /**
+     * Set the sender address.
+     */
+    fun `setSender`(`sender`: Address)
+    
+    /**
      * Split a coin into many.
      */
     fun `splitCoins`(`coin`: PtbArgument, `amounts`: List<PtbArgument>, `names`: List<kotlin.String> = listOf()): ClientTransactionBuilder
@@ -22421,6 +22444,20 @@ open class ClientTransactionBuilder: Disposable, AutoCloseable, ClientTransactio
     }
     )
     }
+    
+
+    
+    /**
+     * Set the sender address.
+     */override fun `setSender`(`sender`: Address)
+        = 
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender(
+        it, FfiConverterTypeAddress.lower(`sender`),_status)
+}
+    }
+    
     
 
     
@@ -50605,6 +50642,11 @@ public interface TransactionBuilderInterface {
     fun `sendIota`(`recipient`: Address, `amount`: PtbArgument): TransactionBuilder
     
     /**
+     * Set the sender address.
+     */
+    fun `setSender`(`sender`: Address)
+    
+    /**
      * Split a coin by the provided amounts.
      */
     fun `splitCoins`(`coin`: PtbArgument, `amounts`: List<PtbArgument>, `names`: List<kotlin.String> = listOf()): TransactionBuilder
@@ -50993,6 +51035,20 @@ open class TransactionBuilder: Disposable, AutoCloseable, TransactionBuilderInte
     }
     )
     }
+    
+
+    
+    /**
+     * Set the sender address.
+     */override fun `setSender`(`sender`: Address)
+        = 
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender(
+        it, FfiConverterTypeAddress.lower(`sender`),_status)
+}
+    }
+    
     
 
     

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -1527,6 +1527,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota() != 65011:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender() != 20194:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins() != 2932:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_sponsor() != 44990:
@@ -2264,6 +2266,8 @@ def _uniffi_check_api_checksums(lib):
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins() != 6220:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota() != 2185:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender() != 37952:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins() != 17747:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -4387,6 +4391,12 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_iota.argt
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_send_iota.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender.argtypes = (
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender.restype = None
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_split_coins.argtypes = (
     ctypes.c_void_p,
     ctypes.c_void_p,
@@ -9473,6 +9483,12 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota.argtypes =
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_send_iota.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender.argtypes = (
+    ctypes.c_void_p,
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender.restype = None
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_split_coins.argtypes = (
     ctypes.c_void_p,
     ctypes.c_void_p,
@@ -14899,6 +14915,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_coi
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_send_iota.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_set_sender.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_clienttransactionbuilder_split_coins.restype = ctypes.c_uint16
@@ -16006,6 +16025,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_coins.res
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_send_iota.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_set_sender.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_transactionbuilder_split_coins.restype = ctypes.c_uint16
@@ -35377,6 +35399,12 @@ class ClientTransactionBuilderProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
+    def set_sender(self, sender: "Address"):
+        """
+        Set the sender address.
+        """
+
+        raise NotImplementedError
     def split_coins(self, coin: "PtbArgument",amounts: "typing.List[PtbArgument]",names: "typing.Union[object, typing.List[str]]" = _DEFAULT):
         """
         Split a coin into many.
@@ -35831,6 +35859,21 @@ _UniffiConverterTypeSdkFfiError,
         _UniffiConverterTypeAddress.lower(recipient),
         _UniffiConverterTypePtbArgument.lower(amount))
         )
+
+
+
+
+
+    def set_sender(self, sender: "Address") -> None:
+        """
+        Set the sender address.
+        """
+
+        _UniffiConverterTypeAddress.check_lower(sender)
+        
+        _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_clienttransactionbuilder_set_sender,self._uniffi_clone_pointer(),
+        _UniffiConverterTypeAddress.lower(sender))
+
 
 
 
@@ -52234,6 +52277,12 @@ class TransactionBuilderProtocol(typing.Protocol):
         """
 
         raise NotImplementedError
+    def set_sender(self, sender: "Address"):
+        """
+        Set the sender address.
+        """
+
+        raise NotImplementedError
     def split_coins(self, coin: "PtbArgument",amounts: "typing.List[PtbArgument]",names: "typing.Union[object, typing.List[str]]" = _DEFAULT):
         """
         Split a coin by the provided amounts.
@@ -52627,6 +52676,21 @@ _UniffiConverterTypeSdkFfiError,
         _UniffiConverterTypeAddress.lower(recipient),
         _UniffiConverterTypePtbArgument.lower(amount))
         )
+
+
+
+
+
+    def set_sender(self, sender: "Address") -> None:
+        """
+        Set the sender address.
+        """
+
+        _UniffiConverterTypeAddress.check_lower(sender)
+        
+        _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_transactionbuilder_set_sender,self._uniffi_clone_pointer(),
+        _UniffiConverterTypeAddress.lower(sender))
+
 
 
 

--- a/crates/iota-sdk-ffi/src/transaction_builder/builder.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/builder.rs
@@ -64,6 +64,13 @@ impl TransactionBuilder {
         )
     }
 
+    /// Set the sender address.
+    pub fn set_sender(self: Arc<Self>, sender: &Address) {
+        self.write(|builder| {
+            builder.set_sender(**sender);
+        });
+    }
+
     /// Add gas coins that will be consumed. Optional.
     pub fn gas(self: Arc<Self>, object_refs: Vec<ObjectReference>) -> Arc<Self> {
         self.write(|builder| {

--- a/crates/iota-sdk-ffi/src/transaction_builder/client_builder.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/client_builder.rs
@@ -53,6 +53,13 @@ impl ClientTransactionBuilder {
 
 #[uniffi::export(async_runtime = "tokio")]
 impl ClientTransactionBuilder {
+    /// Set the sender address.
+    pub fn set_sender(self: Arc<Self>, sender: &Address) {
+        self.write(|builder| {
+            builder.set_sender(**sender);
+        });
+    }
+
     /// Add gas coins that will be consumed. Optional.
     pub fn gas(self: Arc<Self>, object_ids: Vec<Arc<ObjectId>>) -> Arc<Self> {
         self.write(|builder| {

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -82,6 +82,10 @@ pub struct TransactionBuildData {
 }
 
 impl TransactionBuildData {
+    fn set_sender(&mut self, sender: Address) {
+        self.sender = sender;
+    }
+
     fn set_input(&mut self, kind: InputKind, is_gas: bool) -> Argument {
         if let Some((i, input)) = self.inputs.iter_mut().find(|(_, input)| {
             match (kind.object_id(), input.kind.object_id()) {
@@ -204,6 +208,11 @@ impl TransactionBuilder {
             client: (),
             last_command: PhantomData,
         }
+    }
+
+    /// Set the sender address.
+    pub fn set_sender(&mut self, sender: Address) {
+        self.data.set_sender(sender);
     }
 
     /// Set the client to enable automatic object resolution.

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -210,11 +210,6 @@ impl TransactionBuilder {
         }
     }
 
-    /// Set the sender address.
-    pub fn set_sender(&mut self, sender: Address) {
-        self.data.set_sender(sender);
-    }
-
     /// Set the client to enable automatic object resolution.
     pub fn with_client<C>(self, client: C) -> TransactionBuilder<C> {
         TransactionBuilder {
@@ -226,6 +221,11 @@ impl TransactionBuilder {
 }
 
 impl<C, L> TransactionBuilder<C, L> {
+    /// Set the sender address.
+    pub fn set_sender(&mut self, sender: Address) {
+        self.data.set_sender(sender);
+    }
+
     /// Apply the given parameter and return the generated argument
     pub fn apply_argument<P: PTBArgument>(&mut self, param: P) -> Argument {
         param.arg(&mut self.data)


### PR DESCRIPTION
## Description

Adds a `set_sender` method to the transaction builder to allow for special use-cases.

Closes #539