### PR TITLE
chore(tx-builder): replace Argument with SDK version

### DIFF
--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -206,7 +206,8 @@
 //! [PTBArgument] is implemented for any type implementing
 //! [MoveArg](types::MoveArg) as well as:
 //! - [unresolved::Argument]: Arguments returned by various builder functions.
-//!   Distinct from [iota_types::Argument], which cannot be used.
+//!   Distinct from the resolved SDK type `iota_types::transaction::Argument`,
+//!   which cannot be used as a PTB input placeholder.
 //! - [Input](iota_types::Input): A resolved input.
 //! - [ObjectId](iota_types::ObjectId): An object's ID. Can only be used when a
 //!   client is provided. This will be assumed immutable or owned.

--- a/crates/iota-sdk-transaction-builder/src/unresolved.rs
+++ b/crates/iota-sdk-transaction-builder/src/unresolved.rs
@@ -243,15 +243,17 @@ pub enum Argument {
 }
 
 impl Argument {
-    fn resolve(self, input_map: &HashMap<InputId, u16>) -> iota_types::Argument {
+    fn resolve(self, input_map: &HashMap<InputId, u16>) -> iota_types::transaction::Argument {
         match self {
-            Argument::Gas => iota_types::Argument::Gas,
+            Argument::Gas => iota_types::transaction::Argument::Gas,
             Argument::Input(i) => input_map
                 .get(&i)
-                .map(|i| iota_types::Argument::Input(*i))
-                .unwrap_or(iota_types::Argument::Gas),
-            Argument::Result(i) => iota_types::Argument::Result(i),
-            Argument::NestedResult(i1, i2) => iota_types::Argument::NestedResult(i1, i2),
+                .map(|i| iota_types::transaction::Argument::Input(*i))
+                .unwrap_or(iota_types::transaction::Argument::Gas),
+            Argument::Result(i) => iota_types::transaction::Argument::Result(i),
+            Argument::NestedResult(i1, i2) => {
+                iota_types::transaction::Argument::NestedResult(i1, i2)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Aligns Argument references with the SDK transaction type.

## Changes
- Explicitly use `iota_types::transaction::Argument` in unresolved argument resolution
- Clarify docs around unresolved placeholder `Argument` vs resolved SDK `Argument`

## Validation
- `cargo check -p iota-sdk-transaction-builder` ✅

Refs #590