### PR TITLE
chore(ci): revert to use released alpha binary

### DIFF
--- a/.github/actions/start-local-network/action.yml
+++ b/.github/actions/start-local-network/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Get the IOTA alphanet binary and start a local network
       shell: bash
       env:
-        IOTA_BINARY_VERSION: "v1.17.0-alpha"
+        IOTA_BINARY_VERSION: "v1.16.0-alpha"
         EPOCH_DURATION_MS: "10000"
         GH_TOKEN: ${{ github.token }}
       run: |

--- a/.github/actions/start-local-network/action.yml
+++ b/.github/actions/start-local-network/action.yml
@@ -23,23 +23,23 @@ runs:
     - name: Get the IOTA alphanet binary and start a local network
       shell: bash
       env:
-        IOTA_BINARY_VERSION: "v1.15.0-alpha"
+        IOTA_BINARY_VERSION: "v1.17.0-alpha"
         EPOCH_DURATION_MS: "10000"
         GH_TOKEN: ${{ github.token }}
       run: |
         # Uncomment when using a nightly build
-        nightly=$(gh run list --repo iotaledger/iota --workflow release.yml --status success --event schedule --branch develop --limit 1 --json startedAt --json databaseId -q '.[0]')
-        database_id=$(echo $nightly | jq '.databaseId')
-        started_at=$(echo $nightly | jq -r '.startedAt' | cut -dT -f1)
-        gh run download --repo iotaledger/iota $database_id -n "iota-nightly-$started_at-linux-x86_64"
-        tar -zxvf "iota-nightly-$started_at-linux-x86_64.tgz" ./iota
+        # nightly=$(gh run list --repo iotaledger/iota --workflow release.yml --status success --event schedule --branch develop --limit 1 --json startedAt --json databaseId -q '.[0]')
+        # database_id=$(echo $nightly | jq '.databaseId')
+        # started_at=$(echo $nightly | jq -r '.startedAt' | cut -dT -f1)
+        # gh run download --repo iotaledger/iota $database_id -n "iota-nightly-$started_at-linux-x86_64"
+        # tar -zxvf "iota-nightly-$started_at-linux-x86_64.tgz" ./iota
 
         # Uncomment when using a released build
-        # ASSET_NAME="iota-$IOTA_BINARY_VERSION-linux-x86_64.tgz"
-        # download_url="https://github.com/iotaledger/iota/releases/download/$IOTA_BINARY_VERSION/$ASSET_NAME"
-        # echo "Downloading binary from $download_url"
-        # wget -q $download_url -O iota.tgz
-        # tar -zxvf iota.tgz ./iota
+        ASSET_NAME="iota-$IOTA_BINARY_VERSION-linux-x86_64.tgz"
+        download_url="https://github.com/iotaledger/iota/releases/download/$IOTA_BINARY_VERSION/$ASSET_NAME"
+        echo "Downloading binary from $download_url"
+        wget -q $download_url -O iota.tgz
+        tar -zxvf iota.tgz ./iota
 
         chmod +x ./iota
         echo "Starting local network with a faucet, an indexer (port 5432) and GraphQL. Epoch duration is set to $EPOCH_DURATION_MS ms"

--- a/.github/actions/start-local-network/action.yml
+++ b/.github/actions/start-local-network/action.yml
@@ -23,7 +23,7 @@ runs:
     - name: Get the IOTA alphanet binary and start a local network
       shell: bash
       env:
-        IOTA_BINARY_VERSION: "v1.16.0-alpha"
+        IOTA_BINARY_VERSION: "v1.16.2"
         EPOCH_DURATION_MS: "10000"
         GH_TOKEN: ${{ github.token }}
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Get the IOTA alphanet binary
         shell: bash
         env:
-          IOTA_BINARY_VERSION: "v1.16.0-alpha"
+          IOTA_BINARY_VERSION: "v1.16.2"
         run: |
           ASSET_NAME="iota-$IOTA_BINARY_VERSION-linux-x86_64.tgz"
           download_url="https://github.com/iotaledger/iota/releases/download/$IOTA_BINARY_VERSION/$ASSET_NAME"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Get the IOTA alphanet binary
         shell: bash
         env:
-          IOTA_BINARY_VERSION: "v1.17.0-alpha"
+          IOTA_BINARY_VERSION: "v1.16.0-alpha"
         run: |
           ASSET_NAME="iota-$IOTA_BINARY_VERSION-linux-x86_64.tgz"
           download_url="https://github.com/iotaledger/iota/releases/download/$IOTA_BINARY_VERSION/$ASSET_NAME"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Get the IOTA alphanet binary
         shell: bash
         env:
-          IOTA_BINARY_VERSION: "v1.15.0-alpha"
+          IOTA_BINARY_VERSION: "v1.17.0-alpha"
         run: |
           ASSET_NAME="iota-$IOTA_BINARY_VERSION-linux-x86_64.tgz"
           download_url="https://github.com/iotaledger/iota/releases/download/$IOTA_BINARY_VERSION/$ASSET_NAME"


### PR DESCRIPTION
We should use released versions whenever possible as nightly builds are possibly unstable. They were used because AA was not released yet.