### PR TITLE
[Bounty] Add multisig address example across SDK bindings

### DIFF
--- a/bindings/go/examples/multisig_address/main.go
+++ b/bindings/go/examples/multisig_address/main.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func main() {
+	recipientAddress, err := iota_sdk.AddressFromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
+	if err != nil {
+		log.Fatalf("Failed to parse recipient address: %v", err)
+	}
+
+	signer1, err := iota_sdk.NewEd25519PrivateKey(make([]byte, 32))
+	if err != nil {
+		log.Fatalf("Failed to create signer1: %v", err)
+	}
+	signer2Bytes := make([]byte, 32)
+	signer2Bytes[0] = 1
+	signer2, err := iota_sdk.NewEd25519PrivateKey(signer2Bytes)
+	if err != nil {
+		log.Fatalf("Failed to create signer2: %v", err)
+	}
+
+	simple1 := iota_sdk.SimpleKeypairFromEd25519(signer1)
+	simple2 := iota_sdk.SimpleKeypairFromEd25519(signer2)
+
+	committee := iota_sdk.NewMultisigCommittee(
+		[]*iota_sdk.MultisigMember{
+			iota_sdk.NewMultisigMember(simple1.PublicKey(), 1),
+			iota_sdk.NewMultisigMember(simple2.PublicKey(), 1),
+		},
+		2,
+	)
+
+	if !committee.IsValid() {
+		log.Fatalf("Multisig committee is invalid")
+	}
+
+	multisigAddress := committee.DeriveAddress()
+	log.Printf("Multisig sender address: %s", multisigAddress.ToHex())
+
+	client := iota_sdk.GraphQlClientNewLocalnet()
+
+	faucet := iota_sdk.FaucetClientNewLocalnet()
+	_, err = faucet.RequestAndWaitForFinalized(multisigAddress, client)
+	if err != nil {
+		log.Fatalf("Failed to request faucet: %v", err)
+	}
+
+	builder := iota_sdk.NewTransactionBuilder(multisigAddress).WithClient(client)
+	builder.SendIota(recipientAddress, iota_sdk.PtbArgumentU64(1000))
+	txn, err := builder.Finish()
+	if err != nil {
+		log.Fatalf("Failed to build transaction: %v", err)
+	}
+
+	dryRunResult, err := client.DryRunTx(txn, false)
+	if err != nil {
+		log.Fatalf("Failed to dry run: %v", err)
+	}
+	if dryRunResult.Error != nil {
+		log.Fatalf("Dry run failed: %s", *dryRunResult.Error)
+	}
+
+	sig1, err := simple1.SignTransaction(txn)
+	if err != nil {
+		log.Fatalf("Failed to sign with signer1: %v", err)
+	}
+	sig2, err := simple2.SignTransaction(txn)
+	if err != nil {
+		log.Fatalf("Failed to sign with signer2: %v", err)
+	}
+
+	aggregator := iota_sdk.MultisigAggregatorNewWithTransaction(committee, txn)
+	aggregator, err = aggregator.WithSignature(sig1)
+	if err != nil {
+		log.Fatalf("Failed to add signer1 signature: %v", err)
+	}
+	aggregator, err = aggregator.WithSignature(sig2)
+	if err != nil {
+		log.Fatalf("Failed to add signer2 signature: %v", err)
+	}
+
+	multisigSig, err := aggregator.Finish()
+	if err != nil {
+		log.Fatalf("Failed to build multisig signature: %v", err)
+	}
+
+	userSig := iota_sdk.UserSignatureNewMultisig(multisigSig)
+	effects, err := client.ExecuteTx([]*iota_sdk.UserSignature{userSig}, txn, nil)
+	if err != nil {
+		log.Fatalf("Failed to execute transaction: %v", err)
+	}
+
+	log.Printf("Digest: %s", iota_sdk.HexEncode((*effects).Digest().ToBytes()))
+	log.Printf("Transaction status: %v", (*effects).AsV1().Status)
+	log.Printf("Effects: %+v", (*effects).AsV1())
+}

--- a/bindings/kotlin/examples/MultisigAddress.kt
+++ b/bindings/kotlin/examples/MultisigAddress.kt
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.*
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val recipientAddress =
+            Address.fromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
+
+        val signer1 = Ed25519PrivateKey(ByteArray(32))
+        val signer2 = Ed25519PrivateKey(ByteArray(32).also { it[0] = 1 })
+
+        val simple1 = SimpleKeypair.fromEd25519(signer1)
+        val simple2 = SimpleKeypair.fromEd25519(signer2)
+
+        val committee = MultisigCommittee(
+            listOf(
+                MultisigMember(simple1.publicKey(), 1u.toUByte()),
+                MultisigMember(simple2.publicKey(), 1u.toUByte()),
+            ),
+            2u.toUShort(),
+        )
+
+        if (!committee.isValid()) {
+            throw Exception("Multisig committee is invalid")
+        }
+
+        val multisigAddress = committee.deriveAddress()
+        println("Multisig sender address: ${multisigAddress.toHex()}")
+
+        val client = GraphQlClient.newLocalnet()
+
+        val faucet = FaucetClient.newLocalnet()
+        faucet.requestAndWaitForFinalized(multisigAddress, client)
+
+        val builder = TransactionBuilder(multisigAddress).withClient(client)
+        builder.sendIota(recipientAddress, PtbArgument.u64(1000uL))
+        val txn = builder.finish()
+
+        val dryRunResult = client.dryRunTx(txn, false)
+        if (dryRunResult.error != null) {
+            throw Exception("Dry run failed: ${dryRunResult.error}")
+        }
+
+        val sig1 = simple1.signTransaction(txn)
+        val sig2 = simple2.signTransaction(txn)
+
+        var aggregator = MultisigAggregator.newWithTransaction(committee, txn)
+        aggregator = aggregator.withSignature(sig1)
+        aggregator = aggregator.withSignature(sig2)
+
+        val multisigSig = UserSignature.newMultisig(aggregator.finish())
+        val effects = client.executeTx(listOf(multisigSig), txn)
+
+        println("Digest: ${hexEncode(effects.digest().toBytes())}")
+        println("Transaction status: ${effects.asV1().status}")
+        println("Effects: ${effects.asV1()}")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/multisig_address.py
+++ b/bindings/python/examples/multisig_address.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+async def main():
+    recipient_address = Address.from_hex(
+        "0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
+
+    signer_1 = Ed25519PrivateKey(b"\x00" * 32)
+    signer_2 = Ed25519PrivateKey(b"\x01" * 32)
+
+    simple_1 = SimpleKeypair.from_ed25519(signer_1)
+    simple_2 = SimpleKeypair.from_ed25519(signer_2)
+
+    committee = MultisigCommittee([
+        MultisigMember(simple_1.public_key(), 1),
+        MultisigMember(simple_2.public_key(), 1),
+    ], 2)
+
+    if not committee.is_valid():
+        raise Exception("Multisig committee is invalid")
+
+    multisig_address = committee.derive_address()
+    print(f"Multisig sender address: {multisig_address.to_hex()}")
+
+    client = GraphQlClient.new_localnet()
+
+    faucet = FaucetClient.new_localnet()
+    await faucet.request_and_wait_for_finalized(multisig_address, client)
+
+    builder = TransactionBuilder(multisig_address).with_client(client)
+    builder.send_iota(recipient_address, PtbArgument.u64(1000))
+    txn = await builder.finish()
+
+    dry_run_result = await client.dry_run_tx(txn)
+    if dry_run_result.error is not None:
+        raise Exception(f"Dry run failed: {dry_run_result.error}")
+
+    sig_1 = simple_1.sign_transaction(txn)
+    sig_2 = simple_2.sign_transaction(txn)
+
+    aggregator = MultisigAggregator.new_with_transaction(committee, txn)
+    aggregator = aggregator.with_signature(sig_1)
+    aggregator = aggregator.with_signature(sig_2)
+
+    multisig_signature = UserSignature.new_multisig(aggregator.finish())
+    effects = await client.execute_tx([multisig_signature], txn)
+
+    print(f"Digest: {hex_encode(effects.digest().to_bytes())}")
+    print(f"Transaction status: {effects.as_v1().status}")
+    print(f"Effects: {effects.as_v1()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-sdk/examples/multisig_address.rs
+++ b/crates/iota-sdk/examples/multisig_address.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use iota_sdk::{
+    crypto::{IotaSigner, ed25519::Ed25519PrivateKey, multisig::MultisigAggregator},
+    graphql_client::{Client, faucet::FaucetClient},
+    transaction_builder::TransactionBuilder,
+    types::{Address, MultisigCommittee, MultisigMember, MultisigMemberPublicKey, UserSignature},
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let recipient_address =
+        Address::from_hex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
+
+    let signer_1 = Ed25519PrivateKey::new([0; Ed25519PrivateKey::LENGTH]);
+    let signer_2 = Ed25519PrivateKey::new([1; Ed25519PrivateKey::LENGTH]);
+
+    let committee = MultisigCommittee::new(
+        vec![
+            MultisigMember::new(MultisigMemberPublicKey::Ed25519(signer_1.public_key()), 1),
+            MultisigMember::new(MultisigMemberPublicKey::Ed25519(signer_2.public_key()), 1),
+        ],
+        2,
+    );
+
+    if !committee.is_valid() {
+        eyre::bail!("multisig committee is invalid")
+    }
+
+    let multisig_address = committee.derive_address();
+    println!("Multisig sender address: {multisig_address}");
+
+    let client = Client::new_localnet();
+
+    FaucetClient::new_localnet()
+        .request_and_wait_for_finalized(multisig_address, &client)
+        .await?;
+
+    let mut builder = TransactionBuilder::new(multisig_address).with_client(&client);
+    builder.send_iota(recipient_address, 1_000);
+    let tx = builder.finish().await?;
+
+    let dry_run_result = client.dry_run_tx(&tx, false).await?;
+    if let Some(err) = dry_run_result.error {
+        eyre::bail!("Dry run failed: {err}");
+    }
+
+    let sig_1 = signer_1.sign_transaction(&tx)?;
+    let sig_2 = signer_2.sign_transaction(&tx)?;
+
+    let mut aggregator = MultisigAggregator::new_with_transaction(committee, &tx);
+    aggregator.add_signature(sig_1)?;
+    aggregator.add_signature(sig_2)?;
+
+    let multisig_signature = UserSignature::Multisig(aggregator.finish()?);
+    let effects = client.execute_tx(&[multisig_signature], &tx, None).await?;
+
+    println!("Digest: {}", effects.digest());
+    println!("Transaction status: {:?}", effects.status());
+    println!("Effects: {effects:#?}");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a multisig address example in Rust
- add matching examples in Python, Go, and Kotlin bindings
- flow includes: create 2-of-2 multisig committee, derive multisig address, fund via faucet, build tx, collect two signatures, aggregate multisig signature, and execute tx

## Notes
- This addresses issue #501.
- Local environment does not have cargo/go toolchains, so compile checks were not run here.