### PR TITLE
[Bounty] Add move package example across SDK bindings

### DIFF
--- a/bindings/go/examples/move_package/main.go
+++ b/bindings/go/examples/move_package/main.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func main() {
+	client := iota_sdk.GraphQlClientNewDevnet()
+
+	packageAddress, err := iota_sdk.AddressFromHex("0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f")
+	if err != nil {
+		log.Fatalf("Failed to parse address: %v", err)
+	}
+
+	packageVersions, err := client.PackageVersions(packageAddress, nil, nil, nil)
+	if err != nil {
+		log.Fatalf("Failed to get package versions: %v", err)
+	}
+	if len(packageVersions.Data) == 0 {
+		log.Fatalf("No package versions found")
+	}
+
+	versions := make([]uint64, 0, len(packageVersions.Data))
+	for _, pkg := range packageVersions.Data {
+		versions = append(versions, pkg.Version())
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	fmt.Printf("Versions: %v\n", versions)
+
+	latestPackageOpt, err := client.PackageLatest(packageAddress)
+	if err != nil {
+		log.Fatalf("Failed to get latest package: %v", err)
+	}
+	if latestPackageOpt == nil {
+		log.Fatalf("Latest package not found")
+	}
+	latestPackage := *latestPackageOpt
+
+	fmt.Printf("Latest package id: %s\n", latestPackage.Id().ToHex())
+	fmt.Printf("Latest package version: %d\n", latestPackage.Version())
+
+	dependencies := latestPackage.LinkageTable()
+	if len(dependencies) == 0 {
+		fmt.Println("Dependencies: none")
+	} else {
+		fmt.Println("Dependencies:")
+		for dependency := range dependencies {
+			fmt.Printf("- %s\n", dependency.ToHex())
+		}
+	}
+
+	latestVersion := latestPackage.Version()
+	for moduleId := range latestPackage.Modules() {
+		moduleOpt, err := client.NormalizedMoveModule(
+			packageAddress,
+			moduleId.AsStr(),
+			&latestVersion,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+		if err != nil {
+			log.Fatalf("Failed to get module: %v", err)
+		}
+		if moduleOpt == nil {
+			continue
+		}
+		module := *moduleOpt
+
+		fmt.Printf("\nModule: %s\n", moduleId.AsStr())
+		if module.Functions != nil {
+			fmt.Printf("Functions: %d\n", len(module.Functions.Nodes))
+		}
+
+		if module.Structs != nil {
+			fmt.Printf("Structs: %d\n", len(module.Structs.Nodes))
+			for i, moveStruct := range module.Structs.Nodes {
+				if i >= 2 {
+					break
+				}
+				structType := fmt.Sprintf("%s::%s::%s", latestPackage.Id().ToHex(), moduleId.AsStr(), moveStruct.Name)
+				typedObjects, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &structType}, nil)
+				if err != nil {
+					log.Fatalf("Failed to query objects by type: %v", err)
+				}
+				if len(typedObjects.Data) > 0 {
+					fmt.Printf("- %s -> example object %s\n", moveStruct.Name, typedObjects.Data[0].ObjectId().ToHex())
+				} else {
+					fmt.Printf("- %s -> no objects found\n", moveStruct.Name)
+				}
+			}
+		}
+	}
+}

--- a/bindings/kotlin/examples/MovePackage.kt
+++ b/bindings/kotlin/examples/MovePackage.kt
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.Address
+import iota_sdk.GraphQlClient
+import iota_sdk.ObjectFilter
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+
+        val packageAddress =
+            Address.fromHex("0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f")
+
+        val packageVersions = client.`packageVersions`(packageAddress)
+        if (packageVersions.data.isEmpty()) {
+            println("No package versions found")
+            return@runBlocking
+        }
+
+        val versions = packageVersions.data.map { pkg -> pkg.version() }.sorted()
+        println("Versions: $versions")
+
+        val latestPackage = client.`packageLatest`(packageAddress)
+        if (latestPackage == null) {
+            println("Latest package not found")
+            return@runBlocking
+        }
+
+        println("Latest package id: ${latestPackage.id().toHex()}")
+        println("Latest package version: ${latestPackage.version()}")
+
+        val dependencies = latestPackage.linkageTable()
+        if (dependencies.isEmpty()) {
+            println("Dependencies: none")
+        } else {
+            println("Dependencies:")
+            for ((dependency, _) in dependencies) {
+                println("- ${dependency.toHex()}")
+            }
+        }
+
+        for ((moduleId, _) in latestPackage.modules()) {
+            val module = client.normalizedMoveModule(
+                packageAddress,
+                moduleId.asStr(),
+                latestPackage.version(),
+            )
+            if (module == null) {
+                continue
+            }
+
+            println("\nModule: ${moduleId.asStr()}")
+            module.functions?.let { functions ->
+                println("Functions: ${functions.nodes.size}")
+            }
+
+            module.structs?.let { structs ->
+                println("Structs: ${structs.nodes.size}")
+                for (moveStruct in structs.nodes.take(2)) {
+                    val structType =
+                        "${latestPackage.id().toHex()}::${moduleId.asStr()}::${moveStruct.name}"
+                    val typedObjects = client.objects(ObjectFilter(typeTag = structType))
+                    if (typedObjects.data.isNotEmpty()) {
+                        println("- ${moveStruct.name} -> example object ${typedObjects.data[0].objectId().toHex()}")
+                    } else {
+                        println("- ${moveStruct.name} -> no objects found")
+                    }
+                }
+            }
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/move_package.py
+++ b/bindings/python/examples/move_package.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+async def main():
+    client = GraphQlClient.new_devnet()
+
+    package_address = Address.from_hex(
+        "0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f")
+
+    package_versions = await client.package_versions(package_address)
+    if len(package_versions.data) == 0:
+        raise Exception("No package versions found")
+
+    versions = sorted([pkg.version() for pkg in package_versions.data])
+    print(f"Versions: {versions}")
+
+    latest_package = await client.package_latest(package_address)
+    if latest_package is None:
+        raise Exception("Latest package not found")
+
+    print(f"Latest package id: {latest_package.id().to_hex()}")
+    print(f"Latest package version: {latest_package.version()}")
+
+    dependencies = latest_package.linkage_table()
+    if len(dependencies) == 0:
+        print("Dependencies: none")
+    else:
+        print("Dependencies:")
+        for dep_id in dependencies.keys():
+            print(f"- {dep_id.to_hex()}")
+
+    for module_id in latest_package.modules():
+        module = await client.normalized_move_module(
+            package_address,
+            module_id.as_str(),
+            latest_package.version(),
+        )
+        if module is None:
+            continue
+
+        print(f"\nModule: {module_id.as_str()}")
+
+        if module.functions is not None:
+            print(f"Functions: {len(module.functions.nodes)}")
+
+        if module.structs is not None:
+            print(f"Structs: {len(module.structs.nodes)}")
+            for move_struct in module.structs.nodes[:2]:
+                struct_type = f"{latest_package.id().to_hex()}::{module_id.as_str()}::{move_struct.name}"
+                typed_objects = await client.objects(
+                    filter=ObjectFilter(type_tag=struct_type))
+                if len(typed_objects.data) > 0:
+                    print(
+                        f"- {move_struct.name} -> example object {typed_objects.data[0].object_id().to_hex()}")
+                else:
+                    print(f"- {move_struct.name} -> no objects found")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-sdk/examples/move_package.rs
+++ b/crates/iota-sdk/examples/move_package.rs
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use eyre::Result;
+use iota_sdk::{
+    graphql_client::{Client, query_types::ObjectFilter},
+    types::Address,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let package_address =
+        Address::from_str("0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f")?;
+
+    let package_versions = client
+        .package_versions(package_address, Default::default(), None, None)
+        .await?;
+    if package_versions.data.is_empty() {
+        eyre::bail!("no package versions found")
+    }
+
+    let mut versions: Vec<u64> = package_versions.data.iter().map(|pkg| pkg.version()).collect();
+    versions.sort_unstable();
+    println!("Versions: {versions:?}");
+
+    let Some(latest_package) = client.package_latest(package_address).await? else {
+        eyre::bail!("latest package not found")
+    };
+
+    println!("Latest package id: {}", latest_package.id());
+    println!("Latest package version: {}", latest_package.version());
+
+    let dependencies = latest_package.linkage_table();
+    if dependencies.is_empty() {
+        println!("Dependencies: none");
+    } else {
+        println!("Dependencies:");
+        for dependency in dependencies.keys() {
+            println!("- {dependency}");
+        }
+    }
+
+    for (module_id, _) in latest_package.modules() {
+        let Some(module) = client
+            .normalized_move_module(
+                package_address,
+                module_id.as_str(),
+                Some(latest_package.version()),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
+            .await?
+        else {
+            continue;
+        };
+
+        println!("\nModule: {module_id}");
+
+        if let Some(functions) = module.functions {
+            println!("Functions: {}", functions.nodes.len());
+        }
+
+        if let Some(structs) = module.structs {
+            println!("Structs: {}", structs.nodes.len());
+            for move_struct in structs.nodes.iter().take(2) {
+                let struct_type = format!("{}::{module_id}::{}", latest_package.id(), move_struct.name);
+                let objects = client
+                    .objects(
+                        ObjectFilter {
+                            type_: Some(struct_type.clone()),
+                            ..Default::default()
+                        },
+                        Default::default(),
+                    )
+                    .await?;
+                if let Some(obj) = objects.data.first() {
+                    println!("- {} -> example object {}", move_struct.name, obj.object_id());
+                } else {
+                    println!("- {} -> no objects found", move_struct.name);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a new `move_package` example in Rust
- add matching `move_package` examples in Python, Go, and Kotlin bindings
- example shows package versions, latest version details, dependencies, modules/functions, and typed object lookup for package structs

## Notes
- This is examples-only work for issue #515.
- Local toolchain is not available in this environment (no cargo/go), so I could only run Python syntax check.