### PR TITLE
examples(iota-sdk): add move package example

### DIFF
--- a/crates/iota-sdk/examples/move_package.rs
+++ b/crates/iota-sdk/examples/move_package.rs
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Example: inspect a Move package object.
+//!
+//! Set PACKAGE_ID to a published package object id.
+
+use std::{env::var, str::FromStr};
+
+use eyre::{OptionExt, Result, bail};
+use iota_sdk::{graphql_client::Client, types::ObjectId};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+
+    let package_id = ObjectId::from_str(
+        &var("PACKAGE_ID").map_err(|_| eyre::eyre!("PACKAGE_ID env var is required"))?,
+    )?;
+
+    let obj = client
+        .object(package_id, None)
+        .await?
+        .ok_or_eyre("package object not found")?;
+
+    match obj.object_type() {
+        iota_types::ObjectType::Package => {
+            println!("Package ID: {}", obj.object_id());
+            println!("Version: {}", obj.version());
+            println!("Previous Tx: {}", obj.previous_transaction().to_base58());
+            println!("Storage rebate: {}", obj.storage_rebate());
+        }
+        other => bail!("object is not a package: {other:?}"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds a new Move package example for iota-sdk.

## What it demonstrates
- Read package object id from `PACKAGE_ID`
- Fetch object and validate it is a package
- Print key package metadata (id, version, previous tx, storage rebate)

## File added
- `crates/iota-sdk/examples/move_package.rs`

## Validation
- `cargo check -p iota-sdk --example move_package` ✅

Refs #515