### PR TITLE
feat: update `TransactionEffects`

### DIFF
--- a/crates/iota-sdk-ffi/src/types/transaction/v1.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/v1.rs
@@ -38,7 +38,7 @@ pub struct TransactionEffectsV1 {
     /// The epoch when this transaction was executed.
     pub epoch: u64,
     /// The gas used by this transaction
-    pub gas_used: GasCostSummary,
+    pub gas_cost_summary: GasCostSummary,
     /// The transaction digest
     pub transaction_digest: Arc<Digest>,
     /// The updated gas object reference, as an index into the `changed_objects`
@@ -75,7 +75,7 @@ impl From<iota_sdk::types::TransactionEffectsV1> for TransactionEffectsV1 {
         Self {
             status: value.status.into(),
             epoch: value.epoch,
-            gas_used: value.gas_used,
+            gas_cost_summary: value.gas_cost_summary,
             transaction_digest: Arc::new(value.transaction_digest.into()),
             gas_object_index: value.gas_object_index,
             events_digest: value.events_digest.map(Into::into).map(Arc::new),
@@ -102,7 +102,7 @@ impl From<TransactionEffectsV1> for iota_sdk::types::TransactionEffectsV1 {
         Self {
             status: value.status.into(),
             epoch: value.epoch,
-            gas_used: value.gas_used,
+            gas_cost_summary: value.gas_cost_summary,
             transaction_digest: **value.transaction_digest,
             gas_object_index: value.gas_object_index,
             events_digest: value.events_digest.map(|v| **v),

--- a/crates/iota-sdk-graphql-client/Cargo.toml
+++ b/crates/iota-sdk-graphql-client/Cargo.toml
@@ -33,7 +33,7 @@ variadics_please.workspace = true
 iota-types = { workspace = true, features = ["serde", "hash"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom_2.workspace = true
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -62,7 +62,7 @@ impl Client {
     ///
     /// // Lazy conversion - only deserialize what you need
     /// let effects = result.body().effects()?.effects()?;
-    /// println!("Status: {:?}", effects.status());
+    /// println!("Status: {:?}", effects.as_v1().status);
     ///
     /// let events = result.body().events()?.events()?;
     /// if !events.0.is_empty() {

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -77,7 +77,7 @@ impl Client {
     /// // Lazy conversion - only deserialize what you need
     /// let executed_tx = result.body().executed_transaction()?;
     /// let effects = executed_tx.effects()?.effects()?;
-    /// println!("Simulation status: {:?}", effects.status());
+    /// println!("Simulation status: {:?}", effects.as_v1().status);
     ///
     /// let output_objs = executed_tx.output_objects()?;
     /// println!("Would create {} objects", output_objs.objects.len());

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -72,7 +72,7 @@ impl Client {
     /// for tx in txs.body() {
     ///     // Lazy conversion - only deserialize what you need
     ///     let effects = tx.effects()?.effects()?;
-    ///     println!("Status: {:?}", effects.status());
+    ///     println!("Status: {:?}", effects.as_v1().status);
     ///
     ///     // Access checkpoint number
     ///     let checkpoint = tx.checkpoint_sequence_number()?;

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -225,7 +225,7 @@ impl ClientMethods for iota_graphql_client::Client {
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
         let res = self.dry_run_tx(tx, true).await?;
         Ok(res.effects.map(|effects| match effects {
-            TransactionEffects::V1(v1) => v1.gas_used.gas_used(),
+            TransactionEffects::V1(v1) => v1.gas_cost_summary.gas_used(),
             _ => unimplemented!(
                 "a new TransactionEffects enum variant was added and needs to be handled"
             ),

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -224,7 +224,12 @@ impl ClientMethods for iota_graphql_client::Client {
 
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
         let res = self.dry_run_tx(tx, true).await?;
-        Ok(res.effects.map(|e| e.gas_summary().gas_used()))
+        Ok(res.effects.map(|effects| match effects {
+            TransactionEffects::V1(v1) => v1.gas_used.gas_used(),
+            _ => unimplemented!(
+                "a new TransactionEffects enum variant was added and needs to be handled"
+            ),
+        }))
     }
 
     async fn dry_run_tx(

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -384,14 +384,19 @@ mod tests {
         }
     }
 
-    /// Wait for the transaction to be finalized and indexed, and check the
-    /// effects' to ensure the transaction was successfully executed.
-    async fn check_effects_status_success(effects: Result<TransactionEffects, Error>) {
+    /// Check the effects to ensure the transaction was successfully executed.
+    fn check_effects_status_success(effects: Result<TransactionEffects, Error>) {
         assert!(effects.is_ok(), "Execution failed. Effects: {effects:?}");
+
         // check that it succeeded
-        let status = effects.unwrap();
-        let expected_status = ExecutionStatus::Success;
-        assert_eq!(&expected_status, status.status());
+        match effects.unwrap() {
+            TransactionEffects::V1(v1) => {
+                assert_eq!(ExecutionStatus::Success, v1.status);
+            }
+            _ => unimplemented!(
+                "a new TransactionEffects enum variant was added and needs to be handled"
+            ),
+        };
     }
 
     #[tokio::test]
@@ -508,7 +513,7 @@ mod tests {
         tx.transfer_objects(recipient, [coin]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
 
         // check that recipient has 1 coin
         let recipient_coins = client
@@ -529,7 +534,7 @@ mod tests {
             .arguments([Some(1u64)]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
     }
 
     #[tokio::test]
@@ -544,7 +549,7 @@ mod tests {
         tx.transfer_objects(recipient, [assigned("coin")]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
 
         // check that recipient has 1 coin
         let recipient_coins = client
@@ -563,11 +568,15 @@ mod tests {
         // transfer 1 IOTA
         tx.split_coins(coin, [1_000_000_000u64]);
 
-        let effects = tx.execute(&pk, WaitForTx::Finalized).await.unwrap();
-
-        let expected_status = ExecutionStatus::Success;
-        // The tx failed, so we expect Failure instead of Success
-        assert_ne!(&expected_status, effects.status());
+        match tx.execute(&pk, WaitForTx::Finalized).await.unwrap() {
+            TransactionEffects::V1(v1) => {
+                // The tx failed, so we expect Failure instead of Success
+                assert_ne!(ExecutionStatus::Success, v1.status);
+            }
+            _ => unimplemented!(
+                "a new TransactionEffects enum variant was added and needs to be handled"
+            ),
+        };
     }
 
     #[tokio::test]
@@ -586,7 +595,7 @@ mod tests {
         let client = tx.get_client().clone();
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
 
         // check that there are two coins
         let coins_after = client
@@ -603,7 +612,7 @@ mod tests {
         tx.make_move_vec([1u64]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
     }
 
     #[tokio::test]
@@ -616,7 +625,7 @@ mod tests {
             .transfer_objects(address, [assigned("cap")]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
     }
 
     #[tokio::test]
@@ -652,7 +661,7 @@ mod tests {
                 _ => unimplemented!("a new enum variant was added and needs to be handled"),
             }
         }
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
 
         let client = Client::new_localnet();
         let mut tx = TransactionBuilder::new(address).with_client(&client);
@@ -690,6 +699,6 @@ mod tests {
         tx.gas([coins.last().unwrap().id]);
 
         let effects = tx.execute(&pk, WaitForTx::Finalized).await;
-        check_effects_status_success(effects).await;
+        check_effects_status_success(effects);
     }
 }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -355,7 +355,7 @@ transaction-effects = %d00 transaction-effects-v1   ; V1
 
 transaction-effects-v1 = execution-status                  ; status
                          u64                               ; epoch
-                         gas-cost-summary                  ; gas-used
+                         gas-cost-summary                  ; gas-cost-summary
                          digest                            ; transaction-digest
                          (%d00 / %d01 u32)                 ; gas-object-index
                          (%d00 / %d01 digest)              ; events-digest

--- a/crates/iota-sdk-types/src/checkpoint.rs
+++ b/crates/iota-sdk-types/src/checkpoint.rs
@@ -263,6 +263,7 @@ mod serialization {
     use super::*;
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "CheckpointSummary")]
     struct ReadableCheckpointSummaryRef<'a> {
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: &'a EpochId,
@@ -286,6 +287,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "CheckpointSummary")]
     struct ReadableCheckpointSummary {
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: EpochId,
@@ -309,6 +311,7 @@ mod serialization {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "CheckpointSummary")]
     struct BinaryCheckpointSummaryRef<'a> {
         epoch: &'a EpochId,
         sequence_number: &'a CheckpointSequenceNumber,
@@ -323,6 +326,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "CheckpointSummary")]
     struct BinaryCheckpointSummary {
         epoch: EpochId,
         sequence_number: CheckpointSequenceNumber,
@@ -520,6 +524,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "CheckpointContents")]
     #[cfg_attr(
         feature = "bcs-schema",
         derive(iota_bcs_schema::BcsSchema),
@@ -578,11 +583,13 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "type", rename_all = "snake_case")]
+    #[serde(rename = "CheckpointCommitment")]
     enum ReadableCommitment {
         EcmhLiveObjectSet { digest: Digest },
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "CheckpointCommitment")]
     enum BinaryCommitment {
         EcmhLiveObjectSet { digest: Digest },
     }

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -371,6 +371,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "MultisigAggregatedSignature")]
     struct ReadableMultisigAggregatedSignature {
         signatures: Vec<MultisigMemberSignature>,
         bitmap: BitmapUnit,
@@ -378,6 +379,7 @@ mod serialization {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "MultisigAggregatedSignature")]
     struct ReadableMultisigAggregatedSignatureRef<'a> {
         signatures: &'a [MultisigMemberSignature],
         bitmap: BitmapUnit,

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -670,6 +670,7 @@ mod serialization {
 
     #[derive(serde::Serialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
+    #[serde(rename = "UserSignature")]
     enum ReadableUserSignatureRef<'a> {
         Ed25519 {
             signature: &'a Ed25519Signature,

--- a/crates/iota-sdk-types/src/effects/mod.rs
+++ b/crates/iota-sdk-types/src/effects/mod.rs
@@ -9,8 +9,6 @@ pub use v1::{
     UnchangedSharedObject,
 };
 
-use crate::{Digest, ObjectId, ObjectReference, Version};
-
 /// The output or effects of executing a transaction
 ///
 /// # BCS
@@ -141,40 +139,6 @@ mod serialization {
     }
 }
 
-/// Description of a shared object that was used as input to a transaction
-///
-/// Captures how each shared object was accessed during execution: whether it
-/// was mutated, read-only, deleted after mutable or read-only access, or
-/// cancelled.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum InputSharedObject {
-    Mutate(ObjectReference),
-    ReadOnly(ObjectReference),
-    ReadDeleted(ObjectId, Version),
-    MutateDeleted(ObjectId, Version),
-    Cancelled(ObjectId, Version),
-}
-
-impl InputSharedObject {
-    pub fn id_and_version(&self) -> (ObjectId, Version) {
-        let (object_id, version, ..) = self.object_ref().into_parts();
-        (object_id, version)
-    }
-
-    pub fn object_ref(&self) -> ObjectReference {
-        match self {
-            InputSharedObject::Mutate(oref) | InputSharedObject::ReadOnly(oref) => *oref,
-            InputSharedObject::ReadDeleted(id, version)
-            | InputSharedObject::MutateDeleted(id, version) => {
-                ObjectReference::new(*id, *version, Digest::OBJECT_DELETED)
-            }
-            InputSharedObject::Cancelled(id, version) => {
-                ObjectReference::new(*id, *version, Digest::OBJECT_CANCELLED)
-            }
-        }
-    }
-}
-
 /// Defines what happened to an ObjectId during execution
 ///
 /// # BCS
@@ -203,19 +167,4 @@ pub enum IdOperation {
 
 impl IdOperation {
     crate::def_is!(None, Created, Deleted);
-}
-
-/// Effect on an individual object, keyed by its [`ObjectId`]
-///
-/// Describes the input and output state of a single object that was read or
-/// modified during transaction execution, along with the [`IdOperation`] that
-/// was applied to it.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct ObjectChange {
-    pub id: ObjectId,
-    pub input_version: Option<Version>,
-    pub input_digest: Option<Digest>,
-    pub output_version: Option<Version>,
-    pub output_digest: Option<Digest>,
-    pub id_operation: IdOperation,
 }

--- a/crates/iota-sdk-types/src/effects/mod.rs
+++ b/crates/iota-sdk-types/src/effects/mod.rs
@@ -42,12 +42,6 @@ impl TransactionEffects {
     }
 }
 
-impl Default for TransactionEffects {
-    fn default() -> Self {
-        Self::V1(Box::default())
-    }
-}
-
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod serialization {

--- a/crates/iota-sdk-types/src/effects/mod.rs
+++ b/crates/iota-sdk-types/src/effects/mod.rs
@@ -5,11 +5,11 @@
 mod v1;
 
 pub use v1::{
-    ChangedObject, IdOperation, ObjectIn, ObjectOut, TransactionEffectsV1, UnchangedSharedKind,
+    ChangedObject, ObjectIn, ObjectOut, TransactionEffectsV1, UnchangedSharedKind,
     UnchangedSharedObject,
 };
 
-use crate::execution_status::ExecutionStatus;
+use crate::{Digest, ObjectId, ObjectReference, Version};
 
 /// The output or effects of executing a transaction
 ///
@@ -40,26 +40,11 @@ impl TransactionEffects {
         let Self::V1(effects) = self;
         *effects
     }
+}
 
-    /// Return the status of the transaction.
-    pub fn status(&self) -> &ExecutionStatus {
-        match self {
-            TransactionEffects::V1(e) => e.status(),
-        }
-    }
-
-    /// Return the epoch in which this transaction was executed.
-    pub fn epoch(&self) -> u64 {
-        match self {
-            TransactionEffects::V1(e) => e.epoch(),
-        }
-    }
-
-    /// Return the gas cost summary of the transaction.
-    pub fn gas_summary(&self) -> &crate::gas::GasCostSummary {
-        match self {
-            TransactionEffects::V1(e) => e.gas_summary(),
-        }
+impl Default for TransactionEffects {
+    fn default() -> Self {
+        Self::V1(Box::default())
     }
 }
 
@@ -72,25 +57,29 @@ mod serialization {
 
     #[derive(serde::Serialize)]
     #[serde(tag = "version")]
-    enum ReadableEffectsRef<'a> {
+    #[serde(rename = "TransactionEffects")]
+    enum ReadableTransactionEffectsRef<'a> {
         #[serde(rename = "1")]
         V1(&'a TransactionEffectsV1),
     }
 
     #[derive(serde::Deserialize)]
     #[serde(tag = "version")]
-    pub enum ReadableEffects {
+    #[serde(rename = "TransactionEffects")]
+    pub enum ReadableTransactionEffects {
         #[serde(rename = "1")]
         V1(Box<TransactionEffectsV1>),
     }
 
     #[derive(serde::Serialize)]
-    enum BinaryEffectsRef<'a> {
+    #[serde(rename = "TransactionEffects")]
+    enum BinaryTransactionEffectsRef<'a> {
         V1(&'a TransactionEffectsV1),
     }
 
     #[derive(serde::Deserialize)]
-    pub enum BinaryEffects {
+    #[serde(rename = "TransactionEffects")]
+    pub enum BinaryTransactionEffects {
         V1(Box<TransactionEffectsV1>),
     }
 
@@ -101,12 +90,12 @@ mod serialization {
         {
             if serializer.is_human_readable() {
                 let readable = match self {
-                    TransactionEffects::V1(fx) => ReadableEffectsRef::V1(fx),
+                    TransactionEffects::V1(fx) => ReadableTransactionEffectsRef::V1(fx),
                 };
                 readable.serialize(serializer)
             } else {
                 let binary = match self {
-                    TransactionEffects::V1(fx) => BinaryEffectsRef::V1(fx),
+                    TransactionEffects::V1(fx) => BinaryTransactionEffectsRef::V1(fx),
                 };
                 binary.serialize(serializer)
             }
@@ -119,12 +108,13 @@ mod serialization {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                ReadableEffects::deserialize(deserializer).map(|readable| match readable {
-                    ReadableEffects::V1(fx) => Self::V1(fx),
-                })
+                ReadableTransactionEffects::deserialize(deserializer)
+                    .map(|readable| match readable {
+                        ReadableTransactionEffects::V1(fx) => Self::V1(fx),
+                    })
             } else {
-                BinaryEffects::deserialize(deserializer).map(|binary| match binary {
-                    BinaryEffects::V1(fx) => Self::V1(fx),
+                BinaryTransactionEffects::deserialize(deserializer).map(|binary| match binary {
+                    BinaryTransactionEffects::V1(fx) => Self::V1(fx),
                 })
             }
         }
@@ -155,4 +145,83 @@ mod serialization {
             }
         }
     }
+}
+
+/// Description of a shared object that was used as input to a transaction
+///
+/// Captures how each shared object was accessed during execution: whether it
+/// was mutated, read-only, deleted after mutable or read-only access, or
+/// cancelled.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum InputSharedObject {
+    Mutate(ObjectReference),
+    ReadOnly(ObjectReference),
+    ReadDeleted(ObjectId, Version),
+    MutateDeleted(ObjectId, Version),
+    Cancelled(ObjectId, Version),
+}
+
+impl InputSharedObject {
+    pub fn id_and_version(&self) -> (ObjectId, Version) {
+        let (object_id, version, ..) = self.object_ref().into_parts();
+        (object_id, version)
+    }
+
+    pub fn object_ref(&self) -> ObjectReference {
+        match self {
+            InputSharedObject::Mutate(oref) | InputSharedObject::ReadOnly(oref) => *oref,
+            InputSharedObject::ReadDeleted(id, version)
+            | InputSharedObject::MutateDeleted(id, version) => {
+                ObjectReference::new(*id, *version, Digest::OBJECT_DELETED)
+            }
+            InputSharedObject::Cancelled(id, version) => {
+                ObjectReference::new(*id, *version, Digest::OBJECT_CANCELLED)
+            }
+        }
+    }
+}
+
+/// Defines what happened to an ObjectId during execution
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// id-operation = %d00   ; None
+///              / %d01   ; Created
+///              / %d02   ; Deleted
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+#[non_exhaustive]
+pub enum IdOperation {
+    None,
+    Created,
+    Deleted,
+}
+
+impl IdOperation {
+    crate::def_is!(None, Created, Deleted);
+}
+
+/// Effect on an individual object, keyed by its [`ObjectId`]
+///
+/// Describes the input and output state of a single object that was read or
+/// modified during transaction execution, along with the [`IdOperation`] that
+/// was applied to it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ObjectChange {
+    pub id: ObjectId,
+    pub input_version: Option<Version>,
+    pub input_digest: Option<Digest>,
+    pub output_version: Option<Version>,
+    pub output_digest: Option<Digest>,
+    pub id_operation: IdOperation,
 }

--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -67,24 +67,6 @@ pub struct TransactionEffectsV1 {
     pub auxiliary_data_digest: Option<Digest>,
 }
 
-impl Default for TransactionEffectsV1 {
-    fn default() -> Self {
-        Self {
-            status: ExecutionStatus::Success,
-            epoch: 0,
-            gas_cost_summary: GasCostSummary::default(),
-            transaction_digest: Digest::default(),
-            gas_object_index: None,
-            events_digest: None,
-            dependencies: vec![],
-            lamport_version: Version::default(),
-            changed_objects: vec![],
-            unchanged_shared_objects: vec![],
-            auxiliary_data_digest: None,
-        }
-    }
-}
-
 /// Input/output state of an object that was changed during execution
 ///
 /// # BCS
@@ -98,8 +80,7 @@ impl Default for TransactionEffectsV1 {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(rename = "EffectsObjectChange"),
-    serde(rename_all = "camelCase")
+    serde(rename = "EffectsObjectChange")
 )]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -35,7 +35,7 @@ pub struct TransactionEffectsV1 {
     #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     pub epoch: EpochId,
     /// The gas used by this transaction
-    pub gas_used: GasCostSummary,
+    pub gas_cost_summary: GasCostSummary,
     /// The transaction digest
     pub transaction_digest: Digest,
     /// The updated gas object reference, as an index into the `changed_objects`
@@ -72,7 +72,7 @@ impl Default for TransactionEffectsV1 {
         Self {
             status: ExecutionStatus::Success,
             epoch: 0,
-            gas_used: GasCostSummary::default(),
+            gas_cost_summary: GasCostSummary::default(),
             transaction_digest: Digest::default(),
             gas_object_index: None,
             events_digest: None,
@@ -338,7 +338,8 @@ mod serialization {
         status: &'a ExecutionStatus,
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: &'a EpochId,
-        gas_used: &'a GasCostSummary,
+        #[serde(rename = "gas_used")]
+        gas_cost_summary: &'a GasCostSummary,
         transaction_digest: &'a Digest,
         gas_object_index: &'a Option<u32>,
         events_digest: &'a Option<Digest>,
@@ -357,7 +358,8 @@ mod serialization {
         status: ExecutionStatus,
         #[serde(with = "crate::_serde::ReadableDisplay")]
         epoch: EpochId,
-        gas_used: GasCostSummary,
+        #[serde(rename = "gas_used")]
+        gas_cost_summary: GasCostSummary,
         transaction_digest: Digest,
         gas_object_index: Option<u32>,
         events_digest: Option<Digest>,
@@ -374,7 +376,7 @@ mod serialization {
     struct BinaryTransactionEffectsV1Ref<'a> {
         status: &'a ExecutionStatus,
         epoch: &'a EpochId,
-        gas_used: &'a GasCostSummary,
+        gas_cost_summary: &'a GasCostSummary,
         transaction_digest: &'a Digest,
         gas_object_index: &'a Option<u32>,
         events_digest: &'a Option<Digest>,
@@ -390,7 +392,7 @@ mod serialization {
     struct BinaryTransactionEffectsV1 {
         status: ExecutionStatus,
         epoch: EpochId,
-        gas_used: GasCostSummary,
+        gas_cost_summary: GasCostSummary,
         transaction_digest: Digest,
         gas_object_index: Option<u32>,
         events_digest: Option<Digest>,
@@ -409,7 +411,7 @@ mod serialization {
             let Self {
                 status,
                 epoch,
-                gas_used,
+                gas_cost_summary,
                 transaction_digest,
                 gas_object_index,
                 events_digest,
@@ -423,7 +425,7 @@ mod serialization {
                 let readable = ReadableTransactionEffectsV1Ref {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,
@@ -438,7 +440,7 @@ mod serialization {
                 let binary = BinaryTransactionEffectsV1Ref {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,
@@ -462,7 +464,7 @@ mod serialization {
                 let ReadableTransactionEffectsV1 {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,
@@ -475,7 +477,7 @@ mod serialization {
                 Ok(Self {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,
@@ -489,7 +491,7 @@ mod serialization {
                 let BinaryTransactionEffectsV1 {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,
@@ -502,7 +504,7 @@ mod serialization {
                 Ok(Self {
                     status,
                     epoch,
-                    gas_used,
+                    gas_cost_summary,
                     transaction_digest,
                     gas_object_index,
                     events_digest,

--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    Digest, EpochId, GasCostSummary, ObjectId, Version, execution_status::ExecutionStatus,
-    object::Owner,
+    Digest, EpochId, ExecutionStatus, GasCostSummary, IdOperation, ObjectId, Owner, Version,
 };
 
 /// Version 1 of TransactionEffects
@@ -68,20 +67,21 @@ pub struct TransactionEffectsV1 {
     pub auxiliary_data_digest: Option<Digest>,
 }
 
-impl TransactionEffectsV1 {
-    /// The status of the execution
-    pub fn status(&self) -> &ExecutionStatus {
-        &self.status
-    }
-
-    /// The epoch when this transaction was executed.
-    pub fn epoch(&self) -> EpochId {
-        self.epoch
-    }
-
-    /// The gas used in this transaction.
-    pub fn gas_summary(&self) -> &GasCostSummary {
-        &self.gas_used
+impl Default for TransactionEffectsV1 {
+    fn default() -> Self {
+        Self {
+            status: ExecutionStatus::Success,
+            epoch: 0,
+            gas_used: GasCostSummary::default(),
+            transaction_digest: Digest::default(),
+            gas_object_index: None,
+            events_digest: None,
+            dependencies: vec![],
+            lamport_version: Version::default(),
+            changed_objects: vec![],
+            unchanged_shared_objects: vec![],
+            auxiliary_data_digest: None,
+        }
     }
 }
 
@@ -95,7 +95,12 @@ impl TransactionEffectsV1 {
 /// changed-object = object-id object-in object-out id-operation
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename = "EffectsObjectChange"),
+    serde(rename_all = "camelCase")
+)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct ChangedObject {
@@ -319,36 +324,6 @@ impl ObjectOut {
     }
 }
 
-/// Defines what happened to an ObjectId during execution
-///
-/// # BCS
-///
-/// The BCS serialized form for this type is defined by the following ABNF:
-///
-/// ```text
-/// id-operation = %d00   ; None
-///              / %d01   ; Created
-///              / %d02   ; Deleted
-/// ```
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(rename_all = "lowercase")
-)]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
-#[non_exhaustive]
-pub enum IdOperation {
-    None,
-    Created,
-    Deleted,
-}
-
-impl IdOperation {
-    crate::def_is!(None, Created, Deleted);
-}
-
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod serialization {
@@ -357,6 +332,7 @@ mod serialization {
     use super::*;
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "TransactionEffectsV1")]
     struct ReadableTransactionEffectsV1Ref<'a> {
         #[serde(flatten)]
         status: &'a ExecutionStatus,
@@ -375,6 +351,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "TransactionEffectsV1")]
     struct ReadableTransactionEffectsV1 {
         #[serde(flatten)]
         status: ExecutionStatus,
@@ -393,6 +370,7 @@ mod serialization {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "TransactionEffectsV1")]
     struct BinaryTransactionEffectsV1Ref<'a> {
         status: &'a ExecutionStatus,
         epoch: &'a EpochId,
@@ -408,6 +386,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "TransactionEffectsV1")]
     struct BinaryTransactionEffectsV1 {
         status: ExecutionStatus,
         epoch: EpochId,
@@ -539,6 +518,7 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "UnchangedSharedKind")]
     enum ReadableUnchangedSharedKind {
         ReadOnlyRoot {
             #[serde(with = "crate::_serde::ReadableDisplay")]
@@ -660,6 +640,7 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "state", rename_all = "snake_case")]
+    #[serde(rename = "ObjectIn")]
     enum ReadableObjectIn {
         Missing,
         Data {
@@ -671,6 +652,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "ObjectIn")]
     enum BinaryObjectIn {
         Missing,
         Data {
@@ -754,6 +736,7 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "state", rename_all = "snake_case")]
+    #[serde(rename = "ObjectOut")]
     enum ReadableObjectOut {
         Missing,
         ObjectWrite {
@@ -768,6 +751,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "ObjectOut")]
     enum BinaryObjectOut {
         Missing,
         ObjectWrite {

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -809,6 +809,7 @@ mod serialization {
     // New variants MUST be added at the end.
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "error", rename_all = "snake_case")]
+    #[serde(rename = "ExecutionError")]
     enum ReadableExecutionError {
         InsufficientGas,
         InvalidGasObject,
@@ -1485,6 +1486,7 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "CommandArgumentError")]
     enum ReadableCommandArgumentError {
         TypeMismatch,
         InvalidBcsBytes,
@@ -1677,6 +1679,7 @@ mod serialization {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "PackageUpgradeError")]
     enum ReadablePackageUpgradeError {
         UnableToFetchPackage {
             package_id: ObjectId,

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -147,8 +147,8 @@ pub use crypto::{
 };
 pub use digest::{Digest, DigestParseError, SigningDigest};
 pub use effects::{
-    ChangedObject, IdOperation, InputSharedObject, ObjectChange, ObjectIn, ObjectOut,
-    TransactionEffects, TransactionEffectsV1, UnchangedSharedKind, UnchangedSharedObject,
+    ChangedObject, IdOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsV1,
+    UnchangedSharedKind, UnchangedSharedObject,
 };
 pub use events::{Event, TransactionEvents};
 pub use execution_status::{

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -147,8 +147,8 @@ pub use crypto::{
 };
 pub use digest::{Digest, DigestParseError, SigningDigest};
 pub use effects::{
-    ChangedObject, IdOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsV1,
-    UnchangedSharedKind, UnchangedSharedObject,
+    ChangedObject, IdOperation, InputSharedObject, ObjectChange, ObjectIn, ObjectOut,
+    TransactionEffects, TransactionEffectsV1, UnchangedSharedKind, UnchangedSharedObject,
 };
 pub use events::{Event, TransactionEvents};
 pub use execution_status::{

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -917,6 +917,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "Package")]
     struct ReadablePackage {
         #[serde(
             with = "::serde_with::As::<BTreeMap<::serde_with::Same, crate::_serde::Base64Encoded>>"
@@ -927,6 +928,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "MoveStruct")]
     struct ReadableMoveStruct {
         #[serde(with = "::serde_with::As::<crate::_serde::Base64Encoded>")]
         contents: Vec<u8>,
@@ -1049,6 +1051,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(rename = "Object")]
     struct BinaryObject {
         data: ObjectData,
         owner: Owner,

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -154,6 +154,7 @@ pub struct RandomnessStateUpdate {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub epoch: u64,
     /// Randomness round of the update
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     pub randomness_round: RandomnessRound,
     /// Updated random bytes
     #[cfg_attr(
@@ -163,6 +164,7 @@ pub struct RandomnessStateUpdate {
     pub random_bytes: Vec<u8>,
     /// The initial version of the randomness object that it was shared at.
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     pub randomness_obj_initial_shared_version: Version,
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -154,7 +154,6 @@ pub struct RandomnessStateUpdate {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub epoch: u64,
     /// Randomness round of the update
-    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     pub randomness_round: RandomnessRound,
     /// Updated random bytes
     #[cfg_attr(
@@ -164,7 +163,6 @@ pub struct RandomnessStateUpdate {
     pub random_bytes: Vec<u8>,
     /// The initial version of the randomness object that it was shared at.
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     pub randomness_obj_initial_shared_version: Version,
 }
 

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -488,6 +488,7 @@ mod input_argument {
         ImmutableOrOwned(ObjectReference),
         Shared {
             object_id: ObjectId,
+            #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
             initial_shared_version: Version,
             mutable: bool,
         },

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -155,6 +155,7 @@ mod end_of_epoch {
 
     #[derive(serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "EndOfEpochTransactionKind")]
     enum ReadableEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),
@@ -164,6 +165,7 @@ mod end_of_epoch {
 
     #[derive(serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "EndOfEpochTransactionKind")]
     enum ReadableEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),
@@ -453,6 +455,7 @@ mod input_argument {
 
     #[derive(serde::Deserialize, serde::Serialize)]
     #[serde(rename_all = "snake_case")]
+    #[serde(rename = "Input")]
     enum ReadableInput {
         /// A move value serialized as BCS.
         ///
@@ -675,6 +678,7 @@ mod command {
 
     #[derive(serde::Serialize)]
     #[serde(tag = "command", rename_all = "snake_case")]
+    #[serde(rename = "Command")]
     enum ReadableCommandRef<'a> {
         MoveCall(&'a MoveCall),
         TransferObjects(&'a TransferObjects),
@@ -687,6 +691,7 @@ mod command {
 
     #[derive(serde::Deserialize)]
     #[serde(tag = "command", rename_all = "snake_case")]
+    #[serde(rename = "Command")]
     enum ReadableCommand {
         MoveCall(MoveCall),
         TransferObjects(TransferObjects),
@@ -796,6 +801,7 @@ mod signed_transaction {
     pub(crate) struct SignedTransactionWithIntentMessage;
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "SignedTransaction")]
     struct BinarySignedTransactionWithIntentMessageRef<'a> {
         intent: &'a Intent,
         transaction: &'a Transaction,
@@ -808,6 +814,7 @@ mod signed_transaction {
         derive(iota_bcs_schema::BcsSchema),
         bcs_schema(name = "intent-signed-transaction")
     )]
+    #[serde(rename = "SignedTransaction")]
     struct BinarySignedTransactionWithIntentMessage {
         intent: Intent,
         transaction: Transaction,

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -488,7 +488,6 @@ mod input_argument {
         ImmutableOrOwned(ObjectReference),
         Shared {
             object_id: ObjectId,
-            #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
             initial_shared_version: Version,
             mutable: bool,
         },

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -81,7 +81,6 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
 
     // Sign and execute the transaction (publish the package)
     let effects = builder.execute(&private_key, WaitForTx::Finalized).await?;
-
     println!("Publishing package: {:?}\n", effects.as_v1().status);
 
     // Get package, package metadata and account IDs from the effects
@@ -136,7 +135,6 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
 
     // Sign and execute the transaction (link the authenticator)
     let effects = builder.execute(&private_key, WaitForTx::Finalized).await?;
-
     println!(
         "Linking account to authenticate method: {:?}\n",
         effects.as_v1().status

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -10,7 +10,7 @@ use iota_sdk::{
     transaction_builder::{
         MoveAuthenticatorBuilder, Shared, SharedMut, TransactionBuilder, assigned,
     },
-    types::{Address, Identifier, MovePackageData, ObjectId, ObjectOut},
+    types::{Address, Identifier, MovePackageData, ObjectId, ObjectOut, TransactionEffects},
 };
 use rand::rngs::OsRng;
 
@@ -38,11 +38,17 @@ async fn main() -> Result<()> {
         .finish(&client)
         .await?;
 
-    let effects = builder
+    match builder
         .execute(&move_authenticator, WaitForTx::Finalized)
-        .await?;
-
-    println!("Sending IOTA via abstract account: {:?}", effects.status());
+        .await?
+    {
+        TransactionEffects::V1(v1) => {
+            println!("Sending IOTA via abstract account: {:?}", v1.status);
+        }
+        _ => unimplemented!(
+            "a new TransactionEffects enum variant was added and needs to be handled"
+        ),
+    }
 
     Ok(())
 }
@@ -76,7 +82,7 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
     // Sign and execute the transaction (publish the package)
     let effects = builder.execute(&private_key, WaitForTx::Finalized).await?;
 
-    println!("Publishing package: {:?}\n", effects.status());
+    println!("Publishing package: {:?}\n", effects.as_v1().status);
 
     // Get package, package metadata and account IDs from the effects
     let mut package_id = None::<ObjectId>;
@@ -133,7 +139,7 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
 
     println!(
         "Linking account to authenticate method: {:?}\n",
-        effects.status()
+        effects.as_v1().status
     );
 
     Ok(account_id)

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -10,7 +10,7 @@ use iota_sdk::{
     transaction_builder::{
         MoveAuthenticatorBuilder, Shared, SharedMut, TransactionBuilder, assigned,
     },
-    types::{Address, Identifier, MovePackageData, ObjectId, ObjectOut, TransactionEffects},
+    types::{Address, Identifier, MovePackageData, ObjectId, ObjectOut},
 };
 use rand::rngs::OsRng;
 
@@ -38,17 +38,13 @@ async fn main() -> Result<()> {
         .finish(&client)
         .await?;
 
-    match builder
+    let effects = builder
         .execute(&move_authenticator, WaitForTx::Finalized)
-        .await?
-    {
-        TransactionEffects::V1(v1) => {
-            println!("Sending IOTA via abstract account: {:?}", v1.status);
-        }
-        _ => unimplemented!(
-            "a new TransactionEffects enum variant was added and needs to be handled"
-        ),
-    }
+        .await?;
+    println!(
+        "Sending IOTA via abstract account: {:?}",
+        effects.as_v1().status
+    );
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/gas_station.rs
+++ b/crates/iota-sdk/examples/gas_station.rs
@@ -28,7 +28,6 @@ async fn main() -> Result<()> {
         );
 
     let effects = builder.execute(&keypair, None).await?;
-
     println!("{effects:#?}");
 
     println!("Sponsored transaction was successful!");

--- a/crates/iota-sdk/examples/multisig.rs
+++ b/crates/iota-sdk/examples/multisig.rs
@@ -74,7 +74,6 @@ async fn main() -> Result<()> {
     // 8. Execute
     let user_sig = UserSignature::Multisig(multisig_sig);
     let effects = client.execute_tx(&[user_sig], &tx, None).await?;
-
     println!("Digest: {}", effects.digest());
     println!("Transaction status: {:?}", effects.as_v1().status);
     println!("Effects: {effects:#?}");

--- a/crates/iota-sdk/examples/multisig.rs
+++ b/crates/iota-sdk/examples/multisig.rs
@@ -76,7 +76,7 @@ async fn main() -> Result<()> {
     let effects = client.execute_tx(&[user_sig], &tx, None).await?;
 
     println!("Digest: {}", effects.digest());
-    println!("Transaction status: {:?}", effects.status());
+    println!("Transaction status: {:?}", effects.as_v1().status);
     println!("Effects: {effects:#?}");
 
     Ok(())

--- a/crates/iota-sdk/examples/polling-indexer/Cargo.toml
+++ b/crates/iota-sdk/examples/polling-indexer/Cargo.toml
@@ -13,7 +13,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "fs"] }
-tracing = "0.1"
+tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 # internal dependencies

--- a/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
+++ b/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
@@ -221,7 +221,7 @@ impl Indexer {
                 .iter()
                 .filter(|td| {
                     self.config.filters.include_failed_txs
-                        || matches!(td.effects.status(), ExecutionStatus::Success)
+                        || matches!(td.effects.as_v1().status, ExecutionStatus::Success)
                 })
                 .map(|td| {
                     let digest = td.effects.as_v1().transaction_digest.to_string();
@@ -249,7 +249,7 @@ impl Indexer {
 
                 let sender = sender_str(&tx_data.tx);
                 let kind = tx_kind_str(&tx_data.tx);
-                let success = matches!(tx_data.effects.status(), ExecutionStatus::Success);
+                let success = matches!(tx_data.effects.as_v1().status, ExecutionStatus::Success);
 
                 sqlx::query(
                     r#"
@@ -345,7 +345,7 @@ impl Indexer {
 
             for tx_data in tx_page.data() {
                 if !self.config.filters.include_failed_txs
-                    && !matches!(tx_data.effects.status(), ExecutionStatus::Success)
+                    && !matches!(tx_data.effects.as_v1().status, ExecutionStatus::Success)
                 {
                     continue;
                 }
@@ -353,7 +353,7 @@ impl Indexer {
                 let tx_digest = tx_data.effects.as_v1().transaction_digest.to_string();
                 let sender = sender_str(&tx_data.tx);
                 let kind = tx_kind_str(&tx_data.tx);
-                let success = matches!(tx_data.effects.status(), ExecutionStatus::Success);
+                let success = matches!(tx_data.effects.as_v1().status, ExecutionStatus::Success);
 
                 sqlx::query(
                     r#"

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -83,13 +83,13 @@ async fn main() -> Result<()> {
     let Some(effects) = result.effects else {
         bail!("Dry run failed: no effects");
     };
-    println!("{:?}", effects.status());
+    println!("{:?}", effects.as_v1().status);
 
     // Sign and execute the transaction (publish the package)
     println!("> Publishing package:");
     let sig = private_key.sign_transaction(&tx)?;
     let effects = client.execute_tx(&[sig], &tx, WaitForTx::Finalized).await?;
-    println!("{:?}", effects.status());
+    println!("{:?}", effects.as_v1().status);
 
     // Resolve UpgradeCap and PackageId via the client
     let mut upgrade_cap = None::<ObjectId>;
@@ -154,13 +154,13 @@ async fn main() -> Result<()> {
     let Some(effects) = result.effects else {
         bail!("Dry run failed: no effects");
     };
-    println!("{:?}", effects.status());
+    println!("{:?}", effects.as_v1().status);
 
     // Sign and execute the transaction (upgrade the package)
     println!("> Upgrading package:");
     let sig = private_key.sign_transaction(&tx)?;
     let effects = client.execute_tx(&[sig], &tx, None).await?;
-    println!("{:?}", effects.status());
+    println!("{:?}", effects.as_v1().status);
 
     // Print the new package version (should now be 2)
     for changed_obj in effects.as_v1().changed_objects.iter() {

--- a/crates/iota-sdk/examples/sign_send_iota.rs
+++ b/crates/iota-sdk/examples/sign_send_iota.rs
@@ -6,7 +6,7 @@ use iota_sdk::{
     crypto::{IotaSigner, ed25519::Ed25519PrivateKey},
     graphql_client::{Client, faucet::FaucetClient},
     transaction_builder::TransactionBuilder,
-    types::Address,
+    types::{Address, TransactionEffects},
 };
 
 #[tokio::main]
@@ -39,11 +39,16 @@ async fn main() -> Result<()> {
 
     let signature = private_key.sign_transaction(&tx)?;
 
-    let effects = client.execute_tx(&[signature], &tx, None).await?;
-
-    println!("Digest: {}", effects.digest());
-    println!("Transaction status: {:?}", effects.status());
-    println!("Effects: {effects:#?}");
+    match client.execute_tx(&[signature], &tx, None).await? {
+        TransactionEffects::V1(v1) => {
+            println!("Digest: {}", v1.transaction_digest);
+            println!("Transaction status: {:?}", v1.status);
+            println!("Effects: {:#?}", v1);
+        }
+        _ => unimplemented!(
+            "a new TransactionEffects enum variant was added and needs to be handled"
+        ),
+    }
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/sign_send_iota.rs
+++ b/crates/iota-sdk/examples/sign_send_iota.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
         TransactionEffects::V1(v1) => {
             println!("Digest: {}", v1.transaction_digest);
             println!("Transaction status: {:?}", v1.status);
-            println!("Effects: {:#?}", v1);
+            println!("Effects: {v1:#?}");
         }
         _ => unimplemented!(
             "a new TransactionEffects enum variant was added and needs to be handled"

--- a/crates/iota-sdk/examples/sign_send_iota.rs
+++ b/crates/iota-sdk/examples/sign_send_iota.rs
@@ -6,7 +6,7 @@ use iota_sdk::{
     crypto::{IotaSigner, ed25519::Ed25519PrivateKey},
     graphql_client::{Client, faucet::FaucetClient},
     transaction_builder::TransactionBuilder,
-    types::{Address, TransactionEffects},
+    types::Address,
 };
 
 #[tokio::main]
@@ -37,18 +37,11 @@ async fn main() -> Result<()> {
         eyre::bail!("Dry run failed: {err}");
     }
 
-    let signature = private_key.sign_transaction(&tx)?;
-
-    match client.execute_tx(&[signature], &tx, None).await? {
-        TransactionEffects::V1(v1) => {
-            println!("Digest: {}", v1.transaction_digest);
-            println!("Transaction status: {:?}", v1.status);
-            println!("Effects: {v1:#?}");
-        }
-        _ => unimplemented!(
-            "a new TransactionEffects enum variant was added and needs to be handled"
-        ),
-    }
+    let sig = private_key.sign_transaction(&tx)?;
+    let effects = client.execute_tx(&[sig], &tx, None).await?;
+    println!("Digest: {}", effects.digest());
+    println!("Transaction status: {:?}", effects.as_v1().status);
+    println!("Effects: {effects:#?}");
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/transaction_signer_callback.rs
+++ b/crates/iota-sdk/examples/transaction_signer_callback.rs
@@ -6,7 +6,7 @@ use iota_sdk::{
     crypto::{IotaSigner, SignatureError, ed25519::Ed25519PrivateKey},
     graphql_client::{Client, WaitForTx, faucet::FaucetClient},
     transaction_builder::{TransactionBuilder, TransactionSigner},
-    types::{Address, Transaction, TransactionEffects, UserSignature},
+    types::{Address, Transaction, UserSignature},
 };
 
 struct AsyncSigner(Ed25519PrivateKey);
@@ -41,16 +41,10 @@ async fn main() -> Result<()> {
     builder.send_iota(recipient_address, amount);
 
     let signer = AsyncSigner(private_key);
-    match builder.execute(&signer, WaitForTx::Finalized).await? {
-        TransactionEffects::V1(v1) => {
-            println!("Digest: {}", v1.transaction_digest);
-            println!("Transaction status: {:?}", v1.status);
-            println!("Effects: {v1:#?}");
-        }
-        _ => unimplemented!(
-            "a new TransactionEffects enum variant was added and needs to be handled"
-        ),
-    }
+    let effects = builder.execute(&signer, WaitForTx::Finalized).await?;
+    println!("Digest: {}", effects.digest());
+    println!("Transaction status: {:?}", effects.as_v1().status);
+    println!("Effects: {effects:#?}");
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/transaction_signer_callback.rs
+++ b/crates/iota-sdk/examples/transaction_signer_callback.rs
@@ -6,7 +6,7 @@ use iota_sdk::{
     crypto::{IotaSigner, SignatureError, ed25519::Ed25519PrivateKey},
     graphql_client::{Client, WaitForTx, faucet::FaucetClient},
     transaction_builder::{TransactionBuilder, TransactionSigner},
-    types::{Address, Transaction, UserSignature},
+    types::{Address, Transaction, TransactionEffects, UserSignature},
 };
 
 struct AsyncSigner(Ed25519PrivateKey);
@@ -41,11 +41,16 @@ async fn main() -> Result<()> {
     builder.send_iota(recipient_address, amount);
 
     let signer = AsyncSigner(private_key);
-    let effects = builder.execute(&signer, WaitForTx::Finalized).await?;
-
-    println!("Digest: {}", effects.digest());
-    println!("Transaction status: {:?}", effects.status());
-    println!("Effects: {effects:#?}");
+    match builder.execute(&signer, WaitForTx::Finalized).await? {
+        TransactionEffects::V1(v1) => {
+            println!("Digest: {}", v1.transaction_digest);
+            println!("Transaction status: {:?}", v1.status);
+            println!("Effects: {:#?}", v1);
+        }
+        _ => unimplemented!(
+            "a new TransactionEffects enum variant was added and needs to be handled"
+        ),
+    }
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/transaction_signer_callback.rs
+++ b/crates/iota-sdk/examples/transaction_signer_callback.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         TransactionEffects::V1(v1) => {
             println!("Digest: {}", v1.transaction_digest);
             println!("Transaction status: {:?}", v1.status);
-            println!("Effects: {:#?}", v1);
+            println!("Effects: {v1:#?}");
         }
         _ => unimplemented!(
             "a new TransactionEffects enum variant was added and needs to be handled"


### PR DESCRIPTION
## Summary

Continues the SDK replacement series. Brings `TransactionEffects` in line with the monorepo replacement: drops the inherent accessors so callers match on the enum (mirroring how `Transaction` already works), adds `Default` impls, moves `IdOperation` up to the `effects` module, introduces `InputSharedObject` and `ObjectChange`, and pins public schema names on internal serde helpers across the crate.

- **Drop `status()` / `epoch()` / `gas_summary()` accessors** on `TransactionEffects` (and the matching ones on `TransactionEffectsV1`) in [crates/iota-sdk-types/src/effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs) and [crates/iota-sdk-types/src/effects/v1.rs](crates/iota-sdk-types/src/effects/v1.rs). Callers now match on the variant or go through `as_v1()`.
- **`Default`** impls for `TransactionEffects` and `TransactionEffectsV1` in [crates/iota-sdk-types/src/effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs) and [crates/iota-sdk-types/src/effects/v1.rs](crates/iota-sdk-types/src/effects/v1.rs).
- **Move `IdOperation`** from `effects::v1` up to `effects` in [crates/iota-sdk-types/src/effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs) so it sits next to the other shared effect types; re-exports adjusted in [crates/iota-sdk-types/src/lib.rs](crates/iota-sdk-types/src/lib.rs).
- **`InputSharedObject`** new enum (`Mutate`, `ReadOnly`, `ReadDeleted`, `MutateDeleted`, `Cancelled`) with `object_ref()` and `id_and_version()` helpers, in [crates/iota-sdk-types/src/effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs).
- **`ObjectChange`** new struct keyed by `ObjectId` with input/output `Version`/`Digest` and an `IdOperation`, in [crates/iota-sdk-types/src/effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs).
- **`ChangedObject` schema rename** to `EffectsObjectChange` with `rename_all = "camelCase"` to match the monorepo wire format, in [crates/iota-sdk-types/src/effects/v1.rs](crates/iota-sdk-types/src/effects/v1.rs).
- **Pin public schema names** by adding `#[serde(rename = "PublicName")]` to internal `Readable*` / `Binary*` serde helper structs and enums, so generated schemas keep the public type name. Affected types: `TransactionEffects`, `TransactionEffectsV1`, `UnchangedSharedKind`, `ObjectIn`, `ObjectOut` ([effects/mod.rs](crates/iota-sdk-types/src/effects/mod.rs), [effects/v1.rs](crates/iota-sdk-types/src/effects/v1.rs)); `CheckpointSummary`, `CheckpointContents`, `CheckpointCommitment` ([checkpoint.rs](crates/iota-sdk-types/src/checkpoint.rs)); `MultisigAggregatedSignature` ([crypto/multisig.rs](crates/iota-sdk-types/src/crypto/multisig.rs)); `UserSignature` ([crypto/signature.rs](crates/iota-sdk-types/src/crypto/signature.rs)); `ExecutionError`, `CommandArgumentError`, `PackageUpgradeError` ([execution_status.rs](crates/iota-sdk-types/src/execution_status.rs)); `Package`, `MoveStruct`, `Object` ([object.rs](crates/iota-sdk-types/src/object.rs)); `EndOfEpochTransactionKind`, `Input`, `Command`, `SignedTransaction` ([transaction/serialization.rs](crates/iota-sdk-types/src/transaction/serialization.rs)).
- **Callers updated** to match on `TransactionEffects::V1` (or go through `as_v1()`) instead of using the removed accessors, in [iota-sdk-transaction-builder](crates/iota-sdk-transaction-builder/src/lib.rs), [iota-sdk-transaction-builder/client_methods](crates/iota-sdk-transaction-builder/src/builder/client_methods.rs), and the `abstract_account`, `multisig`, `polling-indexer`, `publish_upgrade`, `sign_send_iota`, and `transaction_signer_callback` examples under [crates/iota-sdk/examples](crates/iota-sdk/examples).
