### PR TITLE
examples(iota-sdk): add coin metadata example

### DIFF
--- a/crates/iota-sdk/examples/coin_metadata.rs
+++ b/crates/iota-sdk/examples/coin_metadata.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Example: query coin metadata.
+//!
+//! Demonstrates how to inspect metadata for a given coin type.
+//! Set COIN_TYPE (full struct tag) via env var.
+
+use std::env::var;
+
+use eyre::Result;
+use iota_sdk::graphql_client::Client;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let coin_type = var("COIN_TYPE").unwrap_or_else(|_| "0x2::iota::IOTA".to_string());
+
+    let metadata = client.coin_metadata(&coin_type).await?;
+
+    match metadata {
+        Some(m) => {
+            println!("Coin type: {coin_type}");
+            println!("Name: {:?}", m.name);
+            println!("Symbol: {:?}", m.symbol);
+            println!("Description: {:?}", m.description);
+            println!("Decimals: {:?}", m.decimals);
+            println!("Icon URL: {:?}", m.icon_url);
+        }
+        None => {
+            println!("No metadata found for coin type: {coin_type}");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds a new coin metadata example for iota-sdk.

## What it demonstrates
- Read coin type from environment (`COIN_TYPE`, default `0x2::iota::IOTA`)
- Query metadata with `coin_metadata`
- Print returned metadata fields

## File added
- `crates/iota-sdk/examples/coin_metadata.rs`

## Validation
- `cargo check -p iota-sdk --example coin_metadata` ✅

Refs #600