### PR TITLE
feat: update `ConsensusCommitPrologueV1`

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -710,7 +710,7 @@ impl Ord for ActiveJwk {
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
-    schemars(tag = "kind", rename_all = "snake_case")
+    schemars(tag = "kind", rename_all = "camelCase")
 )]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -707,17 +707,12 @@ impl Ord for ActiveJwk {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "schemars",
-    derive(schemars::JsonSchema),
-)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
 pub enum ConsensusDeterminedVersionAssignments {
     /// Cancelled transaction version assignment.
     CancelledTransactions {
         #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
-        #[cfg_attr(feature = "schemars", schemars(rename = "CancelledTransactions"))]
         cancelled_transactions: Vec<CancelledTransaction>,
     },
 }
@@ -748,7 +743,6 @@ impl ConsensusDeterminedVersionAssignments {
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CancelledTransaction {
     pub digest: Digest,
@@ -771,12 +765,10 @@ pub struct CancelledTransaction {
     derive(serde::Serialize, serde::Deserialize),
     serde(rename_all = "camelCase")
 )]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct VersionAssignment {
     pub object_id: ObjectId,
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    #[cfg_attr(feature = "schemars", schemars(with = "crate::_schemars::U64"))]
     pub version: Version,
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -780,6 +780,13 @@ pub struct VersionAssignment {
     pub version: Version,
 }
 
+impl VersionAssignment {
+    /// Creates a [`VersionAssignment`].
+    pub fn new(object_id: ObjectId, version: Version) -> Self {
+        Self { object_id, version }
+    }
+}
+
 /// V1 of the consensus commit prologue system transaction
 ///
 /// # BCS

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -710,7 +710,6 @@ impl Ord for ActiveJwk {
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
-    schemars(tag = "kind", rename_all = "camelCase")
 )]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
@@ -718,7 +717,7 @@ pub enum ConsensusDeterminedVersionAssignments {
     /// Cancelled transaction version assignment.
     CancelledTransactions {
         #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
-        #[cfg_attr(feature = "schemars", schemars(rename = "cancelledTransactions"))]
+        #[cfg_attr(feature = "schemars", schemars(rename = "CancelledTransactions"))]
         cancelled_transactions: Vec<CancelledTransaction>,
     },
 }

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -780,11 +780,7 @@ impl VersionAssignment {
 ///                                consensus-determined-version-assignments
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct ConsensusCommitPrologueV1 {

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -706,7 +706,7 @@ impl Ord for ActiveJwk {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "schemars",
     derive(schemars::JsonSchema),
@@ -742,7 +742,7 @@ impl ConsensusDeterminedVersionAssignments {
 /// ```text
 /// cancelled-transaction = digest (vector version-assignment)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -765,7 +765,7 @@ pub struct CancelledTransaction {
 /// ```text
 /// version-assignment = object-id u64
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),
@@ -790,7 +790,7 @@ pub struct VersionAssignment {
 /// consensus-commit-prologue-v1 = u64 u64 (option u64) u64 digest
 ///                                consensus-determined-version-assignments
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -718,6 +718,7 @@ pub enum ConsensusDeterminedVersionAssignments {
     /// Cancelled transaction version assignment.
     CancelledTransactions {
         #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
+        #[cfg_attr(feature = "schemars", schemars(rename = "cancelledTransactions"))]
         cancelled_transactions: Vec<CancelledTransaction>,
     },
 }

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -738,11 +738,6 @@ impl ConsensusDeterminedVersionAssignments {
 /// cancelled-transaction = digest (vector version-assignment)
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct CancelledTransaction {
     pub digest: Digest,
@@ -754,21 +749,16 @@ pub struct CancelledTransaction {
 ///
 /// # BCS
 ///
-/// The BCS serialized form for this type is defined by the following ABNF:
+/// The BCS serialized form for this type is defined by the
+/// following ABNF:
 ///
 /// ```text
 /// version-assignment = object-id u64
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "camelCase")
-)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct VersionAssignment {
     pub object_id: ObjectId,
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub version: Version,
 }
 

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -338,7 +338,6 @@ mod version_assignments {
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignments {
         CancelledTransactions {
-            #[serde(rename = "cancelledTransactions")]
             cancelled_transactions: Vec<CancelledTransaction>,
         },
     }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -411,17 +411,11 @@ mod version_assignments {
 
     #[derive(serde::Serialize)]
     #[serde(rename = "VersionAssignment")]
-    struct BinaryVersionAssignmentRef<'a> {
-        object_id: &'a ObjectId,
-        version: &'a crate::Version,
-    }
+    struct BinaryVersionAssignmentRef<'a>(&'a ObjectId, &'a crate::Version);
 
     #[derive(serde::Deserialize)]
     #[serde(rename = "VersionAssignment")]
-    struct BinaryVersionAssignment {
-        object_id: ObjectId,
-        version: crate::Version,
-    }
+    struct BinaryVersionAssignment(ObjectId, crate::Version);
 
     impl Serialize for VersionAssignment {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -435,10 +429,7 @@ mod version_assignments {
                 tuple.serialize_element(&self.version)?;
                 tuple.end()
             } else {
-                let binary = BinaryVersionAssignmentRef {
-                    object_id: &self.object_id,
-                    version: &self.version,
-                };
+                let binary = BinaryVersionAssignmentRef(&self.object_id, &self.version);
                 binary.serialize(serializer)
             }
         }
@@ -457,8 +448,8 @@ mod version_assignments {
                 })
             } else {
                 BinaryVersionAssignment::deserialize(deserializer).map(|b| VersionAssignment {
-                    object_id: b.object_id,
-                    version: b.version,
+                    object_id: b.0,
+                    version: b.1,
                 })
             }
         }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -323,6 +323,8 @@ mod version_assignments {
 
     #[derive(serde::Deserialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
+    #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     enum ReadableConsensusDeterminedVersionAssignments {
         CancelledTransactions {
             cancelled_transactions: Vec<CancelledTransaction>,
@@ -421,7 +423,7 @@ mod version_assignments {
                 use serde::ser::SerializeTuple;
                 let mut tuple = serializer.serialize_tuple(2)?;
                 tuple.serialize_element(&self.object_id)?;
-                tuple.serialize_element(&self.version.to_string())?;
+                tuple.serialize_element(&self.version)?;
                 tuple.end()
             } else {
                 let binary = BinaryVersionAssignmentRef {
@@ -439,12 +441,11 @@ mod version_assignments {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                let (object_id, version): (ObjectId, String) =
-                    Deserialize::deserialize(deserializer)?;
-                let version = version
-                    .parse::<crate::Version>()
-                    .map_err(serde::de::Error::custom)?;
-                Ok(VersionAssignment { object_id, version })
+                let (object_id, version): (ObjectId, u64) = Deserialize::deserialize(deserializer)?;
+                Ok(VersionAssignment {
+                    object_id,
+                    version: version.into(),
+                })
             } else {
                 BinaryVersionAssignment::deserialize(deserializer).map(|b| VersionAssignment {
                     object_id: b.object_id,
@@ -579,64 +580,13 @@ mod version_assignments {
     #[cfg(feature = "schemars")]
     impl schemars::JsonSchema for ConsensusDeterminedVersionAssignments {
         fn schema_name() -> String {
-            "ConsensusDeterminedVersionAssignments".to_owned()
+            ReadableConsensusDeterminedVersionAssignments::schema_name()
         }
 
         fn json_schema(
             generator: &mut schemars::r#gen::SchemaGenerator,
         ) -> schemars::schema::Schema {
-            use schemars::schema::{
-                ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec,
-                SubschemaValidation,
-            };
-
-            // Externally tagged enum with oneOf
-            SchemaObject {
-                metadata: Some(Box::new(schemars::schema::Metadata {
-                    description: Some(
-                        "Uses an enum to allow for future expansion of the \
-                         ConsensusDeterminedVersionAssignments."
-                            .to_owned(),
-                    ),
-                    ..Default::default()
-                })),
-                subschemas: Some(Box::new(SubschemaValidation {
-                    one_of: Some(vec![
-                        // CancelledTransactions variant
-                        SchemaObject {
-                            instance_type: Some(InstanceType::Object.into()),
-                            object: Some(Box::new(ObjectValidation {
-                                required: ["CancelledTransactions".to_owned()]
-                                    .into_iter()
-                                    .collect(),
-                                properties: [(
-                                    "CancelledTransactions".to_owned(),
-                                    SchemaObject {
-                                        instance_type: Some(InstanceType::Array.into()),
-                                        array: Some(Box::new(ArrayValidation {
-                                            items: Some(SingleOrVec::Single(Box::new(
-                                                generator.subschema_for::<CancelledTransaction>(),
-                                            ))),
-                                            ..Default::default()
-                                        })),
-                                        ..Default::default()
-                                    }
-                                    .into(),
-                                )]
-                                .into_iter()
-                                .collect(),
-                                additional_properties: Some(Box::new(Schema::Bool(false))),
-                                ..Default::default()
-                            })),
-                            ..Default::default()
-                        }
-                        .into(),
-                    ]),
-                    ..Default::default()
-                })),
-                ..Default::default()
-            }
-            .into()
+            ReadableConsensusDeterminedVersionAssignments::json_schema(generator)
         }
     }
 }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -331,17 +331,13 @@ mod version_assignments {
     #[derive(serde::Serialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions {
-            cancelled_transactions: &'a Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
     #[derive(serde::Deserialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignments {
-        CancelledTransactions {
-            cancelled_transactions: Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(Vec<CancelledTransaction>),
     }
 
     impl Serialize for ConsensusDeterminedVersionAssignments {
@@ -362,9 +358,9 @@ mod version_assignments {
                 let binary = match self {
                     Self::CancelledTransactions {
                         cancelled_transactions,
-                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions {
+                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
                         cancelled_transactions,
-                    },
+                    ),
                 };
                 binary.serialize(serializer)
             }
@@ -389,9 +385,9 @@ mod version_assignments {
             } else {
                 BinaryConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
                     |binary| match binary {
-                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions {
+                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions(
                             cancelled_transactions,
-                        } => Self::CancelledTransactions {
+                        ) => Self::CancelledTransactions {
                             cancelled_transactions,
                         },
                     },
@@ -498,17 +494,11 @@ mod version_assignments {
 
     #[derive(serde::Serialize)]
     #[serde(rename = "CancelledTransaction")]
-    struct BinaryCancelledTransactionRef<'a> {
-        digest: &'a crate::Digest,
-        version_assignments: &'a Vec<VersionAssignment>,
-    }
+    struct BinaryCancelledTransactionRef<'a>(&'a crate::Digest, &'a Vec<VersionAssignment>);
 
     #[derive(serde::Deserialize)]
     #[serde(rename = "CancelledTransaction")]
-    struct BinaryCancelledTransaction {
-        digest: crate::Digest,
-        version_assignments: Vec<VersionAssignment>,
-    }
+    struct BinaryCancelledTransaction(crate::Digest, Vec<VersionAssignment>);
 
     impl Serialize for CancelledTransaction {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -522,10 +512,7 @@ mod version_assignments {
                 tuple.serialize_element(&self.version_assignments)?;
                 tuple.end()
             } else {
-                let binary = BinaryCancelledTransactionRef {
-                    digest: &self.digest,
-                    version_assignments: &self.version_assignments,
-                };
+                let binary = BinaryCancelledTransactionRef(&self.digest, &self.version_assignments);
                 binary.serialize(serializer)
             }
         }
@@ -546,8 +533,8 @@ mod version_assignments {
             } else {
                 BinaryCancelledTransaction::deserialize(deserializer).map(|b| {
                     CancelledTransaction {
-                        digest: b.digest,
-                        version_assignments: b.version_assignments,
+                        digest: b.0,
+                        version_assignments: b.1,
                     }
                 })
             }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -338,6 +338,7 @@ mod version_assignments {
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignments {
         CancelledTransactions {
+            #[serde(rename = "cancelledTransactions")]
             cancelled_transactions: Vec<CancelledTransaction>,
         },
     }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -335,6 +335,7 @@ mod version_assignments {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignments {
         CancelledTransactions {
             cancelled_transactions: Vec<CancelledTransaction>,

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -314,7 +314,7 @@ mod version_assignments {
     };
 
     #[derive(serde::Serialize)]
-    #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions {
             cancelled_transactions: &'a Vec<CancelledTransaction>,
@@ -322,7 +322,6 @@ mod version_assignments {
     }
 
     #[derive(serde::Deserialize)]
-    #[serde(tag = "kind", rename_all = "snake_case")]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     enum ReadableConsensusDeterminedVersionAssignments {
@@ -332,6 +331,7 @@ mod version_assignments {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions {
             cancelled_transactions: &'a Vec<CancelledTransaction>,
@@ -402,7 +402,21 @@ mod version_assignments {
         }
     }
 
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for ConsensusDeterminedVersionAssignments {
+        fn schema_name() -> String {
+            ReadableConsensusDeterminedVersionAssignments::schema_name()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            ReadableConsensusDeterminedVersionAssignments::json_schema(generator)
+        }
+    }
+
     #[derive(serde::Serialize)]
+    #[serde(rename = "VersionAssignment")]
     struct BinaryVersionAssignmentRef<'a> {
         object_id: &'a ObjectId,
         version: &'a crate::Version,
@@ -456,7 +470,36 @@ mod version_assignments {
         }
     }
 
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for VersionAssignment {
+        fn schema_name() -> String {
+            "VersionAssignment".to_owned()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
+
+            SchemaObject {
+                instance_type: Some(InstanceType::Array.into()),
+                array: Some(Box::new(ArrayValidation {
+                    items: Some(schemars::schema::SingleOrVec::Vec(vec![
+                        generator.subschema_for::<ObjectId>(),
+                        generator.subschema_for::<crate::Version>(),
+                    ])),
+                    max_items: Some(2),
+                    min_items: Some(2),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
     #[derive(serde::Serialize)]
+    #[serde(rename = "CancelledTransaction")]
     struct BinaryCancelledTransactionRef<'a> {
         digest: &'a crate::Digest,
         version_assignments: &'a Vec<VersionAssignment>,
@@ -514,34 +557,6 @@ mod version_assignments {
     }
 
     #[cfg(feature = "schemars")]
-    impl schemars::JsonSchema for VersionAssignment {
-        fn schema_name() -> String {
-            "VersionAssignment".to_owned()
-        }
-
-        fn json_schema(
-            generator: &mut schemars::r#gen::SchemaGenerator,
-        ) -> schemars::schema::Schema {
-            use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
-
-            SchemaObject {
-                instance_type: Some(InstanceType::Array.into()),
-                array: Some(Box::new(ArrayValidation {
-                    items: Some(schemars::schema::SingleOrVec::Vec(vec![
-                        generator.subschema_for::<ObjectId>(),
-                        generator.subschema_for::<crate::Version>(),
-                    ])),
-                    max_items: Some(2),
-                    min_items: Some(2),
-                    ..Default::default()
-                })),
-                ..Default::default()
-            }
-            .into()
-        }
-    }
-
-    #[cfg(feature = "schemars")]
     impl schemars::JsonSchema for CancelledTransaction {
         fn schema_name() -> String {
             "CancelledTransaction".to_owned()
@@ -576,19 +591,6 @@ mod version_assignments {
                 ..Default::default()
             }
             .into()
-        }
-    }
-
-    #[cfg(feature = "schemars")]
-    impl schemars::JsonSchema for ConsensusDeterminedVersionAssignments {
-        fn schema_name() -> String {
-            ReadableConsensusDeterminedVersionAssignments::schema_name()
-        }
-
-        fn json_schema(
-            generator: &mut schemars::r#gen::SchemaGenerator,
-        ) -> schemars::schema::Schema {
-            ReadableConsensusDeterminedVersionAssignments::json_schema(generator)
         }
     }
 }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -316,18 +316,16 @@ mod version_assignments {
     #[derive(serde::Serialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions {
-            cancelled_transactions: &'a Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
+    /// Uses an enum to allow for future expansion of the
+    /// ConsensusDeterminedVersionAssignments.
     #[derive(serde::Deserialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
     enum ReadableConsensusDeterminedVersionAssignments {
-        CancelledTransactions {
-            cancelled_transactions: Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(Vec<CancelledTransaction>),
     }
 
     #[derive(serde::Serialize)]
@@ -355,9 +353,9 @@ mod version_assignments {
                 let readable = match self {
                     Self::CancelledTransactions {
                         cancelled_transactions,
-                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions {
+                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
                         cancelled_transactions,
-                    },
+                    ),
                 };
                 readable.serialize(serializer)
             } else {
@@ -381,9 +379,9 @@ mod version_assignments {
             if deserializer.is_human_readable() {
                 ReadableConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
                     |readable| match readable {
-                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions {
+                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions(
                             cancelled_transactions,
-                        } => Self::CancelledTransactions {
+                        ) => Self::CancelledTransactions {
                             cancelled_transactions,
                         },
                     },

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -309,7 +309,9 @@ mod end_of_epoch {
 
 mod version_assignments {
     use super::*;
-    use crate::transaction::{CancelledTransaction, ConsensusDeterminedVersionAssignments};
+    use crate::transaction::{
+        CancelledTransaction, ConsensusDeterminedVersionAssignments, VersionAssignment,
+    };
 
     #[derive(serde::Serialize)]
     #[serde(tag = "kind", rename_all = "snake_case")]
@@ -395,6 +397,139 @@ mod version_assignments {
                     },
                 )
             }
+        }
+    }
+
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for VersionAssignment {
+        fn schema_name() -> String {
+            "VersionAssignment".to_owned()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
+
+            // Tuple: [ObjectId, Version]
+            SchemaObject {
+                instance_type: Some(InstanceType::Array.into()),
+                array: Some(Box::new(ArrayValidation {
+                    items: Some(schemars::schema::SingleOrVec::Vec(vec![
+                        generator.subschema_for::<ObjectId>(),
+                        generator.subschema_for::<crate::Version>(),
+                    ])),
+                    max_items: Some(2),
+                    min_items: Some(2),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for CancelledTransaction {
+        fn schema_name() -> String {
+            "CancelledTransaction".to_owned()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
+
+            // Tuple: [Digest, Vec<VersionAssignment>]
+            SchemaObject {
+                instance_type: Some(InstanceType::Array.into()),
+                array: Some(Box::new(ArrayValidation {
+                    items: Some(schemars::schema::SingleOrVec::Vec(vec![
+                        generator.subschema_for::<crate::Digest>(),
+                        SchemaObject {
+                            instance_type: Some(InstanceType::Array.into()),
+                            array: Some(Box::new(ArrayValidation {
+                                items: Some(schemars::schema::SingleOrVec::Single(Box::new(
+                                    generator.subschema_for::<VersionAssignment>(),
+                                ))),
+                                ..Default::default()
+                            })),
+                            ..Default::default()
+                        }
+                        .into(),
+                    ])),
+                    max_items: Some(2),
+                    min_items: Some(2),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+            .into()
+        }
+    }
+
+    #[cfg(feature = "schemars")]
+    impl schemars::JsonSchema for ConsensusDeterminedVersionAssignments {
+        fn schema_name() -> String {
+            "ConsensusDeterminedVersionAssignments".to_owned()
+        }
+
+        fn json_schema(
+            generator: &mut schemars::r#gen::SchemaGenerator,
+        ) -> schemars::schema::Schema {
+            use schemars::schema::{
+                ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject,
+                SingleOrVec, SubschemaValidation,
+            };
+
+            // Externally tagged enum with oneOf
+            SchemaObject {
+                metadata: Some(Box::new(schemars::schema::Metadata {
+                    description: Some(
+                        "Uses an enum to allow for future expansion of the \
+                         ConsensusDeterminedVersionAssignments."
+                            .to_owned(),
+                    ),
+                    ..Default::default()
+                })),
+                subschemas: Some(Box::new(SubschemaValidation {
+                    one_of: Some(vec![
+                        // CancelledTransactions variant
+                        SchemaObject {
+                            instance_type: Some(InstanceType::Object.into()),
+                            object: Some(Box::new(ObjectValidation {
+                                required: ["CancelledTransactions".to_owned()]
+                                    .into_iter()
+                                    .collect(),
+                                properties: [(
+                                    "CancelledTransactions".to_owned(),
+                                    SchemaObject {
+                                        instance_type: Some(InstanceType::Array.into()),
+                                        array: Some(Box::new(ArrayValidation {
+                                            items: Some(SingleOrVec::Single(Box::new(
+                                                generator
+                                                    .subschema_for::<CancelledTransaction>(),
+                                            ))),
+                                            ..Default::default()
+                                        })),
+                                        ..Default::default()
+                                    }
+                                    .into(),
+                                )]
+                                .into_iter()
+                                .collect(),
+                                additional_properties: Some(Box::new(Schema::Bool(false))),
+                                ..Default::default()
+                            })),
+                            ..Default::default()
+                        }
+                        .into(),
+                    ]),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }
+            .into()
         }
     }
 }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -400,6 +400,116 @@ mod version_assignments {
         }
     }
 
+    #[derive(serde::Serialize)]
+    struct BinaryVersionAssignmentRef<'a> {
+        object_id: &'a ObjectId,
+        version: &'a crate::Version,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct BinaryVersionAssignment {
+        object_id: ObjectId,
+        version: crate::Version,
+    }
+
+    impl Serialize for VersionAssignment {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if serializer.is_human_readable() {
+                use serde::ser::SerializeTuple;
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(&self.object_id)?;
+                tuple.serialize_element(&self.version.to_string())?;
+                tuple.end()
+            } else {
+                let binary = BinaryVersionAssignmentRef {
+                    object_id: &self.object_id,
+                    version: &self.version,
+                };
+                binary.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for VersionAssignment {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            if deserializer.is_human_readable() {
+                let (object_id, version): (ObjectId, String) =
+                    Deserialize::deserialize(deserializer)?;
+                let version = version
+                    .parse::<crate::Version>()
+                    .map_err(serde::de::Error::custom)?;
+                Ok(VersionAssignment { object_id, version })
+            } else {
+                BinaryVersionAssignment::deserialize(deserializer).map(|b| VersionAssignment {
+                    object_id: b.object_id,
+                    version: b.version,
+                })
+            }
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    struct BinaryCancelledTransactionRef<'a> {
+        digest: &'a crate::Digest,
+        version_assignments: &'a Vec<VersionAssignment>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct BinaryCancelledTransaction {
+        digest: crate::Digest,
+        version_assignments: Vec<VersionAssignment>,
+    }
+
+    impl Serialize for CancelledTransaction {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if serializer.is_human_readable() {
+                use serde::ser::SerializeTuple;
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(&self.digest)?;
+                tuple.serialize_element(&self.version_assignments)?;
+                tuple.end()
+            } else {
+                let binary = BinaryCancelledTransactionRef {
+                    digest: &self.digest,
+                    version_assignments: &self.version_assignments,
+                };
+                binary.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for CancelledTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            if deserializer.is_human_readable() {
+                let (digest, version_assignments): (crate::Digest, Vec<VersionAssignment>) =
+                    Deserialize::deserialize(deserializer)?;
+                Ok(CancelledTransaction {
+                    digest,
+                    version_assignments,
+                })
+            } else {
+                BinaryCancelledTransaction::deserialize(deserializer).map(|b| {
+                    CancelledTransaction {
+                        digest: b.digest,
+                        version_assignments: b.version_assignments,
+                    }
+                })
+            }
+        }
+    }
+
     #[cfg(feature = "schemars")]
     impl schemars::JsonSchema for VersionAssignment {
         fn schema_name() -> String {
@@ -411,7 +521,6 @@ mod version_assignments {
         ) -> schemars::schema::Schema {
             use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
 
-            // Tuple: [ObjectId, Version]
             SchemaObject {
                 instance_type: Some(InstanceType::Array.into()),
                 array: Some(Box::new(ArrayValidation {
@@ -440,7 +549,6 @@ mod version_assignments {
         ) -> schemars::schema::Schema {
             use schemars::schema::{ArrayValidation, InstanceType, SchemaObject};
 
-            // Tuple: [Digest, Vec<VersionAssignment>]
             SchemaObject {
                 instance_type: Some(InstanceType::Array.into()),
                 array: Some(Box::new(ArrayValidation {
@@ -478,8 +586,8 @@ mod version_assignments {
             generator: &mut schemars::r#gen::SchemaGenerator,
         ) -> schemars::schema::Schema {
             use schemars::schema::{
-                ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject,
-                SingleOrVec, SubschemaValidation,
+                ArrayValidation, InstanceType, ObjectValidation, Schema, SchemaObject, SingleOrVec,
+                SubschemaValidation,
             };
 
             // Externally tagged enum with oneOf
@@ -507,8 +615,7 @@ mod version_assignments {
                                         instance_type: Some(InstanceType::Array.into()),
                                         array: Some(Box::new(ArrayValidation {
                                             items: Some(SingleOrVec::Single(Box::new(
-                                                generator
-                                                    .subschema_for::<CancelledTransaction>(),
+                                                generator.subschema_for::<CancelledTransaction>(),
                                             ))),
                                             ..Default::default()
                                         })),

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -409,6 +409,7 @@ mod version_assignments {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "VersionAssignment")]
     struct BinaryVersionAssignment {
         object_id: ObjectId,
         version: crate::Version,
@@ -462,6 +463,7 @@ mod version_assignments {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "CancelledTransaction")]
     struct BinaryCancelledTransaction {
         digest: crate::Digest,
         version_assignments: Vec<VersionAssignment>,


### PR DESCRIPTION
Key changes:
* Added a custom JsonSchema impl that keeps backwards compatibility with `openrpc.json` spec in the monorepo
* Replaced the `serde` derives with a custom impl that is distinguishes between JSON and BCS 