### PR TITLE
chore!: remove `BalanceChange` type

### DIFF
--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Address, Identifier, ObjectId, StructTag, TypeTag};
+use super::{Address, Identifier, ObjectId, StructTag};
 
 /// Events emitted during the successful execution of a transaction
 ///
@@ -56,26 +56,4 @@ pub struct Event {
     )]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::Base64"))]
     pub contents: Vec<u8>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-pub struct BalanceChange {
-    /// Owner of the balance change
-    pub address: Address,
-    /// Type of the Coin
-    pub coin_type: TypeTag,
-    /// The amount indicate the balance value changes.
-    ///
-    /// A negative amount means spending coin value and positive means receiving
-    /// coin value.
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::I128"))]
-    pub amount: i128,
 }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -486,32 +486,6 @@ mod _schemars {
         }
     }
 
-    #[expect(dead_code)]
-    pub(crate) struct I128;
-
-    impl JsonSchema for I128 {
-        fn schema_name() -> String {
-            "i128".to_owned()
-        }
-
-        fn json_schema(_: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
-            SchemaObject {
-                metadata: Some(Box::new(Metadata {
-                    description: Some("Radix-10 encoded 128-bit signed integer".to_owned()),
-                    ..Default::default()
-                })),
-                instance_type: Some(InstanceType::String.into()),
-                format: Some("i128".to_owned()),
-                ..Default::default()
-            }
-            .into()
-        }
-
-        fn is_referenceable() -> bool {
-            false
-        }
-    }
-
     pub(crate) struct U256;
 
     impl JsonSchema for U256 {

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -151,7 +151,7 @@ pub use effects::{
     ChangedObject, IdOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsV1,
     UnchangedSharedKind, UnchangedSharedObject,
 };
-pub use events::{BalanceChange, Event, TransactionEvents};
+pub use events::{Event, TransactionEvents};
 pub use execution_status::{
     CommandArgumentError, ExecutionError, ExecutionStatus, MoveLocation, PackageUpgradeError,
     TypeArgumentError,
@@ -486,6 +486,7 @@ mod _schemars {
         }
     }
 
+    #[expect(dead_code)]
     pub(crate) struct I128;
 
     impl JsonSchema for I128 {

--- a/crates/iota-sdk-types/src/serialization_proptests.rs
+++ b/crates/iota-sdk-types/src/serialization_proptests.rs
@@ -122,7 +122,6 @@ serialization_test!(TransactionEffects);
 serialization_test!(TransactionEffectsV1);
 serialization_test!(UnchangedSharedKind);
 serialization_test!(UnchangedSharedObject);
-serialization_test!(BalanceChange);
 serialization_test!(Event);
 serialization_test!(TransactionEvents);
 serialization_test!(CommandArgumentError);


### PR DESCRIPTION
If I am not mistaken, this type is completely useless in the SDK, because:

- it's not exported in the FFI
- is incompatible with the graphql schema spec (which allows different owner variants)
- only compatible with the REST API version, but the SDK doesn't provide a client for that.

Therefore this PR removes it.