### PR TITLE
fix(types): Remove space from StructTag canonical string

### DIFF
--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -211,7 +211,7 @@ impl StructTag {
         if let Some(first_type) = self.type_params.first() {
             tag.push_str(&format!("<{}", first_type.to_canonical_string(with_prefix)));
             for ty in self.type_params.iter().skip(1) {
-                tag.push_str(&format!(", {}", ty.to_canonical_string(with_prefix)));
+                tag.push_str(&format!(",{}", ty.to_canonical_string(with_prefix)));
             }
             tag.push('>');
         }


### PR DESCRIPTION
## Description

The StructTag canonical string must be precicely the same as the core definition, and the current one has an extra space between type args. This was removed.