### PR TITLE
feat: add Display implementations for iota-sdk-types

### DIFF
--- a/crates/iota-sdk-types/src/checkpoint.rs
+++ b/crates/iota-sdk-types/src/checkpoint.rs
@@ -39,6 +39,16 @@ pub enum CheckpointCommitment {
     // Other commitment types (e.g. merkle roots) go here.
 }
 
+impl std::fmt::Display for CheckpointCommitment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EcmhLiveObjectSet { digest } => {
+                write!(f, "EcmhLiveObjectSet({digest})")
+            }
+        }
+    }
+}
+
 impl CheckpointCommitment {
     crate::def_is!(EcmhLiveObjectSet);
 
@@ -171,6 +181,31 @@ pub struct CheckpointSummary {
     pub version_specific_data: Vec<u8>,
 }
 
+impl std::fmt::Display for EndOfEpochData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EndOfEpochData(next_committee: {} members, next_protocol_version: {}, supply_change: {})",
+            self.next_epoch_committee.len(),
+            self.next_epoch_protocol_version,
+            self.epoch_supply_change
+        )
+    }
+}
+
+impl std::fmt::Display for CheckpointSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Checkpoint(epoch: {}, seq: {}, txns: {}, digest: {})",
+            self.epoch,
+            self.sequence_number,
+            self.network_total_transactions,
+            self.content_digest
+        )
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -178,6 +213,12 @@ pub struct CheckpointSummary {
 pub struct SignedCheckpointSummary {
     pub checkpoint: CheckpointSummary,
     pub signature: ValidatorAggregatedSignature,
+}
+
+impl std::fmt::Display for SignedCheckpointSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SignedCheckpointSummary({})", self.checkpoint)
+    }
 }
 
 /// The committed to contents of a checkpoint.
@@ -206,6 +247,12 @@ pub struct CheckpointContents(
     pub  Vec<CheckpointTransactionInfo>,
 );
 
+impl std::fmt::Display for CheckpointContents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CheckpointContents({} transactions)", self.0.len())
+    }
+}
+
 impl CheckpointContents {
     pub fn new(transactions: Vec<CheckpointTransactionInfo>) -> Self {
         Self(transactions)
@@ -232,6 +279,16 @@ pub struct CheckpointTransactionInfo {
     pub signatures: Vec<UserSignature>,
 }
 
+impl std::fmt::Display for CheckpointTransactionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CheckpointTransactionInfo(tx: {}, effects: {})",
+            self.transaction, self.effects
+        )
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
@@ -245,6 +302,17 @@ pub struct CheckpointData {
     pub checkpoint_contents: CheckpointContents,
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=1).lift()))]
     pub transactions: Vec<CheckpointTransaction>,
+}
+
+impl std::fmt::Display for CheckpointData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CheckpointData({}, {} transactions)",
+            self.checkpoint_summary.checkpoint,
+            self.transactions.len()
+        )
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -274,6 +342,21 @@ pub struct CheckpointTransaction {
     /// The state of all output objects created or mutated by this transaction.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub output_objects: Vec<Object>,
+}
+
+impl std::fmt::Display for CheckpointTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "CheckpointTransaction(effects: {}, events: {}, inputs: {}, outputs: {})",
+            self.effects,
+            self.events
+                .as_ref()
+                .map_or(0, |e| e.0.len()),
+            self.input_objects.len(),
+            self.output_objects.len()
+        )
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -53,6 +53,16 @@ pub struct Intent {
     pub app_id: IntentAppId,
 }
 
+impl std::fmt::Display for Intent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Intent(scope: {}, version: {}, app_id: {})",
+            self.scope, self.version, self.app_id
+        )
+    }
+}
+
 impl Intent {
     pub fn new(scope: IntentScope, version: IntentVersion, app_id: IntentAppId) -> Self {
         Self {
@@ -169,6 +179,23 @@ pub enum IntentScope {
     AuthorityCapabilities = 9, // Used for authority capabilities from non-committee authorities.
 }
 
+impl std::fmt::Display for IntentScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntentScope::TransactionData => write!(f, "TransactionData"),
+            IntentScope::TransactionEffects => write!(f, "TransactionEffects"),
+            IntentScope::CheckpointSummary => write!(f, "CheckpointSummary"),
+            IntentScope::PersonalMessage => write!(f, "PersonalMessage"),
+            IntentScope::SenderSignedTransaction => write!(f, "SenderSignedTransaction"),
+            IntentScope::ProofOfPossession => write!(f, "ProofOfPossession"),
+            IntentScope::BridgeEventDeprecated => write!(f, "BridgeEventDeprecated"),
+            IntentScope::ConsensusBlock => write!(f, "ConsensusBlock"),
+            IntentScope::DiscoveryPeers => write!(f, "DiscoveryPeers"),
+            IntentScope::AuthorityCapabilities => write!(f, "AuthorityCapabilities"),
+        }
+    }
+}
+
 impl IntentScope {
     crate::def_is!(
         TransactionData,
@@ -217,6 +244,14 @@ pub enum IntentVersion {
     V0 = 0,
 }
 
+impl std::fmt::Display for IntentVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntentVersion::V0 => write!(f, "V0"),
+        }
+    }
+}
+
 impl IntentVersion {
     crate::def_is!(V0);
 }
@@ -257,6 +292,15 @@ pub enum IntentAppId {
     Consensus = 1,
 }
 
+impl std::fmt::Display for IntentAppId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IntentAppId::Iota => write!(f, "Iota"),
+            IntentAppId::Consensus => write!(f, "Consensus"),
+        }
+    }
+}
+
 impl IntentAppId {
     crate::def_is!(Iota, Consensus);
 }
@@ -285,6 +329,12 @@ pub struct IntentMessage<T> {
     pub value: T,
 }
 
+impl<T: std::fmt::Display> std::fmt::Display for IntentMessage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "IntentMessage(intent: {}, value: {})", self.intent, self.value)
+    }
+}
+
 impl<T> IntentMessage<T> {
     pub fn new(intent: Intent, value: T) -> Self {
         Self { intent, value }
@@ -307,7 +357,22 @@ pub enum HashingIntentScope {
     RegularObjectId = 0xf1,
 }
 
+impl std::fmt::Display for HashingIntentScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HashingIntentScope::ChildObjectId => write!(f, "ChildObjectId"),
+            HashingIntentScope::RegularObjectId => write!(f, "RegularObjectId"),
+        }
+    }
+}
+
 /// A personal message that wraps around a byte array.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);
+
+impl<'a> std::fmt::Display for PersonalMessage<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PersonalMessage(len: {})", self.0.len())
+    }
+}

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -55,6 +55,17 @@ pub enum MultisigMemberPublicKey {
     ZkLogin(ZkLoginPublicIdentifier),
 }
 
+impl std::fmt::Display for MultisigMemberPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MultisigMemberPublicKey::Ed25519(_) => write!(f, "MultisigMemberPublicKey(ed25519)"),
+            MultisigMemberPublicKey::Secp256k1(_) => write!(f, "MultisigMemberPublicKey(secp256k1)"),
+            MultisigMemberPublicKey::Secp256r1(_) => write!(f, "MultisigMemberPublicKey(secp256r1)"),
+            MultisigMemberPublicKey::ZkLogin(_) => write!(f, "MultisigMemberPublicKey(zklogin)"),
+        }
+    }
+}
+
 impl MultisigMemberPublicKey {
     crate::def_is_as_into_opt!(
         Ed25519(Ed25519PublicKey),
@@ -109,6 +120,12 @@ pub struct MultisigMember {
     weight: WeightUnit,
 }
 
+impl std::fmt::Display for MultisigMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MultisigMember(weight: {})", self.weight)
+    }
+}
+
 impl MultisigMember {
     /// Construct a new member from a `MultisigMemberPublicKey` and a `weight`.
     pub fn new(public_key: MultisigMemberPublicKey, weight: WeightUnit) -> Self {
@@ -159,6 +176,17 @@ pub struct MultisigCommittee {
     /// If the total weight of the public keys corresponding to verified
     /// signatures is larger than threshold, the Multisig is verified.
     threshold: ThresholdUnit,
+}
+
+impl std::fmt::Display for MultisigCommittee {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MultisigCommittee(members: {}, threshold: {})",
+            self.members.len(),
+            self.threshold
+        )
+    }
 }
 
 impl MultisigCommittee {
@@ -260,6 +288,17 @@ pub struct MultisigAggregatedSignature {
     committee: MultisigCommittee,
 }
 
+impl std::fmt::Display for MultisigAggregatedSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MultisigAggregatedSignature(signatures: {}, bitmap: {})",
+            self.signatures.len(),
+            self.bitmap
+        )
+    }
+}
+
 impl MultisigAggregatedSignature {
     /// Construct a new aggregated multisig signature.
     ///
@@ -331,6 +370,17 @@ pub enum MultisigMemberSignature {
     Secp256k1(Secp256k1Signature),
     Secp256r1(Secp256r1Signature),
     ZkLogin(Box<ZkLoginAuthenticator>),
+}
+
+impl std::fmt::Display for MultisigMemberSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MultisigMemberSignature::Ed25519(_) => write!(f, "MultisigMemberSignature(ed25519)"),
+            MultisigMemberSignature::Secp256k1(_) => write!(f, "MultisigMemberSignature(secp256k1)"),
+            MultisigMemberSignature::Secp256r1(_) => write!(f, "MultisigMemberSignature(secp256r1)"),
+            MultisigMemberSignature::ZkLogin(_) => write!(f, "MultisigMemberSignature(zklogin)"),
+        }
+    }
 }
 
 impl MultisigMemberSignature {

--- a/crates/iota-sdk-types/src/crypto/passkey.rs
+++ b/crates/iota-sdk-types/src/crypto/passkey.rs
@@ -52,6 +52,16 @@ pub struct PasskeyAuthenticator {
     client_data_json: String,
 }
 
+impl std::fmt::Display for PasskeyAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PasskeyAuthenticator(authenticator_data_len: {})",
+            self.authenticator_data.len()
+        )
+    }
+}
+
 impl PasskeyAuthenticator {
     /// Opaque authenticator data for this passkey signature.
     ///
@@ -104,6 +114,12 @@ impl PasskeyAuthenticator {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PasskeyPublicKey(Secp256r1PublicKey);
+
+impl std::fmt::Display for PasskeyPublicKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PasskeyPublicKey")
+    }
+}
 
 impl PasskeyPublicKey {
     pub fn new(public_key: Secp256r1PublicKey) -> Self {

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -54,6 +54,16 @@ pub enum SimpleSignature {
     },
 }
 
+impl std::fmt::Display for SimpleSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SimpleSignature::Ed25519 { .. } => write!(f, "SimpleSignature(scheme: ed25519)"),
+            SimpleSignature::Secp256k1 { .. } => write!(f, "SimpleSignature(scheme: secp256k1)"),
+            SimpleSignature::Secp256r1 { .. } => write!(f, "SimpleSignature(scheme: secp256r1)"),
+        }
+    }
+}
+
 impl SimpleSignature {
     crate::def_is!(Ed25519, Secp256k1, Secp256r1);
 
@@ -316,6 +326,18 @@ pub enum UserSignature {
     ZkLoginAuthenticator(Box<ZkLoginAuthenticator>),
     PasskeyAuthenticator(PasskeyAuthenticator),
     MoveAuthenticator(MoveAuthenticator),
+}
+
+impl std::fmt::Display for UserSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UserSignature::Simple(sig) => write!(f, "UserSignature(Simple: {})", sig),
+            UserSignature::Multisig(_) => write!(f, "UserSignature(Multisig)"),
+            UserSignature::ZkLoginAuthenticator(_) => write!(f, "UserSignature(ZkLoginAuthenticator)"),
+            UserSignature::PasskeyAuthenticator(_) => write!(f, "UserSignature(PasskeyAuthenticator)"),
+            UserSignature::MoveAuthenticator(_) => write!(f, "UserSignature(MoveAuthenticator)"),
+        }
+    }
 }
 
 impl UserSignature {

--- a/crates/iota-sdk-types/src/crypto/zklogin.rs
+++ b/crates/iota-sdk-types/src/crypto/zklogin.rs
@@ -16,7 +16,7 @@ use crate::{checkpoint::EpochId, u256::U256};
 /// zklogin     = zklogin-flag
 ///               zklogin-inputs
 ///               u64               ; max epoch
-///               simple-signature    
+///               simple-signature
 /// ```
 ///
 /// Note: Due to historical reasons, signatures are serialized slightly
@@ -35,6 +35,12 @@ pub struct ZkLoginAuthenticator {
     pub max_epoch: EpochId,
     /// User signature with the pubkey attested to by the provided proof.
     pub signature: SimpleSignature,
+}
+
+impl std::fmt::Display for ZkLoginAuthenticator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZkLoginAuthenticator(max_epoch: {})", self.max_epoch)
+    }
 }
 
 /// A zklogin groth16 proof and the required inputs to perform proof
@@ -59,6 +65,12 @@ pub struct ZkLoginInputs {
     jwt_header: JwtHeader,
     jwk_id: JwkId,
     public_identifier: ZkLoginPublicIdentifier,
+}
+
+impl std::fmt::Display for ZkLoginInputs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZkLoginInputs(iss: {})", self.public_identifier.iss)
+    }
 }
 
 impl ZkLoginInputs {
@@ -199,6 +211,12 @@ impl proptest::arbitrary::Arbitrary for ZkLoginInputs {
 pub struct ZkLoginClaim {
     pub value: String,
     pub index_mod_4: u8,
+}
+
+impl std::fmt::Display for ZkLoginClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZkLoginClaim(index_mod_4: {})", self.index_mod_4)
+    }
 }
 
 #[derive(Debug)]
@@ -404,6 +422,12 @@ pub struct ZkLoginProof {
     pub c: CircomG1,
 }
 
+impl std::fmt::Display for ZkLoginProof {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZkLoginProof")
+    }
+}
+
 /// A G1 point
 ///
 /// This represents the canonical decimal representation of the projective
@@ -421,6 +445,12 @@ pub struct ZkLoginProof {
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CircomG1(pub [Bn254FieldElement; 3]);
 
+impl std::fmt::Display for CircomG1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CircomG1")
+    }
+}
+
 /// A G2 point
 ///
 /// This represents the canonical decimal representation of the coefficients of
@@ -437,6 +467,12 @@ pub struct CircomG1(pub [Bn254FieldElement; 3]);
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CircomG2(pub [[Bn254FieldElement; 2]; 3]);
+
+impl std::fmt::Display for CircomG2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CircomG2")
+    }
+}
 
 /// Public Key equivalent for Zklogin authenticators
 ///
@@ -498,6 +534,12 @@ pub struct ZkLoginPublicIdentifier {
     address_seed: Bn254FieldElement,
 }
 
+impl std::fmt::Display for ZkLoginPublicIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ZkLoginPublicIdentifier(iss: {})", self.iss)
+    }
+}
+
 impl ZkLoginPublicIdentifier {
     pub fn new(iss: String, address_seed: Bn254FieldElement) -> Option<Self> {
         if iss.len() > 255 {
@@ -544,6 +586,12 @@ pub struct Jwk {
     pub alg: String,
 }
 
+impl std::fmt::Display for Jwk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Jwk(kty: {}, alg: {})", self.kty, self.alg)
+    }
+}
+
 /// Key to uniquely identify a JWK
 ///
 /// # BCS
@@ -562,6 +610,12 @@ pub struct JwkId {
     pub iss: String,
     /// A key id use to uniquely identify a key from an OIDC provider.
     pub kid: String,
+}
+
+impl std::fmt::Display for JwkId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JwkId(iss: {}, kid: {})", self.iss, self.kid)
+    }
 }
 
 /// A point on the BN254 elliptic curve.

--- a/crates/iota-sdk-types/src/effects/mod.rs
+++ b/crates/iota-sdk-types/src/effects/mod.rs
@@ -34,6 +34,14 @@ pub enum TransactionEffects {
     V1(Box<TransactionEffectsV1>),
 }
 
+impl std::fmt::Display for TransactionEffects {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V1(effects) => write!(f, "{effects}"),
+        }
+    }
+}
+
 impl TransactionEffects {
     crate::def_is!(V1);
 

--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -71,6 +71,20 @@ pub struct TransactionEffectsV1 {
     pub auxiliary_data_digest: Option<Digest>,
 }
 
+impl std::fmt::Display for TransactionEffectsV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "TransactionEffects(status: {}, epoch: {}, digest: {}, changed: {}, unchanged_shared: {})",
+            self.status,
+            self.epoch,
+            self.transaction_digest,
+            self.changed_objects.len(),
+            self.unchanged_shared_objects.len()
+        )
+    }
+}
+
 impl TransactionEffectsV1 {
     /// The status of the execution
     pub fn status(&self) -> &ExecutionStatus {
@@ -116,6 +130,16 @@ pub struct ChangedObject {
     /// This information isn't required by the protocol but is useful for
     /// providing more detailed semantics on object changes.
     pub id_operation: IdOperation,
+}
+
+impl std::fmt::Display for ChangedObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ChangedObject({}, in: {}, out: {}, op: {})",
+            self.object_id, self.input_state, self.output_state, self.id_operation
+        )
+    }
 }
 
 /// A shared object that wasn't changed during execution
@@ -197,6 +221,26 @@ pub enum UnchangedSharedKind {
     PerEpochConfig,
 }
 
+impl std::fmt::Display for UnchangedSharedObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UnchangedShared({}, {})", self.object_id, self.kind)
+    }
+}
+
+impl std::fmt::Display for UnchangedSharedKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadOnlyRoot { version, digest } => {
+                write!(f, "ReadOnlyRoot(v{version}, {digest})")
+            }
+            Self::MutateDeleted { version } => write!(f, "MutateDeleted(v{version})"),
+            Self::ReadDeleted { version } => write!(f, "ReadDeleted(v{version})"),
+            Self::Cancelled { version } => write!(f, "Cancelled(v{version})"),
+            Self::PerEpochConfig => write!(f, "PerEpochConfig"),
+        }
+    }
+}
+
 impl UnchangedSharedKind {
     crate::def_is!(
         ReadOnlyRoot,
@@ -240,6 +284,19 @@ pub enum ObjectIn {
         digest: Digest,
         owner: Owner,
     },
+}
+
+impl std::fmt::Display for ObjectIn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing => write!(f, "Missing"),
+            Self::Data {
+                version,
+                digest,
+                owner,
+            } => write!(f, "Data(v{version}, {digest}, {owner})"),
+        }
+    }
 }
 
 impl ObjectIn {
@@ -318,6 +375,20 @@ pub enum ObjectOut {
         version: Version,
         digest: Digest,
     },
+}
+
+impl std::fmt::Display for ObjectOut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Missing => write!(f, "Missing"),
+            Self::ObjectWrite { digest, owner } => {
+                write!(f, "ObjectWrite({digest}, {owner})")
+            }
+            Self::PackageWrite { version, digest } => {
+                write!(f, "PackageWrite(v{version}, {digest})")
+            }
+        }
+    }
 }
 
 impl ObjectOut {
@@ -400,6 +471,16 @@ pub enum IdOperation {
     None,
     Created,
     Deleted,
+}
+
+impl std::fmt::Display for IdOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Created => write!(f, "Created"),
+            Self::Deleted => write!(f, "Deleted"),
+        }
+    }
 }
 
 impl IdOperation {

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -19,6 +19,12 @@ use super::{Address, Identifier, ObjectId, StructTag, TypeTag};
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct TransactionEvents(pub Vec<Event>);
 
+impl std::fmt::Display for TransactionEvents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransactionEvents({} events)", self.0.len())
+    }
+}
+
 /// An event
 ///
 /// # BCS
@@ -58,6 +64,16 @@ pub struct Event {
     pub contents: Vec<u8>,
 }
 
+impl std::fmt::Display for Event {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Event(type: {}, sender: {}, package: {}::{})",
+            self.type_, self.sender, self.package_id, self.module
+        )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
@@ -78,4 +94,15 @@ pub struct BalanceChange {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::I128"))]
     pub amount: i128,
+}
+
+impl std::fmt::Display for BalanceChange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let sign = if self.amount >= 0 { "+" } else { "" };
+        write!(
+            f,
+            "BalanceChange({}{} {}, owner: {})",
+            sign, self.amount, self.coin_type, self.address
+        )
+    }
 }

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -36,6 +36,21 @@ pub enum ExecutionStatus {
     },
 }
 
+impl std::fmt::Display for ExecutionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Success => write!(f, "Success"),
+            Self::Failure { error, command } => {
+                write!(f, "Failure")?;
+                if let Some(cmd) = command {
+                    write!(f, " at command {cmd}")?;
+                }
+                write!(f, ": {error}")
+            }
+        }
+    }
+}
+
 impl ExecutionStatus {
     crate::def_is!(Success, Failure);
 
@@ -279,6 +294,152 @@ pub enum ExecutionError {
     InvalidLinkage,
 }
 
+impl std::fmt::Display for ExecutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsufficientGas => write!(f, "Insufficient gas"),
+            Self::InvalidGasObject => write!(f, "Invalid gas object"),
+            Self::InvariantViolation => write!(f, "Invariant violation"),
+            Self::FeatureNotYetSupported => write!(f, "Feature not yet supported"),
+            Self::ObjectTooBig {
+                object_size,
+                max_object_size,
+            } => write!(
+                f,
+                "Object too big: size {object_size} exceeds max {max_object_size}"
+            ),
+            Self::PackageTooBig {
+                object_size,
+                max_object_size,
+            } => write!(
+                f,
+                "Package too big: size {object_size} exceeds max {max_object_size}"
+            ),
+            Self::CircularObjectOwnership { object } => {
+                write!(f, "Circular object ownership for {object}")
+            }
+            Self::InsufficientCoinBalance => write!(f, "Insufficient coin balance"),
+            Self::CoinBalanceOverflow => write!(f, "Coin balance overflow"),
+            Self::PublishErrorNonZeroAddress => {
+                write!(f, "Publish error: non-zero address")
+            }
+            Self::IotaMoveVerificationError => {
+                write!(f, "IOTA Move bytecode verification error")
+            }
+            Self::MovePrimitiveRuntimeError { location } => {
+                write!(f, "Move primitive runtime error")?;
+                if let Some(loc) = location {
+                    write!(f, " at {loc}")?;
+                }
+                Ok(())
+            }
+            Self::MoveAbort { location, code } => {
+                write!(f, "Move abort at {location} with code {code}")
+            }
+            Self::VmVerificationOrDeserializationError => {
+                write!(f, "VM verification or deserialization error")
+            }
+            Self::VmInvariantViolation => write!(f, "VM invariant violation"),
+            Self::FunctionNotFound => write!(f, "Function not found"),
+            Self::ArityMismatch => write!(f, "Arity mismatch"),
+            Self::TypeArityMismatch => write!(f, "Type arity mismatch"),
+            Self::NonEntryFunctionInvoked => write!(f, "Non-entry function invoked"),
+            Self::CommandArgumentError { argument, kind } => {
+                write!(f, "Command argument error at argument {argument}: {kind}")
+            }
+            Self::TypeArgumentError {
+                type_argument,
+                kind,
+            } => {
+                write!(
+                    f,
+                    "Type argument error at type argument {type_argument}: {kind}"
+                )
+            }
+            Self::UnusedValueWithoutDrop { result, subresult } => {
+                write!(
+                    f,
+                    "Unused value without drop: result {result}, subresult {subresult}"
+                )
+            }
+            Self::InvalidPublicFunctionReturnType { index } => {
+                write!(f, "Invalid public function return type at index {index}")
+            }
+            Self::InvalidTransferObject => write!(f, "Invalid transfer object"),
+            Self::EffectsTooLarge {
+                current_size,
+                max_size,
+            } => write!(
+                f,
+                "Effects too large: size {current_size} exceeds max {max_size}"
+            ),
+            Self::PublishUpgradeMissingDependency => {
+                write!(f, "Publish/upgrade missing dependency")
+            }
+            Self::PublishUpgradeDependencyDowngrade => {
+                write!(f, "Publish/upgrade dependency downgrade")
+            }
+            Self::PackageUpgradeError { kind } => {
+                write!(f, "Package upgrade error: {kind}")
+            }
+            Self::WrittenObjectsTooLarge {
+                object_size,
+                max_object_size,
+            } => write!(
+                f,
+                "Written objects too large: size {object_size} exceeds max {max_object_size}"
+            ),
+            Self::CertificateDenied => write!(f, "Certificate denied"),
+            Self::IotaMoveVerificationTimeout => {
+                write!(f, "IOTA Move bytecode verification timeout")
+            }
+            Self::SharedObjectOperationNotAllowed => {
+                write!(f, "Shared object operation not allowed")
+            }
+            Self::InputObjectDeleted => write!(f, "Input object deleted"),
+            Self::ExecutionCancelledDueToSharedObjectCongestion {
+                congested_objects,
+            } => {
+                write!(f, "Execution cancelled due to shared object congestion: ")?;
+                for (i, obj) in congested_objects.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{obj}")?;
+                }
+                Ok(())
+            }
+            Self::ExecutionCancelledDueToSharedObjectCongestionV2 {
+                congested_objects,
+                suggested_gas_price,
+            } => {
+                write!(f, "Execution cancelled due to shared object congestion: ")?;
+                for (i, obj) in congested_objects.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{obj}")?;
+                }
+                write!(f, " (suggested gas price: {suggested_gas_price})")
+            }
+            Self::AddressDeniedForCoin {
+                address,
+                coin_type,
+            } => write!(f, "Address {address} denied for coin type {coin_type}"),
+            Self::CoinTypeGlobalPause { coin_type } => {
+                write!(f, "Coin type globally paused: {coin_type}")
+            }
+            Self::ExecutionCancelledDueToRandomnessUnavailable => {
+                write!(
+                    f,
+                    "Execution cancelled due to randomness unavailable"
+                )
+            }
+            Self::InvalidLinkage => write!(f, "Invalid linkage"),
+        }
+    }
+}
+
 impl ExecutionError {
     crate::def_is!(
         InsufficientGas,
@@ -352,6 +513,18 @@ pub struct MoveLocation {
     pub instruction: u16,
     /// The name of the function if available
     pub function_name: Option<Identifier>,
+}
+
+impl std::fmt::Display for MoveLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}::{}", self.package, self.module)?;
+        if let Some(ref name) = self.function_name {
+            write!(f, "::{name}")?;
+        } else {
+            write!(f, "::function#{}", self.function)?;
+        }
+        write!(f, " at instruction {}", self.instruction)
+    }
 }
 
 /// An error with an argument to a command
@@ -432,6 +605,43 @@ pub enum CommandArgumentError {
     InvalidArgumentArity,
 }
 
+impl std::fmt::Display for CommandArgumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TypeMismatch => write!(f, "Type mismatch"),
+            Self::InvalidBcsBytes => write!(f, "Invalid BCS bytes"),
+            Self::InvalidUsageOfPureArgument => {
+                write!(f, "Invalid usage of pure argument")
+            }
+            Self::InvalidArgumentToPrivateEntryFunction => {
+                write!(f, "Invalid argument to private entry function")
+            }
+            Self::IndexOutOfBounds { index } => {
+                write!(f, "Index out of bounds: {index}")
+            }
+            Self::SecondaryIndexOutOfBounds { result, subresult } => {
+                write!(
+                    f,
+                    "Secondary index out of bounds: result {result}, subresult {subresult}"
+                )
+            }
+            Self::InvalidResultArity { result } => {
+                write!(f, "Invalid result arity: {result}")
+            }
+            Self::InvalidGasCoinUsage => write!(f, "Invalid gas coin usage"),
+            Self::InvalidValueUsage => write!(f, "Invalid value usage"),
+            Self::InvalidObjectByValue => write!(f, "Invalid object by value"),
+            Self::InvalidObjectByMutRef => {
+                write!(f, "Invalid object by mutable reference")
+            }
+            Self::SharedObjectOperationNotAllowed => {
+                write!(f, "Shared object operation not allowed")
+            }
+            Self::InvalidArgumentArity => write!(f, "Invalid argument arity"),
+        }
+    }
+}
+
 impl CommandArgumentError {
     crate::def_is!(
         TypeMismatch,
@@ -496,6 +706,33 @@ pub enum PackageUpgradeError {
     },
 }
 
+impl std::fmt::Display for PackageUpgradeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnableToFetchPackage { package_id } => {
+                write!(f, "Unable to fetch package {package_id}")
+            }
+            Self::NotAPackage { object_id } => {
+                write!(f, "Object {object_id} is not a package")
+            }
+            Self::IncompatibleUpgrade => write!(f, "Incompatible upgrade"),
+            Self::DigestDoesNotMatch { digest } => {
+                write!(f, "Digest does not match: {digest}")
+            }
+            Self::UnknownUpgradePolicy { policy } => {
+                write!(f, "Unknown upgrade policy: {policy}")
+            }
+            Self::PackageIdDoesNotMatch {
+                package_id,
+                ticket_id,
+            } => write!(
+                f,
+                "Package ID {package_id} does not match ticket ID {ticket_id}"
+            ),
+        }
+    }
+}
+
 impl PackageUpgradeError {
     crate::def_is!(
         UnableToFetchPackage,
@@ -536,6 +773,15 @@ pub enum TypeArgumentError {
     TypeNotFound,
     /// A type provided did not match the specified constraint
     ConstraintNotSatisfied,
+}
+
+impl std::fmt::Display for TypeArgumentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TypeNotFound => write!(f, "Type not found"),
+            Self::ConstraintNotSatisfied => write!(f, "Constraint not satisfied"),
+        }
+    }
 }
 
 impl TypeArgumentError {

--- a/crates/iota-sdk-types/src/framework.rs
+++ b/crates/iota-sdk-types/src/framework.rs
@@ -13,6 +13,16 @@ pub struct Coin {
     balance: u64,
 }
 
+impl std::fmt::Display for Coin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Coin(type: {}, id: {}, balance: {})",
+            self.coin_type, self.id, self.balance
+        )
+    }
+}
+
 impl Coin {
     pub fn coin_type(&self) -> &TypeTag {
         &self.coin_type

--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -59,6 +59,18 @@ pub struct MovePackageData {
     pub digest: Digest,
 }
 
+impl std::fmt::Display for MovePackageData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MovePackageData(modules: {}, dependencies: {}, digest: {})",
+            self.modules.len(),
+            self.dependencies.len(),
+            self.digest
+        )
+    }
+}
+
 impl MovePackageData {
     #[cfg(feature = "hash")]
     pub fn new(modules: Vec<Vec<u8>>, dependencies: Vec<ObjectId>) -> Self {

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -79,6 +79,12 @@ impl ObjectReference {
     }
 }
 
+impl std::fmt::Display for ObjectReference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}(v{})", self.object_id, self.version)
+    }
+}
+
 /// Enum of different types of ownership for an object.
 ///
 /// # BCS
@@ -160,6 +166,15 @@ pub enum ObjectData {
     // ... IOTA "native" types go here
 }
 
+impl std::fmt::Display for ObjectData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Struct(s) => write!(f, "Struct({})", s.type_),
+            Self::Package(p) => write!(f, "Package({})", p.id),
+        }
+    }
+}
+
 impl ObjectData {
     crate::def_is_as_into_opt!(Struct(MoveStruct), Package(MovePackage));
 }
@@ -226,6 +241,18 @@ pub struct MovePackage {
     pub linkage_table: BTreeMap<ObjectId, UpgradeInfo>,
 }
 
+impl std::fmt::Display for MovePackage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MovePackage(id: {}, version: {}, modules: {})",
+            self.id,
+            self.version,
+            self.modules.len()
+        )
+    }
+}
+
 /// Identifies a struct and the module it was defined in
 ///
 /// # BCS
@@ -247,6 +274,16 @@ pub struct TypeOrigin {
     pub module_name: Identifier,
     pub struct_name: Identifier,
     pub package: ObjectId,
+}
+
+impl std::fmt::Display for TypeOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}::{}(package: {})",
+            self.module_name, self.struct_name, self.package
+        )
+    }
 }
 
 /// Upgraded package info for the linkage table
@@ -273,6 +310,16 @@ pub struct UpgradeInfo {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
     pub upgraded_version: Version,
+}
+
+impl std::fmt::Display for UpgradeInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "UpgradeInfo(id: {}, version: {})",
+            self.upgraded_id, self.upgraded_version
+        )
+    }
 }
 
 /// A move struct
@@ -322,6 +369,12 @@ pub struct MoveStruct {
     pub contents: Vec<u8>,
 }
 
+impl std::fmt::Display for MoveStruct {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MoveStruct(type: {}, version: {})", self.type_, self.version)
+    }
+}
+
 /// Type of an IOTA object
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum ObjectType {
@@ -368,6 +421,16 @@ pub struct Object {
     /// This number is re-calculated each time the object is mutated based on
     /// the present storage gas price.
     pub storage_rebate: u64,
+}
+
+impl std::fmt::Display for Object {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Object({}, owner: {}, prev_tx: {})",
+            self.data, self.owner, self.previous_transaction
+        )
+    }
 }
 
 impl Object {
@@ -505,6 +568,12 @@ fn id_opt(contents: &[u8]) -> Option<ObjectId> {
 pub struct GenesisObject {
     pub data: ObjectData,
     pub owner: Owner,
+}
+
+impl std::fmt::Display for GenesisObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GenesisObject({}, owner: {})", self.data, self.owner)
+    }
 }
 
 impl GenesisObject {

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -37,6 +37,14 @@ pub enum Transaction {
     // in the validity_check function based on the protocol config.
 }
 
+impl std::fmt::Display for Transaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V1(v1) => write!(f, "Transaction::V1({})", v1),
+        }
+    }
+}
+
 impl Transaction {
     crate::def_is_as_into_opt!(V1(TransactionV1));
 }
@@ -62,6 +70,12 @@ pub struct TransactionV1 {
     pub expiration: TransactionExpiration,
 }
 
+impl std::fmt::Display for TransactionV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransactionV1(sender: {}, expiration: {})", self.sender, self.expiration)
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(serde::Deserialize))]
 pub struct SenderSignedTransaction(
     #[cfg_attr(
@@ -71,6 +85,12 @@ pub struct SenderSignedTransaction(
     pub SignedTransaction,
 );
 
+impl std::fmt::Display for SenderSignedTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SenderSignedTransaction({})", self.0)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -78,6 +98,12 @@ pub struct SenderSignedTransaction(
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub signatures: Vec<UserSignature>,
+}
+
+impl std::fmt::Display for SignedTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SignedTransaction(signatures: {})", self.signatures.len())
+    }
 }
 
 /// A TTL for a transaction
@@ -100,6 +126,15 @@ pub enum TransactionExpiration {
     /// Validators won't sign a transaction unless the expiration Epoch
     /// is greater than or equal to the current epoch
     Epoch(EpochId),
+}
+
+impl std::fmt::Display for TransactionExpiration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "None"),
+            Self::Epoch(epoch) => write!(f, "Epoch({})", epoch),
+        }
+    }
 }
 
 impl TransactionExpiration {
@@ -141,6 +176,12 @@ pub struct GasPayment {
     pub budget: u64,
 }
 
+impl std::fmt::Display for GasPayment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GasPayment(owner: {}, price: {}, budget: {})", self.owner, self.price, self.budget)
+    }
+}
+
 /// Randomness update
 ///
 /// # BCS
@@ -180,6 +221,12 @@ pub struct RandomnessStateUpdate {
     pub randomness_obj_initial_shared_version: u64,
 }
 
+impl std::fmt::Display for RandomnessStateUpdate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RandomnessStateUpdate(epoch: {}, round: {})", self.epoch, self.randomness_round)
+    }
+}
+
 /// Transaction type
 ///
 /// # BCS
@@ -217,6 +264,19 @@ pub enum TransactionKind {
     EndOfEpoch(Vec<EndOfEpochTransactionKind>),
     /// Randomness update
     RandomnessStateUpdate(RandomnessStateUpdate),
+}
+
+impl std::fmt::Display for TransactionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProgrammableTransaction(_) => write!(f, "ProgrammableTransaction"),
+            Self::Genesis(_) => write!(f, "Genesis"),
+            Self::ConsensusCommitPrologueV1(_) => write!(f, "ConsensusCommitPrologueV1"),
+            Self::AuthenticatorStateUpdateV1(_) => write!(f, "AuthenticatorStateUpdateV1"),
+            Self::EndOfEpoch(_) => write!(f, "EndOfEpoch"),
+            Self::RandomnessStateUpdate(_) => write!(f, "RandomnessStateUpdate"),
+        }
+    }
 }
 
 impl TransactionKind {
@@ -281,6 +341,19 @@ pub enum EndOfEpochTransactionKind {
     AuthenticatorStateExpire(AuthenticatorStateExpire),
 }
 
+impl std::fmt::Display for EndOfEpochTransactionKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ChangeEpoch(_) => write!(f, "ChangeEpoch"),
+            Self::ChangeEpochV2(_) => write!(f, "ChangeEpochV2"),
+            Self::ChangeEpochV3(_) => write!(f, "ChangeEpochV3"),
+            Self::ChangeEpochV4(_) => write!(f, "ChangeEpochV4"),
+            Self::AuthenticatorStateCreate => write!(f, "AuthenticatorStateCreate"),
+            Self::AuthenticatorStateExpire(_) => write!(f, "AuthenticatorStateExpire"),
+        }
+    }
+}
+
 impl EndOfEpochTransactionKind {
     crate::def_is!(AuthenticatorStateCreate);
 
@@ -310,6 +383,14 @@ pub enum ExecutionTimeObservations {
     V1(Vec<ExecutionTimeObservation>),
 }
 
+impl std::fmt::Display for ExecutionTimeObservations {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::V1(observations) => write!(f, "ExecutionTimeObservations::V1({})", observations.len()),
+        }
+    }
+}
+
 impl ExecutionTimeObservations {
     crate::def_is_as_into_opt!(V1(Vec<ExecutionTimeObservation>));
 }
@@ -321,6 +402,12 @@ impl ExecutionTimeObservations {
 pub struct ExecutionTimeObservation {
     pub key: ExecutionTimeObservationKey,
     pub observations: Vec<ValidatorExecutionTimeObservation>,
+}
+
+impl std::fmt::Display for ExecutionTimeObservation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ExecutionTimeObservation(key: {}, observations: {})", self.key, self.observations.len())
+    }
 }
 
 /// An execution time observation from a particular validator
@@ -341,6 +428,12 @@ pub struct ExecutionTimeObservation {
 pub struct ValidatorExecutionTimeObservation {
     pub validator: crate::Bls12381PublicKey,
     pub duration: std::time::Duration,
+}
+
+impl std::fmt::Display for ValidatorExecutionTimeObservation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ValidatorExecutionTimeObservation(duration: {:?})", self.duration)
+    }
 }
 
 /// Key for an execution time observation
@@ -390,6 +483,22 @@ pub enum ExecutionTimeObservationKey {
     Upgrade,
 }
 
+impl std::fmt::Display for ExecutionTimeObservationKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MoveEntryPoint { package, module, function, .. } => {
+                write!(f, "MoveEntryPoint({}::{}::{})", package, module, function)
+            }
+            Self::TransferObjects => write!(f, "TransferObjects"),
+            Self::SplitCoins => write!(f, "SplitCoins"),
+            Self::MergeCoins => write!(f, "MergeCoins"),
+            Self::Publish => write!(f, "Publish"),
+            Self::MakeMoveVec => write!(f, "MakeMoveVec"),
+            Self::Upgrade => write!(f, "Upgrade"),
+        }
+    }
+}
+
 impl ExecutionTimeObservationKey {
     crate::def_is!(
         MoveEntryPoint,
@@ -430,6 +539,12 @@ pub struct AuthenticatorStateExpire {
     pub authenticator_obj_initial_shared_version: u64,
 }
 
+impl std::fmt::Display for AuthenticatorStateExpire {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AuthenticatorStateExpire(min_epoch: {})", self.min_epoch)
+    }
+}
+
 /// Update the set of valid JWKs
 ///
 /// # BCS
@@ -467,6 +582,12 @@ pub struct AuthenticatorStateUpdateV1 {
     pub authenticator_obj_initial_shared_version: u64,
 }
 
+impl std::fmt::Display for AuthenticatorStateUpdateV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AuthenticatorStateUpdateV1(epoch: {}, round: {})", self.epoch, self.round)
+    }
+}
+
 /// A new Jwk
 ///
 /// # BCS
@@ -495,6 +616,12 @@ pub struct ActiveJwk {
     pub epoch: u64,
 }
 
+impl std::fmt::Display for ActiveJwk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ActiveJwk(epoch: {})", self.epoch)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "schemars",
@@ -509,6 +636,16 @@ pub enum ConsensusDeterminedVersionAssignments {
         #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
         cancelled_transactions: Vec<CancelledTransaction>,
     },
+}
+
+impl std::fmt::Display for ConsensusDeterminedVersionAssignments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::CancelledTransactions { cancelled_transactions } => {
+                write!(f, "CancelledTransactions(count: {})", cancelled_transactions.len())
+            }
+        }
+    }
 }
 
 impl ConsensusDeterminedVersionAssignments {
@@ -545,6 +682,12 @@ pub struct CancelledTransaction {
     pub version_assignments: Vec<VersionAssignment>,
 }
 
+impl std::fmt::Display for CancelledTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CancelledTransaction(digest: {})", self.digest)
+    }
+}
+
 /// Object version assignment from consensus
 ///
 /// # BCS
@@ -567,6 +710,12 @@ pub struct VersionAssignment {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
     pub version: Version,
+}
+
+impl std::fmt::Display for VersionAssignment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "VersionAssignment(version: {})", self.version)
+    }
 }
 
 /// V1 of the consensus commit prologue system transaction
@@ -612,6 +761,12 @@ pub struct ConsensusCommitPrologueV1 {
     pub consensus_commit_digest: Digest,
     /// Stores consensus handler determined shared object version assignments.
     pub consensus_determined_version_assignments: ConsensusDeterminedVersionAssignments,
+}
+
+impl std::fmt::Display for ConsensusCommitPrologueV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ConsensusCommitPrologueV1(epoch: {}, round: {})", self.epoch, self.round)
+    }
 }
 
 /// System transaction used to change the epoch
@@ -675,6 +830,12 @@ pub struct ChangeEpoch {
     /// their package ID), and a list of their transitive dependencies.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub system_packages: Vec<SystemPackage>,
+}
+
+impl std::fmt::Display for ChangeEpoch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChangeEpoch(epoch: {}, protocol_version: {})", self.epoch, self.protocol_version)
+    }
 }
 
 /// System transaction used to change the epoch
@@ -745,6 +906,12 @@ pub struct ChangeEpochV2 {
     pub system_packages: Vec<SystemPackage>,
 }
 
+impl std::fmt::Display for ChangeEpochV2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChangeEpochV2(epoch: {}, protocol_version: {})", self.epoch, self.protocol_version)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
@@ -797,6 +964,12 @@ pub struct ChangeEpochV3 {
     /// Vector of active validator indices eligible to take part in committee
     /// selection because they support the new, target protocol version.
     pub eligible_active_validators: Vec<u64>,
+}
+
+impl std::fmt::Display for ChangeEpochV3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChangeEpochV3(epoch: {}, protocol_version: {})", self.epoch, self.protocol_version)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -858,6 +1031,12 @@ pub struct ChangeEpochV4 {
     pub adjust_rewards_by_score: bool,
 }
 
+impl std::fmt::Display for ChangeEpochV4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ChangeEpochV4(epoch: {}, protocol_version: {})", self.epoch, self.protocol_version)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -878,6 +1057,12 @@ pub struct SystemPackage {
     pub dependencies: Vec<ObjectId>,
 }
 
+impl std::fmt::Display for SystemPackage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SystemPackage(version: {})", self.version)
+    }
+}
+
 /// The genesis transaction
 ///
 /// # BCS
@@ -896,6 +1081,12 @@ pub struct GenesisTransaction {
     pub objects: Vec<GenesisObject>,
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=10).lift()))]
     pub events: Vec<Event>,
+}
+
+impl std::fmt::Display for GenesisTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GenesisTransaction(objects: {}, events: {})", self.objects.len(), self.events.len())
+    }
 }
 
 /// A user transaction
@@ -922,6 +1113,12 @@ pub struct ProgrammableTransaction {
     /// result in the failure of the entire transaction.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=10).lift()))]
     pub commands: Vec<Command>,
+}
+
+impl std::fmt::Display for ProgrammableTransaction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ProgrammableTransaction(inputs: {}, commands: {})", self.inputs.len(), self.commands.len())
+    }
 }
 
 /// An input to a user transaction
@@ -970,6 +1167,19 @@ pub enum Input {
     /// A move object that is attempted to be received in this transaction.
     // TODO add discussion around what receiving is
     Receiving(ObjectReference),
+}
+
+impl std::fmt::Display for Input {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pure { .. } => write!(f, "Pure"),
+            Self::ImmutableOrOwned(obj_ref) => write!(f, "ImmutableOrOwned({})", obj_ref.object_id),
+            Self::Shared { object_id, initial_shared_version, mutable } => {
+                write!(f, "Shared(id: {}, version: {}, mutable: {})", object_id, initial_shared_version, mutable)
+            }
+            Self::Receiving(obj_ref) => write!(f, "Receiving({})", obj_ref.object_id),
+        }
+    }
 }
 
 impl Input {
@@ -1044,6 +1254,20 @@ pub enum Command {
     Upgrade(Upgrade),
 }
 
+impl std::fmt::Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MoveCall(_) => write!(f, "MoveCall"),
+            Self::TransferObjects(_) => write!(f, "TransferObjects"),
+            Self::SplitCoins(_) => write!(f, "SplitCoins"),
+            Self::MergeCoins(_) => write!(f, "MergeCoins"),
+            Self::Publish(_) => write!(f, "Publish"),
+            Self::MakeMoveVector(_) => write!(f, "MakeMoveVector"),
+            Self::Upgrade(_) => write!(f, "Upgrade"),
+        }
+    }
+}
+
 impl Command {
     crate::def_is_as_into_opt!(
         MoveCall,
@@ -1077,6 +1301,12 @@ pub struct TransferObjects {
     pub address: Argument,
 }
 
+impl std::fmt::Display for TransferObjects {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TransferObjects(objects: {})", self.objects.len())
+    }
+}
+
 /// Command to split a single coin object into multiple coins
 ///
 /// # BCS
@@ -1096,6 +1326,12 @@ pub struct SplitCoins {
     /// The amounts to split off
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub amounts: Vec<Argument>,
+}
+
+impl std::fmt::Display for SplitCoins {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SplitCoins(amounts: {})", self.amounts.len())
+    }
 }
 
 /// Command to merge multiple coins of the same type into a single coin
@@ -1123,6 +1359,12 @@ pub struct MergeCoins {
     /// All listed coins must be of the same type and be the same type as `coin`
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub coins_to_merge: Vec<Argument>,
+}
+
+impl std::fmt::Display for MergeCoins {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MergeCoins(coins_to_merge: {})", self.coins_to_merge.len())
+    }
 }
 
 /// Command to publish a new move package
@@ -1153,6 +1395,12 @@ pub struct Publish {
     pub dependencies: Vec<ObjectId>,
 }
 
+impl std::fmt::Display for Publish {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Publish(modules: {}, dependencies: {})", self.modules.len(), self.dependencies.len())
+    }
+}
+
 /// Command to build a move vector out of a set of individual elements
 ///
 /// # BCS
@@ -1176,6 +1424,12 @@ pub struct MakeMoveVector {
     /// The set individual elements to build the vector with
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub elements: Vec<Argument>,
+}
+
+impl std::fmt::Display for MakeMoveVector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MakeMoveVector(elements: {})", self.elements.len())
+    }
 }
 
 /// Command to upgrade an already published package
@@ -1212,6 +1466,12 @@ pub struct Upgrade {
     pub ticket: Argument,
 }
 
+impl std::fmt::Display for Upgrade {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Upgrade(package: {})", self.package)
+    }
+}
+
 /// An argument to a programmable transaction command
 ///
 /// # BCS
@@ -1246,6 +1506,17 @@ pub enum Argument {
     /// return values.
     // (command index, subresult index)
     NestedResult(u16, u16),
+}
+
+impl std::fmt::Display for Argument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Gas => write!(f, "Gas"),
+            Self::Input(idx) => write!(f, "Input({})", idx),
+            Self::Result(idx) => write!(f, "Result({})", idx),
+            Self::NestedResult(cmd_idx, res_idx) => write!(f, "NestedResult({}, {})", cmd_idx, res_idx),
+        }
+    }
 }
 
 impl Argument {
@@ -1335,4 +1606,10 @@ pub struct MoveCall {
     /// The arguments to the function.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
     pub arguments: Vec<Argument>,
+}
+
+impl std::fmt::Display for MoveCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MoveCall({}::{}::{})", self.package, self.module, self.function)
+    }
 }

--- a/crates/iota-sdk-types/src/validator.rs
+++ b/crates/iota-sdk-types/src/validator.rs
@@ -88,6 +88,47 @@ pub struct ValidatorAggregatedSignature {
     pub bitmap: roaring::RoaringBitmap,
 }
 
+impl std::fmt::Display for ValidatorCommittee {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ValidatorCommittee(epoch: {}, members: {})",
+            self.epoch,
+            self.members.len()
+        )
+    }
+}
+
+impl std::fmt::Display for ValidatorCommitteeMember {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ValidatorCommitteeMember(key: {}, stake: {})",
+            self.public_key, self.stake
+        )
+    }
+}
+
+impl std::fmt::Display for ValidatorAggregatedSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ValidatorAggregatedSignature(epoch: {}, sig: {})",
+            self.epoch, self.signature
+        )
+    }
+}
+
+impl std::fmt::Display for ValidatorSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ValidatorSignature(epoch: {}, key: {}, sig: {})",
+            self.epoch, self.public_key, self.signature
+        )
+    }
+}
+
 #[cfg(feature = "serde")]
 type RoaringBitMapSerialization = ::serde_with::As<
     ::serde_with::IfIsHumanReadable<


### PR DESCRIPTION
## Summary

Implements `std::fmt::Display` for **~100 public types** across the `iota-sdk-types` crate, providing human-readable string representations for debugging, logging, and error reporting.

### Changes by module:

- **execution_status.rs** (6 types): `ExecutionStatus`, `ExecutionError` (all 33+ variants), `MoveLocation`, `CommandArgumentError`, `PackageUpgradeError`, `TypeArgumentError`
- **events.rs** (3 types): `TransactionEvents`, `Event`, `BalanceChange`
- **object.rs** (8 types): `ObjectReference`, `ObjectData`, `MovePackage`, `TypeOrigin`, `UpgradeInfo`, `MoveStruct`, `Object`, `GenesisObject`
- **checkpoint.rs** (8 types): `CheckpointCommitment`, `EndOfEpochData`, `CheckpointSummary`, `SignedCheckpointSummary`, `CheckpointContents`, `CheckpointTransactionInfo`, `CheckpointData`, `CheckpointTransaction`
- **validator.rs** (4 types): `ValidatorCommittee`, `ValidatorCommitteeMember`, `ValidatorAggregatedSignature`, `ValidatorSignature`
- **framework.rs** (1 type): `Coin`
- **move_package.rs** (1 type): `MovePackageData`
- **effects/** (8 types): `TransactionEffects`, `TransactionEffectsV1`, `ChangedObject`, `UnchangedSharedObject`, `UnchangedSharedKind`, `ObjectIn`, `ObjectOut`, `IdOperation`
- **transaction/** (37 types): `Transaction`, `TransactionV1`, `SignedTransaction`, `TransactionKind`, `Command`, `Argument`, `MoveCall`, `ProgrammableTransaction`, and 29 more
- **crypto/** (24 types): `SimpleSignature`, `UserSignature`, `Intent`, `IntentScope`, `MultisigCommittee`, `ZkLoginAuthenticator`, `Jwk`, `JwkId`, and 16 more

### Design decisions:

- **Consistent patterns**: Follows existing crate conventions (`Owner`, `GasCostSummary`, `ObjectType` Display patterns)
- **Enum variants**: Use descriptive match arms with field details
- **Struct types**: Use `TypeName(key: value, ...)` format showing essential fields
- **Security-sensitive types** (crypto keys/signatures): Delegate to existing Display impls
- **Collection types**: Show counts rather than dumping all elements
- **No new dependencies**: Pure `std::fmt` implementations

### Verification:

- `cargo check -p iota-sdk-types` passes cleanly
- No changes to existing behavior or serialization
- Pre-existing test compilation issues in `move_package.rs` are unaffected

Resolves #502