### PR TITLE
feat(examples): add move package inspection example across bindings

### DIFF
--- a/bindings/go/examples/move_package/main.go
+++ b/bindings/go/examples/move_package/main.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+const packageAddressHex = "0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f"
+
+func main() {
+	client := iota_sdk.GraphQlClientNewDevnet()
+
+	packageAddress, err := iota_sdk.AddressFromHex(packageAddressHex)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to parse package address: %v", err)
+	}
+
+	pkg, err := client.Package(packageAddress, nil)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to fetch package: %v", err)
+	}
+	if pkg == nil {
+		log.Fatalf("Missing package: %s", packageAddressHex)
+	}
+
+	packageID := pkg.Id().ToHex()
+	packageVersion := pkg.Version()
+
+	fmt.Printf("Package ID: %s\n", packageID)
+	fmt.Printf("Current version: %d\n\n", packageVersion)
+
+	versionsPage, err := client.PackageVersions(packageAddress, nil, nil, nil)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to fetch package versions: %v", err)
+	}
+
+	versions := versionsPage.Data
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].Version() < versions[j].Version()
+	})
+
+	fmt.Println("Package versions:")
+	for _, versionedPkg := range versions {
+		marker := ""
+		if versionedPkg.Id().ToHex() == packageID && versionedPkg.Version() == packageVersion {
+			marker = " (current)"
+		}
+		fmt.Printf("- id=%s version=%d%s\n", versionedPkg.Id().ToHex(), versionedPkg.Version(), marker)
+	}
+	fmt.Println()
+
+	fmt.Println("Dependencies:")
+	dependencies := pkg.LinkageTable()
+	if len(dependencies) == 0 {
+		fmt.Println("- none")
+	} else {
+		for originalID, info := range dependencies {
+			fmt.Printf("- %s -> %s (version %d)\n", originalID.ToHex(), info.UpgradedId.ToHex(), info.UpgradedVersion)
+		}
+	}
+	fmt.Println()
+
+	moduleIDs := pkg.Modules()
+	moduleNames := make([]string, 0, len(moduleIDs))
+	moduleIDByName := make(map[string]*iota_sdk.Identifier, len(moduleIDs))
+	for moduleID := range moduleIDs {
+		moduleName := moduleID.AsStr()
+		moduleNames = append(moduleNames, moduleName)
+		moduleIDByName[moduleName] = moduleID
+	}
+	sort.Strings(moduleNames)
+
+	one := int32(1)
+	for _, moduleName := range moduleNames {
+		module, err := client.NormalizedMoveModule(
+			packageAddress,
+			moduleName,
+			&packageVersion,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+		if err.(*iota_sdk.SdkFfiError) != nil {
+			log.Fatalf("Failed to fetch module %s: %v", moduleName, err)
+		}
+
+		if module == nil {
+			fmt.Printf("Module: %s (not found)\n", moduleName)
+			continue
+		}
+
+		fmt.Printf("Module: %s\n", moduleName)
+		fmt.Println("Functions:")
+		if module.Functions == nil || len(module.Functions.Nodes) == 0 {
+			fmt.Println("- none")
+		} else {
+			for _, fn := range module.Functions.Nodes {
+				fmt.Printf("- %s\n", fn.String())
+			}
+		}
+
+		fmt.Println("Types (with sample object if available):")
+		if module.Structs == nil || len(module.Structs.Nodes) == 0 {
+			fmt.Println("- none")
+		} else {
+			moduleID := moduleIDByName[moduleName]
+			for _, structQuery := range module.Structs.Nodes {
+				typeTag := fmt.Sprintf("%s::%s::%s", packageID, moduleID.AsStr(), structQuery.Name)
+				objectPage, err := client.Objects(
+					&iota_sdk.ObjectFilter{TypeTag: &typeTag},
+					&iota_sdk.PaginationFilter{Direction: iota_sdk.DirectionForward, Limit: &one},
+				)
+				if err.(*iota_sdk.SdkFfiError) != nil {
+					log.Fatalf("Failed to query objects for type %s: %v", typeTag, err)
+				}
+				if len(objectPage.Data) > 0 {
+					fmt.Printf("- %s (example object: %s)\n", structQuery.Name, objectPage.Data[0].ObjectId().ToHex())
+				} else {
+					fmt.Printf("- %s (no example object found)\n", structQuery.Name)
+				}
+			}
+		}
+
+		fmt.Println()
+	}
+}

--- a/bindings/kotlin/examples/MovePackage.kt
+++ b/bindings/kotlin/examples/MovePackage.kt
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.Address
+import iota_sdk.Direction
+import iota_sdk.GraphQlClient
+import iota_sdk.ObjectFilter
+import iota_sdk.PaginationFilter
+import kotlinx.coroutines.runBlocking
+
+private const val PACKAGE_ADDRESS = "0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f"
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+        val packageAddress = Address.fromHex(PACKAGE_ADDRESS)
+
+        val pkg = client.`package`(packageAddress, null)
+        if (pkg == null) {
+            println("No package found for $PACKAGE_ADDRESS")
+            return@runBlocking
+        }
+
+        val packageId = pkg.id().toHex()
+        val packageVersion = pkg.version()
+
+        println("Package ID: $packageId")
+        println("Current version: $packageVersion")
+        println()
+
+        val versions = client.`packageVersions`(packageAddress, null, null, null).data.sortedBy { it.version() }
+        println("Package versions:")
+        versions.forEach { versionedPackage ->
+            val marker =
+                if (versionedPackage.id().toHex() == packageId && versionedPackage.version() == packageVersion) {
+                    " (current)"
+                } else {
+                    ""
+                }
+            println("- id=${versionedPackage.id().toHex()} version=${versionedPackage.version()}$marker")
+        }
+        println()
+
+        println("Dependencies:")
+        val dependencies = pkg.linkageTable()
+        if (dependencies.isEmpty()) {
+            println("- none")
+        } else {
+            dependencies.forEach { (originalId, info) ->
+                println("- ${originalId.toHex()} -> ${info.upgradedId.toHex()} (version ${info.upgradedVersion})")
+            }
+        }
+        println()
+
+        val modules = pkg.modules().keys.map { it.asStr() }.sorted()
+        for (moduleName in modules) {
+            val module = client.normalizedMoveModule(packageAddress, moduleName, packageVersion)
+            if (module == null) {
+                println("Module: $moduleName (not found)")
+                continue
+            }
+
+            println("Module: $moduleName")
+            println("Functions:")
+            val functions = module.functions?.nodes ?: emptyList()
+            if (functions.isEmpty()) {
+                println("- none")
+            } else {
+                functions.forEach { fn ->
+                    println("- $fn")
+                }
+            }
+
+            println("Types (with sample object if available):")
+            val structs = module.structs?.nodes ?: emptyList()
+            if (structs.isEmpty()) {
+                println("- none")
+            } else {
+                structs.forEach { struct ->
+                    val typeTag = "$packageId::$moduleName::${struct.name}"
+                    val objects = client.objects(
+                        ObjectFilter(typeTag = typeTag),
+                        PaginationFilter(direction = Direction.FORWARD, limit = 1),
+                    )
+                    if (objects.data.isNotEmpty()) {
+                        println("- ${struct.name} (example object: ${objects.data[0].objectId().toHex()})")
+                    } else {
+                        println("- ${struct.name} (no example object found)")
+                    }
+                }
+            }
+
+            println()
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/move_package.py
+++ b/bindings/python/examples/move_package.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2026 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+PACKAGE_ADDRESS = "0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f"
+
+
+async def main():
+    client = GraphQlClient.new_devnet()
+    package_address = Address.from_hex(PACKAGE_ADDRESS)
+
+    package = await client.package(package_address)
+    if package is None:
+        raise Exception(f"Missing package: {PACKAGE_ADDRESS}")
+
+    package_id = package.id().to_hex()
+    package_version = package.version()
+
+    print(f"Package ID: {package_id}")
+    print(f"Current version: {package_version}")
+    print()
+
+    versions_page = await client.package_versions(package_address)
+    versions = sorted(versions_page.data, key=lambda p: p.version())
+
+    print("Package versions:")
+    for versioned_package in versions:
+        marker = ""
+        if (
+            versioned_package.id().to_hex() == package_id
+            and versioned_package.version() == package_version
+        ):
+            marker = " (current)"
+        print(
+            f"- id={versioned_package.id().to_hex()} "
+            f"version={versioned_package.version()}{marker}"
+        )
+    print()
+
+    print("Dependencies:")
+    dependencies = package.linkage_table()
+    if len(dependencies) == 0:
+        print("- none")
+    else:
+        for original_id, info in dependencies.items():
+            print(
+                f"- {original_id.to_hex()} -> {info.upgraded_id.to_hex()} "
+                f"(version {info.upgraded_version})"
+            )
+    print()
+
+    module_ids = sorted(package.modules().keys(), key=lambda module_id: module_id.as_str())
+    for module_id in module_ids:
+        module_name = module_id.as_str()
+        module = await client.normalized_move_module(
+            package_address,
+            module_name,
+            version=package_version,
+        )
+
+        if module is None:
+            print(f"Module: {module_name} (not found)")
+            continue
+
+        print(f"Module: {module_name}")
+        print("Functions:")
+        if module.functions is None or len(module.functions.nodes) == 0:
+            print("- none")
+        else:
+            for fun in module.functions.nodes:
+                print(f"- {str(fun)}")
+
+        print("Types (with sample object if available):")
+        if module.structs is None or len(module.structs.nodes) == 0:
+            print("- none")
+        else:
+            for struct in module.structs.nodes:
+                type_tag = f"{package_id}::{module_name}::{struct.name}"
+                sample_objects = await client.objects(
+                    filter=ObjectFilter(type_tag=type_tag),
+                    pagination_filter=PaginationFilter(limit=1),
+                )
+                if len(sample_objects.data) > 0:
+                    print(
+                        f"- {struct.name} "
+                        f"(example object: {sample_objects.data[0].object_id().to_hex()})"
+                    )
+                else:
+                    print(f"- {struct.name} (no example object found)")
+
+        print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-sdk/examples/move_package.rs
+++ b/crates/iota-sdk/examples/move_package.rs
@@ -1,0 +1,137 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use eyre::{Result, eyre};
+use iota_sdk::{
+    graphql_client::{Client, pagination::PaginationFilter, query_types::ObjectFilter},
+    types::Address,
+};
+
+const PACKAGE_ADDRESS: &str = "0x3ec4826f1d6e0d9f00680b2e9a7a41f03788ee610b3d11c24f41ab0ae71da39f";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+    let package_address = Address::from_str(PACKAGE_ADDRESS)?;
+
+    let Some(package) = client.package(package_address, None).await? else {
+        return Err(eyre!("no package found for {PACKAGE_ADDRESS}"));
+    };
+
+    println!("Package ID: {}", package.id);
+    println!("Current version: {}", package.version);
+    println!();
+
+    let mut versions = client
+        .package_versions(
+            package_address,
+            PaginationFilter {
+                limit: Some(50),
+                ..Default::default()
+            },
+            None,
+            None,
+        )
+        .await?
+        .data;
+    versions.sort_by_key(|p| p.version);
+
+    println!("Package versions:");
+    for v in versions {
+        let marker = if v.id == package.id && v.version == package.version {
+            " (current)"
+        } else {
+            ""
+        };
+        println!("- id={} version={}{}", v.id, v.version, marker);
+    }
+    println!();
+
+    println!("Dependencies:");
+    if package.linkage_table.is_empty() {
+        println!("- none");
+    } else {
+        for (original_id, info) in &package.linkage_table {
+            println!(
+                "- {} -> {} (version {})",
+                original_id, info.upgraded_id, info.upgraded_version
+            );
+        }
+    }
+    println!();
+
+    let mut module_ids = package
+        .modules
+        .keys()
+        .map(|id| id.as_str().to_owned())
+        .collect::<Vec<_>>();
+    module_ids.sort();
+
+    for module_id in module_ids {
+        let Some(module) = client
+            .normalized_move_module(
+                package_address,
+                &module_id,
+                Some(package.version),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                Default::default(),
+            )
+            .await?
+        else {
+            println!("Module: {module_id} (not found)");
+            continue;
+        };
+
+        println!("Module: {module_id}");
+
+        println!("Functions:");
+        match module.functions {
+            Some(functions) if !functions.nodes.is_empty() => {
+                for fun in functions.nodes {
+                    println!("- {fun}");
+                }
+            }
+            _ => println!("- none"),
+        }
+
+        println!("Types (with sample object if available):");
+        match module.structs {
+            Some(structs) if !structs.nodes.is_empty() => {
+                for struct_ in structs.nodes {
+                    let type_tag = format!("{}::{}::{}", package.id, module_id, struct_.name);
+                    let sample_objects = client
+                        .objects(
+                            ObjectFilter {
+                                type_: Some(type_tag),
+                                ..Default::default()
+                            },
+                            PaginationFilter {
+                                limit: Some(1),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
+
+                    if let Some(sample_object) = sample_objects.data.first() {
+                        println!(
+                            "- {} (example object: {})",
+                            struct_.name,
+                            sample_object.object_id()
+                        );
+                    } else {
+                        println!("- {} (no example object found)", struct_.name);
+                    }
+                }
+            }
+            _ => println!("- none"),
+        }
+
+        println!();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a new Rust example `move_package.rs` that inspects a Move package and prints:
  - current package id/version
  - all known package versions
  - dependencies from linkage table
  - modules and their functions
  - package-defined types with one sample object id if available
- add matching binding examples:
  - `bindings/python/examples/move_package.py`
  - `bindings/go/examples/move_package/main.go`
  - `bindings/kotlin/examples/MovePackage.kt`

## Validation
- Python syntax check: `python -m py_compile bindings/python/examples/move_package.py`
- Rust/Go compile checks were not run in this environment because `cargo` and `go` are unavailable.

Closes #515