### PR TITLE
feat(examples): add IOTA Names examples for Go and Python (#514)

### DIFF
--- a/bindings/go/examples/iota_names/main.go
+++ b/bindings/go/examples/iota_names/main.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func failOnErr(context string, err error) {
+	if err == nil {
+		return
+	}
+	if sdkErr, ok := err.(*iota_sdk.SdkFfiError); ok {
+		log.Fatalf("%s: %v", context, sdkErr)
+	}
+	log.Fatalf("%s: %v", context, err)
+}
+
+func main() {
+	client := iota_sdk.GraphQlClientNewDevnet()
+
+	// Query with a known sample name and address used across examples.
+	name := "auc.iota"
+	address, err := iota_sdk.AddressFromHex("0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c")
+	failOnErr("failed to parse address", err)
+
+	resolvedAddressOpt, err := client.IotaNamesLookup(name)
+	failOnErr("failed to lookup IOTA name", err)
+	if resolvedAddressOpt == nil {
+		fmt.Printf("No address found for %s\n", name)
+	} else {
+		fmt.Printf("Resolved %s -> %s\n", name, (*resolvedAddressOpt).ToHex())
+	}
+
+	nameFormat := iota_sdk.NameFormatDot
+	defaultNameOpt, err := client.IotaNamesDefaultName(address, &nameFormat)
+	failOnErr("failed to query default name", err)
+	if defaultNameOpt == nil {
+		fmt.Printf("No default IOTA name configured for %s\n", address.ToHex())
+	} else {
+		fmt.Printf("Default name for %s: %s\n", address.ToHex(), (*defaultNameOpt).String())
+	}
+
+	limit := int32(10)
+	registrations, err := client.IotaNamesRegistrations(address, iota_sdk.PaginationFilter{
+		Direction: iota_sdk.DirectionForward,
+		Limit:     &limit,
+	})
+	failOnErr("failed to query name registrations", err)
+
+	fmt.Printf("Name registrations fetched: %d\n", len(registrations.Data))
+	for _, registration := range registrations.Data {
+		fmt.Printf(
+			"- %s (id: %s, expires_at_ms: %d)\n",
+			registration.NameStr(),
+			registration.Id().ToHex(),
+			registration.ExpirationTimestampMs(),
+		)
+	}
+}

--- a/bindings/python/examples/iota_names.py
+++ b/bindings/python/examples/iota_names.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+async def main():
+    client = GraphQlClient.new_devnet()
+
+    # Query with a known sample name and address used across examples.
+    name = "auc.iota"
+    address = Address.from_hex(
+        "0x611830d3641a68f94a690dcc25d1f4b0dac948325ac18f6dd32564371735f32c"
+    )
+
+    resolved_address = await client.iota_names_lookup(name)
+    if resolved_address is None:
+        print(f"No address found for {name}")
+    else:
+        print(f"Resolved {name} -> {resolved_address.to_hex()}")
+
+    default_name = await client.iota_names_default_name(address, NameFormat.DOT)
+    if default_name is None:
+        print(f"No default IOTA name configured for {address.to_hex()}")
+    else:
+        print(f"Default name for {address.to_hex()}: {default_name}")
+
+    registrations_page = await client.iota_names_registrations(
+        address,
+        PaginationFilter(direction=Direction.FORWARD, limit=10),
+    )
+    print(f"Name registrations fetched: {len(registrations_page.data)}")
+    for registration in registrations_page.data:
+        print(
+            f"- {registration.name_str()} "
+            f"(id: {registration.id().to_hex()}, "
+            f"expires_at_ms: {registration.expiration_timestamp_ms()})"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a new Go example at `bindings/go/examples/iota_names/main.go`
- add a new Python example at `bindings/python/examples/iota_names.py`
- demonstrate the three GraphQL IOTA Names APIs:
  - `iota_names_lookup`
  - `iota_names_default_name`
  - `iota_names_registrations`
- include optional-value handling and printed output for resolved names and registrations

## Validation
- `python -m py_compile bindings/python/examples/iota_names.py`
- `go build -buildvcs=false ./examples/iota_names` (with cgo linker flags to `target/release`)