### PR TITLE
refactor(iota-sdk-graphql-client): split shared types/scalars for better module uniformity

### DIFF
--- a/crates/iota-sdk-graphql-client/src/query_types/common.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/common.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use serde_json::Value as JsonValue;
+
+use crate::{Address, query_types::Base64};
+
+#[derive(cynic::QueryFragment, Debug, Clone, Copy)]
+#[cynic(schema = "rpc", graphql_type = "Address")]
+pub struct GQLAddress {
+    pub address: Address,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema = "rpc", graphql_type = "MoveObject")]
+pub struct MoveObject {
+    pub bcs: Option<Base64>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveObject")]
+pub struct MoveObjectContents {
+    pub contents: Option<MoveValue>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveValue")]
+pub struct MoveValue {
+    pub type_: MoveType,
+    pub bcs: Base64,
+    pub json: Option<JsonValue>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+#[cynic(schema = "rpc", graphql_type = "MoveType")]
+pub struct MoveType {
+    pub repr: String,
+}
+
+#[derive(Clone, Default, cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "PageInfo")]
+/// Information about pagination in a connection.
+pub struct PageInfo {
+    /// When paginating backwards, are there more items?
+    pub has_previous_page: bool,
+    /// Are there more items when paginating forwards?
+    pub has_next_page: bool,
+    /// When paginating backwards, the cursor to continue.
+    pub start_cursor: Option<String>,
+    /// When paginating forwards, the cursor to continue.
+    pub end_cursor: Option<String>,
+}

--- a/crates/iota-sdk-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/mod.rs
@@ -7,6 +7,7 @@ mod balance;
 mod chain;
 mod checkpoint;
 mod coin;
+mod common;
 mod dry_run;
 mod dynamic_fields;
 mod epoch;
@@ -18,6 +19,7 @@ mod normalized_move;
 mod object;
 mod packages;
 mod protocol_config;
+mod scalars;
 mod service_config;
 mod transaction;
 
@@ -32,7 +34,7 @@ pub use checkpoint::{
     CheckpointsQuery,
 };
 pub use coin::{CoinMetadata, CoinMetadataArgs, CoinMetadataQuery};
-use cynic::impl_scalar;
+pub use common::{GQLAddress, MoveObject, MoveObjectContents, MoveType, MoveValue, PageInfo};
 pub use dry_run::{
     DryRunArgs, DryRunEffect, DryRunMutation, DryRunQuery, DryRunResult, DryRunReturn, GasCoin,
     Input, ObjectRef, ResultArg, TransactionArgument, TransactionMetadata,
@@ -50,7 +52,6 @@ pub use iota_names::{
     NameRegistration, NameRegistrationConnection, ResolveIotaNamesAddressArgs,
     ResolveIotaNamesAddressQuery,
 };
-use iota_types::{Address, ObjectId};
 pub use move_view_call::{MoveViewCallArgs, MoveViewCallQuery, MoveViewResult};
 pub use normalized_move::{
     MoveAbility, MoveEnum, MoveEnumConnection, MoveEnumVariant, MoveField, MoveFunction,
@@ -71,7 +72,7 @@ pub use protocol_config::{
     ProtocolConfigAttr, ProtocolConfigFeatureFlag, ProtocolConfigQuery, ProtocolConfigs,
     ProtocolVersionArgs,
 };
-use serde_json::Value as JsonValue;
+pub use scalars::{Base64, BigInt, DateTime, MoveData};
 pub use service_config::{Feature, ServiceConfig, ServiceConfigQuery};
 pub use transaction::{
     TransactionBlock, TransactionBlockArgs, TransactionBlockCheckpointQuery,
@@ -81,94 +82,5 @@ pub use transaction::{
     TransactionBlocksWithEffectsQuery, TransactionsFilter,
 };
 
-use crate::error;
-
 #[cynic::schema("rpc")]
 pub mod schema {}
-
-// ===========================================================================
-// Scalars
-// ===========================================================================
-
-impl_scalar!(Address, schema::IotaAddress);
-impl_scalar!(ObjectId, schema::IotaAddress);
-impl_scalar!(u64, schema::UInt53);
-impl_scalar!(JsonValue, schema::JSON);
-
-#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
-#[cynic(graphql_type = "Base64")]
-pub struct Base64(pub String);
-
-#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
-#[cynic(graphql_type = "BigInt")]
-pub struct BigInt(pub String);
-
-#[derive(cynic::Scalar, Debug, Clone)]
-#[cynic(graphql_type = "DateTime")]
-pub struct DateTime(pub String);
-
-#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
-#[cynic(graphql_type = "MoveData")]
-pub struct MoveData(pub serde_json::Value);
-
-// ===========================================================================
-// Types used in several queries
-// ===========================================================================
-
-#[derive(cynic::QueryFragment, Debug, Clone, Copy)]
-#[cynic(schema = "rpc", graphql_type = "Address")]
-pub struct GQLAddress {
-    pub address: Address,
-}
-
-#[derive(cynic::QueryFragment, Debug, Clone)]
-#[cynic(schema = "rpc", graphql_type = "MoveObject")]
-pub struct MoveObject {
-    pub bcs: Option<Base64>,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveObject")]
-pub struct MoveObjectContents {
-    pub contents: Option<MoveValue>,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveValue")]
-pub struct MoveValue {
-    pub type_: MoveType,
-    pub bcs: Base64,
-    pub json: Option<JsonValue>,
-}
-
-#[derive(cynic::QueryFragment, Debug, Clone)]
-#[cynic(schema = "rpc", graphql_type = "MoveType")]
-pub struct MoveType {
-    pub repr: String,
-}
-
-// ===========================================================================
-// Utility Types
-// ===========================================================================
-
-#[derive(Clone, Default, cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "PageInfo")]
-/// Information about pagination in a connection.
-pub struct PageInfo {
-    /// When paginating backwards, are there more items?
-    pub has_previous_page: bool,
-    /// Are there more items when paginating forwards?
-    pub has_next_page: bool,
-    /// When paginating backwards, the cursor to continue.
-    pub start_cursor: Option<String>,
-    /// When paginating forwards, the cursor to continue.
-    pub end_cursor: Option<String>,
-}
-
-impl TryFrom<BigInt> for u64 {
-    type Error = error::Error;
-
-    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
-        Ok(value.0.parse::<u64>()?)
-    }
-}

--- a/crates/iota-sdk-graphql-client/src/query_types/scalars.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/scalars.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use cynic::impl_scalar;
+use iota_types::{Address, ObjectId};
+use serde_json::Value as JsonValue;
+
+use crate::error;
+
+use super::schema;
+
+impl_scalar!(Address, schema::IotaAddress);
+impl_scalar!(ObjectId, schema::IotaAddress);
+impl_scalar!(u64, schema::UInt53);
+impl_scalar!(JsonValue, schema::JSON);
+
+#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
+#[cynic(graphql_type = "Base64")]
+pub struct Base64(pub String);
+
+#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
+#[cynic(graphql_type = "BigInt")]
+pub struct BigInt(pub String);
+
+#[derive(cynic::Scalar, Debug, Clone)]
+#[cynic(graphql_type = "DateTime")]
+pub struct DateTime(pub String);
+
+#[derive(cynic::Scalar, Debug, Clone, derive_more::From)]
+#[cynic(graphql_type = "MoveData")]
+pub struct MoveData(pub serde_json::Value);
+
+impl TryFrom<BigInt> for u64 {
+    type Error = error::Error;
+
+    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
+        Ok(value.0.parse::<u64>()?)
+    }
+}


### PR DESCRIPTION
Relates to #512.

This PR improves iota-sdk-graphql-client structure without changing behavior:
- extracted shared query fragments/types from query_types/mod.rs into query_types/common.rs;
- extracted GraphQL scalar declarations and conversion logic into query_types/scalars.rs;
- kept public re-exports in query_types/mod.rs so external API surface remains consistent.

Why:
- reduces mod.rs size and mixes less concerns;
- makes module layout more uniform and easier to extend/review.

Validation:
- code-level refactor only, no behavior changes intended.
- local cargo is not available on this machine, so I could not run local checks here; CI should validate build/tests.