### PR TITLE
feat(examples): add multisig address example

### DIFF
--- a/bindings/go/examples/multisig_address/main.go
+++ b/bindings/go/examples/multisig_address/main.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func failOnErr(context string, err error) {
+	if err == nil {
+		return
+	}
+	if sdkErr, ok := err.(*iota_sdk.SdkFfiError); ok {
+		log.Fatalf("%s: %v", context, sdkErr)
+	}
+	log.Fatalf("%s: %v", context, err)
+}
+
+func main() {
+	client := iota_sdk.GraphQlClientNewLocalnet()
+	faucetClient := iota_sdk.FaucetClientNewLocalnet()
+
+	recipient, err := iota_sdk.AddressFromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
+	failOnErr("parse recipient address", err)
+	amount := uint64(1_000)
+
+	// Deterministic keys for the example. Do not use hardcoded mnemonics in production.
+	mnemonic := "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+	key1, err := iota_sdk.Ed25519PrivateKeyFromMnemonic(mnemonic, 0, "")
+	failOnErr("create key1", err)
+	key2, err := iota_sdk.Ed25519PrivateKeyFromMnemonic(mnemonic, 1, "")
+	failOnErr("create key2", err)
+
+	pk1 := key1.PublicKey()
+	pk2 := key2.PublicKey()
+
+	// Create MultisigMemberPublicKey objects via JSON conversion.
+	// Format: {"scheme":"ed25519","public_key":"<base64-32-bytes>"}
+	pk1b64 := base64.StdEncoding.EncodeToString(pk1.ToBytes())
+	pk2b64 := base64.StdEncoding.EncodeToString(pk2.ToBytes())
+	mpk1, err := iota_sdk.MultisigMemberPublicKeyFromJson(
+		fmt.Sprintf(`{"scheme":"ed25519","public_key":"%s"}`, pk1b64),
+	)
+	failOnErr("create multisig member public key 1", err)
+	mpk2, err := iota_sdk.MultisigMemberPublicKeyFromJson(
+		fmt.Sprintf(`{"scheme":"ed25519","public_key":"%s"}`, pk2b64),
+	)
+	failOnErr("create multisig member public key 2", err)
+
+	member1 := iota_sdk.NewMultisigMember(mpk1, 1)
+	member2 := iota_sdk.NewMultisigMember(mpk2, 1)
+	committee := iota_sdk.NewMultisigCommittee([]*iota_sdk.MultisigMember{member1, member2}, 2)
+
+	multisigAddress := committee.DeriveAddress()
+	fmt.Printf("Multisig address: %s\n", multisigAddress.ToHex())
+
+	_, err = faucetClient.RequestAndWaitForFinalized(multisigAddress, client)
+	failOnErr("faucet request", err)
+
+	builder := iota_sdk.NewTransactionBuilder(multisigAddress).WithClient(client)
+	builder.SendIota(recipient, iota_sdk.PtbArgumentU64(amount))
+
+	tx, err := builder.Finish()
+	failOnErr("build transaction", err)
+
+	dryRun, err := client.DryRunTx(tx, false)
+	failOnErr("dry run transaction", err)
+	if dryRun.Error != nil {
+		log.Fatalf("dry run failed: %v", *dryRun.Error)
+	}
+
+	sig1, err := key1.SignTransaction(tx)
+	failOnErr("sign tx (key1)", err)
+	sig2, err := key2.SignTransaction(tx)
+	failOnErr("sign tx (key2)", err)
+
+	aggregator := iota_sdk.MultisigAggregatorNewWithTransaction(committee, tx)
+	aggregator, err = aggregator.WithSignature(sig1)
+	failOnErr("add signature (key1)", err)
+	aggregator, err = aggregator.WithSignature(sig2)
+	failOnErr("add signature (key2)", err)
+
+	aggSig, err := aggregator.Finish()
+	failOnErr("finish multisig aggregation", err)
+
+	msUserSig := iota_sdk.UserSignatureNewMultisig(aggSig)
+	effects, err := client.ExecuteTx([]*iota_sdk.UserSignature{msUserSig}, tx, nil)
+	failOnErr("execute transaction", err)
+
+	fmt.Printf("Digest: %s\n", iota_sdk.HexEncode((*effects).Digest().ToBytes()))
+	fmt.Printf("Status: %v\n", (*effects).AsV1().Status)
+}

--- a/bindings/kotlin/examples/MultisigAddress.kt
+++ b/bindings/kotlin/examples/MultisigAddress.kt
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.*
+import java.util.Base64
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newLocalnet()
+        val faucet = FaucetClient.newLocalnet()
+
+        val recipient =
+            Address.fromHex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")
+        val amount = 1000uL
+
+        // Demo keys. Do not use fixed keys like this in production.
+        val key1 = Ed25519PrivateKey(ByteArray(32) { 1 })
+        val key2 = Ed25519PrivateKey(ByteArray(32) { 2 })
+
+        val pk1B64 = Base64.getEncoder().encodeToString(key1.publicKey().toBytes())
+        val pk2B64 = Base64.getEncoder().encodeToString(key2.publicKey().toBytes())
+
+        val mpk1 = multisigMemberPublicKeyFromJson("""{"scheme":"ed25519","public_key":"$pk1B64"}""")
+        val mpk2 = multisigMemberPublicKeyFromJson("""{"scheme":"ed25519","public_key":"$pk2B64"}""")
+
+        val committee = MultisigCommittee(
+            listOf(
+                MultisigMember(mpk1, 1u),
+                MultisigMember(mpk2, 1u),
+            ),
+            2u,
+        )
+
+        val multisigAddress = committee.deriveAddress()
+        println("Multisig address: ${multisigAddress.toHex()}")
+
+        faucet.requestAndWaitForFinalized(multisigAddress, client)
+
+        val builder = TransactionBuilder(multisigAddress).withClient(client)
+        builder.sendIota(recipient, PtbArgument.u64(amount))
+        val txn = builder.finish()
+
+        val dryRun = client.dryRunTx(txn, false)
+        if (dryRun.error != null) {
+            throw Exception("Dry run failed: ${dryRun.error}")
+        }
+
+        val sig1 = UserSignature.newSimple(key1.trySignSimple(txn.signingDigest()))
+        val sig2 = UserSignature.newSimple(key2.trySignSimple(txn.signingDigest()))
+
+        var aggregator = MultisigAggregator.newWithTransaction(committee, txn)
+        aggregator = aggregator.withSignature(sig1)
+        aggregator = aggregator.withSignature(sig2)
+        val aggSig = aggregator.finish()
+
+        val msUserSig = UserSignature.newMultisig(aggSig)
+        val effects = client.executeTx(listOf(msUserSig), txn)
+
+        println("Digest: ${hexEncode(effects.digest().toBytes())}")
+        println("Status: ${effects.asV1().status}")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/multisig_address.py
+++ b/bindings/python/examples/multisig_address.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+import base64
+import json
+
+
+async def main():
+    client = GraphQlClient.new_localnet()
+    faucet_client = FaucetClient.new_localnet()
+
+    recipient = Address.from_hex(
+        "0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900"
+    )
+    amount = 1_000
+
+    # Demo keys. Do not use hardcoded keys like this in production.
+    key_1 = Ed25519PrivateKey(bytes([1] * 32))
+    key_2 = Ed25519PrivateKey(bytes([2] * 32))
+
+    pk1_b64 = base64.b64encode(key_1.public_key().to_bytes()).decode("ascii")
+    pk2_b64 = base64.b64encode(key_2.public_key().to_bytes()).decode("ascii")
+
+    mpk1 = multisig_member_public_key_from_json(
+        json.dumps({"scheme": "ed25519", "public_key": pk1_b64})
+    )
+    mpk2 = multisig_member_public_key_from_json(
+        json.dumps({"scheme": "ed25519", "public_key": pk2_b64})
+    )
+
+    member_1 = MultisigMember(mpk1, 1)
+    member_2 = MultisigMember(mpk2, 1)
+    committee = MultisigCommittee([member_1, member_2], 2)
+    multisig_address = committee.derive_address()
+    print(f"Multisig address: {multisig_address.to_hex()}")
+
+    await faucet_client.request_and_wait_for_finalized(multisig_address, client)
+
+    builder = TransactionBuilder(multisig_address).with_client(client)
+    builder.send_iota(recipient, PtbArgument.u64(amount))
+    tx = await builder.finish()
+
+    dry_run = await client.dry_run_tx(tx, False)
+    if dry_run.error is not None:
+        raise Exception(f"Dry run failed: {dry_run.error}")
+
+    sig1 = key_1.sign_transaction(tx)
+    sig2 = key_2.sign_transaction(tx)
+
+    aggregator = MultisigAggregator.new_with_transaction(committee, tx)
+    aggregator = aggregator.with_signature(sig1)
+    aggregator = aggregator.with_signature(sig2)
+    agg_sig = aggregator.finish()
+
+    ms_user_sig = UserSignature.new_multisig(agg_sig)
+    effects = await client.execute_tx([ms_user_sig], tx, None)
+    print(f"Digest: {effects.digest().to_base58()}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/crates/iota-sdk/examples/multisig_address.rs
+++ b/crates/iota-sdk/examples/multisig_address.rs
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use eyre::Result;
+use iota_sdk::{
+    crypto::{
+        IotaSigner,
+        ed25519::Ed25519PrivateKey,
+        multisig::MultisigAggregator,
+    },
+    graphql_client::{Client, faucet::FaucetClient},
+    transaction_builder::TransactionBuilder,
+    types::{
+        Address,
+        MultisigCommittee,
+        MultisigMember,
+        MultisigMemberPublicKey,
+        UserSignature,
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Recipient for demo transfer (amount is in nanos).
+    let amount = 1_000u64;
+    let recipient_address =
+        Address::from_hex("0x0000a4984bd495d4346fa208ddff4f5d5e5ad48c21dec631ddebc99809f16900")?;
+
+    // Demo keys. Do not use fixed keys like this in production.
+    let key_1 = Ed25519PrivateKey::new([1; Ed25519PrivateKey::LENGTH]);
+    let key_2 = Ed25519PrivateKey::new([2; Ed25519PrivateKey::LENGTH]);
+
+    // 2-of-2 multisig committee (weight 1 each, threshold 2).
+    let members = vec![
+        MultisigMember::new(MultisigMemberPublicKey::Ed25519(key_1.public_key()), 1),
+        MultisigMember::new(MultisigMemberPublicKey::Ed25519(key_2.public_key()), 1),
+    ];
+    let committee = MultisigCommittee::new(members, 2);
+    let multisig_address = committee.derive_address();
+    println!("Multisig address: {multisig_address}");
+
+    let client = Client::new_localnet();
+
+    // Fund the multisig address.
+    FaucetClient::new_localnet()
+        .request_and_wait_for_finalized(multisig_address, &client)
+        .await?;
+
+    // Build a transaction from the multisig address.
+    let mut builder = TransactionBuilder::new(multisig_address).with_client(&client);
+    builder.send_iota(recipient_address, amount);
+    let tx = builder.finish().await?;
+
+    let dry_run_result = client.dry_run_tx(&tx, false).await?;
+    if let Some(err) = dry_run_result.error {
+        eyre::bail!("Dry run failed: {err}");
+    }
+
+    // Each committee member signs the transaction, then the signatures are aggregated.
+    let sig_1 = key_1.sign_transaction(&tx)?;
+    let sig_2 = key_2.sign_transaction(&tx)?;
+
+    let mut aggregator = MultisigAggregator::new_with_transaction(committee, &tx);
+    aggregator.add_signature(sig_1)?;
+    aggregator.add_signature(sig_2)?;
+    let multisig_signature = aggregator.finish()?;
+
+    let effects = client
+        .execute_tx(&[UserSignature::Multisig(multisig_signature)], &tx, None)
+        .await?;
+
+    println!("Digest: {}", effects.digest());
+    println!("Transaction status: {:?}", effects.status());
+    println!("Effects: {effects:#?}");
+
+    Ok(())
+}
+


### PR DESCRIPTION
Adds multisig address example for Rust SDK and Go/Python/Kotlin bindings.

Closes #501.