### PR TITLE
Add IOTA Names example across Rust, Python, Go, and Kotlin

### DIFF
--- a/bindings/go/examples/iota_names/main.go
+++ b/bindings/go/examples/iota_names/main.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func main() {
+	client := iota_sdk.GraphQlClientNewDevnet()
+
+	name := "name.iota"
+	fmt.Printf("Resolving name: %s\n", name)
+
+	resolvedAddressOpt, err := client.IotaNamesLookup(name)
+	if err != nil {
+		log.Fatalf("Failed to lookup name: %v", err)
+	}
+	if resolvedAddressOpt == nil {
+		fmt.Printf("No address resolved for %s\n", name)
+		return
+	}
+	resolvedAddress := *resolvedAddressOpt
+	fmt.Printf("Resolved address: %s\n", resolvedAddress.ToHex())
+
+	dotFormat := iota_sdk.NameFormatDot
+	defaultNameDotOpt, err := client.IotaNamesDefaultName(resolvedAddress, &dotFormat)
+	if err != nil {
+		log.Fatalf("Failed to fetch default dot-format name: %v", err)
+	}
+	if defaultNameDotOpt == nil {
+		fmt.Println("No default dot-format name found")
+	} else {
+		defaultNameDot := *defaultNameDotOpt
+		fmt.Printf("Default name (dot): %s\n", defaultNameDot.String())
+	}
+
+	atFormat := iota_sdk.NameFormatAt
+	defaultNameAtOpt, err := client.IotaNamesDefaultName(resolvedAddress, &atFormat)
+	if err != nil {
+		log.Fatalf("Failed to fetch default at-format name: %v", err)
+	}
+	if defaultNameAtOpt == nil {
+		fmt.Println("No default at-format name found")
+	} else {
+		defaultNameAt := *defaultNameAtOpt
+		fmt.Printf("Default name (at): %s\n", defaultNameAt.Format(iota_sdk.NameFormatAt))
+	}
+
+	limit := int32(10)
+	registrations, err := client.IotaNamesRegistrations(
+		resolvedAddress,
+		iota_sdk.PaginationFilter{Direction: iota_sdk.DirectionForward, Limit: &limit},
+	)
+	if err != nil {
+		log.Fatalf("Failed to fetch registrations: %v", err)
+	}
+
+	if len(registrations.Data) == 0 {
+		fmt.Println("No IOTA Names registrations found for this address")
+		return
+	}
+
+	fmt.Printf("Registrations (%d):\n", len(registrations.Data))
+	for _, registration := range registrations.Data {
+		fmt.Printf(
+			"- %s (id: %s, expires_at_ms: %d)\n",
+			registration.NameStr(),
+			registration.Id().ToHex(),
+			registration.ExpirationTimestampMs(),
+		)
+	}
+}

--- a/bindings/kotlin/examples/IotaNames.kt
+++ b/bindings/kotlin/examples/IotaNames.kt
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.Direction
+import iota_sdk.GraphQlClient
+import iota_sdk.NameFormat
+import iota_sdk.PaginationFilter
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+
+        val name = "name.iota"
+        println("Resolving name: $name")
+
+        val resolvedAddress = client.iotaNamesLookup(name)
+        if (resolvedAddress == null) {
+            println("No address resolved for $name")
+            return@runBlocking
+        }
+        println("Resolved address: ${resolvedAddress.toHex()}")
+
+        val defaultNameDot = client.iotaNamesDefaultName(resolvedAddress, NameFormat.DOT)
+        if (defaultNameDot == null) {
+            println("No default dot-format name found")
+        } else {
+            println("Default name (dot): $defaultNameDot")
+        }
+
+        val defaultNameAt = client.iotaNamesDefaultName(resolvedAddress, NameFormat.AT)
+        if (defaultNameAt == null) {
+            println("No default at-format name found")
+        } else {
+            println("Default name (at): ${defaultNameAt.format(NameFormat.AT)}")
+        }
+
+        val registrations = client.iotaNamesRegistrations(
+            resolvedAddress,
+            PaginationFilter(direction = Direction.FORWARD, limit = 10),
+        )
+
+        if (registrations.data.isEmpty()) {
+            println("No IOTA Names registrations found for this address")
+            return@runBlocking
+        }
+
+        println("Registrations (${registrations.data.size}):")
+        for (registration in registrations.data) {
+            println(
+                "- ${registration.nameStr()} " +
+                    "(id: ${registration.id().toHex()}, " +
+                    "expires_at_ms: ${registration.expirationTimestampMs()})"
+            )
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/iota_names.py
+++ b/bindings/python/examples/iota_names.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+async def main():
+    client = GraphQlClient.new_devnet()
+
+    name = "name.iota"
+    print(f"Resolving name: {name}")
+
+    resolved_address = await client.iota_names_lookup(name)
+    if resolved_address is None:
+        print(f"No address resolved for {name}")
+        return
+
+    print(f"Resolved address: {resolved_address.to_hex()}")
+
+    default_name_dot = await client.iota_names_default_name(
+        resolved_address,
+        NameFormat.DOT,
+    )
+    if default_name_dot is None:
+        print("No default dot-format name found")
+    else:
+        print(f"Default name (dot): {default_name_dot}")
+
+    default_name_at = await client.iota_names_default_name(
+        resolved_address,
+        NameFormat.AT,
+    )
+    if default_name_at is None:
+        print("No default at-format name found")
+    else:
+        print(f"Default name (at): {default_name_at.format(NameFormat.AT)}")
+
+    registrations = await client.iota_names_registrations(
+        resolved_address,
+        PaginationFilter(direction=Direction.FORWARD, limit=10),
+    )
+
+    if len(registrations.data) == 0:
+        print("No IOTA Names registrations found for this address")
+        return
+
+    print(f"Registrations ({len(registrations.data)}):")
+    for registration in registrations.data:
+        print(
+            f"- {registration.name_str()} "
+            f"(id: {registration.id().to_hex()}, "
+            f"expires_at_ms: {registration.expiration_timestamp_ms()})"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-sdk/examples/iota_names.rs
+++ b/crates/iota-sdk/examples/iota_names.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use iota_sdk::{
+    graphql_client::{error::Result, pagination::PaginationFilter, Client},
+    types::iota_names::{IotaNamesNft, NameFormat},
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let name = "name.iota";
+    println!("Resolving name: {name}");
+
+    let Some(resolved_address) = client.iota_names_lookup(name).await? else {
+        println!("No address resolved for {name}");
+        return Ok(());
+    };
+    println!("Resolved address: {resolved_address}");
+
+    let default_name_dot = client
+        .iota_names_default_name(resolved_address.clone(), Some(NameFormat::Dot))
+        .await?;
+    match default_name_dot {
+        Some(default_name) => println!("Default name (dot): {default_name}"),
+        None => println!("No default dot-format name found"),
+    }
+
+    let default_name_at = client
+        .iota_names_default_name(resolved_address.clone(), Some(NameFormat::At))
+        .await?;
+    match default_name_at {
+        Some(default_name) => {
+            println!("Default name (at): {}", default_name.format(NameFormat::At))
+        }
+        None => println!("No default at-format name found"),
+    }
+
+    let registrations = client
+        .iota_names_registrations(
+            resolved_address,
+            PaginationFilter {
+                limit: Some(10),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    if registrations.is_empty() {
+        println!("No IOTA Names registrations found for this address");
+        return Ok(());
+    }
+
+    println!("Registrations ({}):", registrations.data().len());
+    for registration in registrations.data() {
+        println!(
+            "- {} (id: {}, expires_at_ms: {})",
+            registration.name_str(),
+            registration.id(),
+            registration.expiration_timestamp_ms()
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a new Rust example: `crates/iota-sdk/examples/iota_names.rs`
- add matching IOTA Names examples for Python, Go, and Kotlin bindings
- cover the major IOTA Names operations in each example:
  - `iota_names_lookup`
  - `iota_names_default_name` (dot + at formats)
  - `iota_names_registrations` with pagination

## Notes
- examples gracefully handle missing name resolution and empty registration pages
- changes are limited to new example files only

Fixes #514
