### PR TITLE
feat: add IOTA Names example in Rust and all bindings

### DIFF
--- a/bindings/go/examples/iota_names/main.go
+++ b/bindings/go/examples/iota_names/main.go
@@ -1,0 +1,388 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This example demonstrates the major IOTA Names operations:
+//
+// 1. Name lookup: resolve an IOTA name to an address
+// 2. Reverse lookup: resolve an address back to its IOTA name
+// 3. Name record details: query expiration timestamp
+// 4. Check existence: verify if a name is registered
+//
+// All operations use dev_inspect (dry run) so no gas or signing is needed.
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+// IOTA Names package address and shared object ID on devnet
+const iotaNamesPackageHex = "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba"
+const iotaNamesObjectHex = "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342"
+
+func mustAddr(hex string) *iota_sdk.Address {
+	addr, err := iota_sdk.AddressFromHex(hex)
+	if err != nil {
+		log.Fatalf("Failed to parse address: %v", err)
+	}
+	return addr
+}
+
+func mustObjId(hex string) *iota_sdk.ObjectId {
+	id, err := iota_sdk.ObjectIdFromHex(hex)
+	if err != nil {
+		log.Fatalf("Failed to parse object ID: %v", err)
+	}
+	return id
+}
+
+func ident(s string) *iota_sdk.Identifier {
+	id, err := iota_sdk.NewIdentifier(s)
+	if err != nil {
+		log.Fatalf("Failed to create identifier: %v", err)
+	}
+	return id
+}
+
+func registryTypeTag(pkg *iota_sdk.Address) *iota_sdk.TypeTag {
+	return iota_sdk.TypeTagNewStruct(
+		iota_sdk.NewStructTag(pkg, ident("registry"), ident("Registry"), []*iota_sdk.TypeTag{}),
+	)
+}
+
+func nameRecordTypeTag(pkg *iota_sdk.Address) *iota_sdk.TypeTag {
+	return iota_sdk.TypeTagNewStruct(
+		iota_sdk.NewStructTag(pkg, ident("name_record"), ident("NameRecord"), []*iota_sdk.TypeTag{}),
+	)
+}
+
+// Example 1: Look up an IOTA name to get the associated address.
+func lookupName(client *iota_sdk.GraphQlClient, name string) *iota_sdk.Address {
+	pkg := mustAddr(iotaNamesPackageHex)
+	obj := mustObjId(iotaNamesObjectHex)
+	std := iota_sdk.AddressStd()
+	sender := iota_sdk.AddressZero()
+
+	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
+
+	// 1. Get the registry
+	builder.MoveCall(
+		pkg, ident("iota_names"), ident("registry"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentSharedMut(obj)},
+		[]*iota_sdk.TypeTag{registryTypeTag(pkg)},
+		[]string{"iota_names"},
+	)
+
+	// 2. Create name from string
+	builder.MoveCall(
+		pkg, ident("name"), ident("new"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentString(name)},
+		nil,
+		[]string{"name"},
+	)
+
+	// 3. Lookup name record
+	builder.MoveCall(
+		pkg, ident("registry"), ident("lookup"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("iota_names"), iota_sdk.PtbArgumentAssigned("name")},
+		nil,
+		[]string{"name_record_opt"},
+	)
+
+	// 4. Borrow name record from option
+	builder.MoveCall(
+		std, ident("option"), ident("borrow"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record_opt")},
+		[]*iota_sdk.TypeTag{nameRecordTypeTag(pkg)},
+		[]string{"name_record"},
+	)
+
+	// 5. Get target address from name record
+	builder.MoveCall(
+		pkg, ident("name_record"), ident("target_address"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record")},
+		nil,
+		[]string{"target_address_opt"},
+	)
+
+	// 6. Borrow address from option
+	builder.MoveCall(
+		std, ident("option"), ident("borrow"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("target_address_opt")},
+		[]*iota_sdk.TypeTag{iota_sdk.TypeTagNewAddress()},
+		[]string{"target_address"},
+	)
+
+	res, err := builder.DryRun(true)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to dry run: %v", err)
+	}
+
+	if res.Error != nil {
+		// Name not found or expired
+		return nil
+	}
+
+	if len(res.Results) > 0 {
+		lastEffect := res.Results[len(res.Results)-1]
+		if len(lastEffect.ReturnValues) > 0 {
+			rv := lastEffect.ReturnValues[0]
+			if rv.TypeTag.IsAddress() && len(rv.Bcs) == 32 {
+				addr, err := iota_sdk.AddressFromBytes(rv.Bcs)
+				if err != nil {
+					return nil
+				}
+				return addr
+			}
+		}
+	}
+	return nil
+}
+
+// Example 2: Reverse lookup - resolve an address to its IOTA name.
+func reverseLookup(client *iota_sdk.GraphQlClient, address *iota_sdk.Address) {
+	pkg := mustAddr(iotaNamesPackageHex)
+	obj := mustObjId(iotaNamesObjectHex)
+	sender := iota_sdk.AddressZero()
+
+	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
+
+	// Get the shared registry
+	builder.MoveCall(
+		pkg, ident("iota_names"), ident("registry"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentSharedMut(obj)},
+		[]*iota_sdk.TypeTag{registryTypeTag(pkg)},
+		[]string{"registry"},
+	)
+
+	// Reverse lookup: address -> Option<Name>
+	builder.MoveCall(
+		pkg, ident("registry"), ident("reverse_lookup"),
+		[]*iota_sdk.PtbArgument{
+			iota_sdk.PtbArgumentAssigned("registry"),
+			iota_sdk.PtbArgumentAddress(address),
+		},
+		nil,
+		[]string{"name_opt"},
+	)
+
+	res, err := builder.DryRun(true)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		fmt.Printf("  Reverse lookup failed: %v\n", err)
+		return
+	}
+
+	if res.Error != nil {
+		fmt.Printf("  Reverse lookup failed: %v\n", *res.Error)
+		return
+	}
+
+	if len(res.Results) > 0 {
+		lastEffect := res.Results[len(res.Results)-1]
+		if len(lastEffect.ReturnValues) > 0 {
+			rv := lastEffect.ReturnValues[0]
+			if len(rv.Bcs) > 0 && rv.Bcs[0] == 1 {
+				fmt.Printf("  Address %s has a reverse name record\n", address.ToHex())
+			} else {
+				fmt.Printf("  Address %s does not have a reverse name record\n", address.ToHex())
+			}
+		}
+	}
+}
+
+// Example 3: Query name record details (target address, expiration).
+func nameRecordDetails(client *iota_sdk.GraphQlClient, name string) {
+	pkg := mustAddr(iotaNamesPackageHex)
+	obj := mustObjId(iotaNamesObjectHex)
+	std := iota_sdk.AddressStd()
+	sender := iota_sdk.AddressZero()
+
+	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
+
+	// Get the shared registry
+	builder.MoveCall(
+		pkg, ident("iota_names"), ident("registry"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentSharedMut(obj)},
+		[]*iota_sdk.TypeTag{registryTypeTag(pkg)},
+		[]string{"registry"},
+	)
+
+	// Create the name object
+	builder.MoveCall(
+		pkg, ident("name"), ident("new"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentString(name)},
+		nil,
+		[]string{"name"},
+	)
+
+	// Look up the name record
+	builder.MoveCall(
+		pkg, ident("registry"), ident("lookup"),
+		[]*iota_sdk.PtbArgument{
+			iota_sdk.PtbArgumentAssigned("registry"),
+			iota_sdk.PtbArgumentAssigned("name"),
+		},
+		nil,
+		[]string{"name_record_opt"},
+	)
+
+	// Borrow the name record from Option
+	builder.MoveCall(
+		std, ident("option"), ident("borrow"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record_opt")},
+		[]*iota_sdk.TypeTag{nameRecordTypeTag(pkg)},
+		[]string{"name_record"},
+	)
+
+	// Get the target address
+	builder.MoveCall(
+		pkg, ident("name_record"), ident("target_address"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record")},
+		nil,
+		[]string{"target_address_opt"},
+	)
+
+	// Get the expiration timestamp
+	builder.MoveCall(
+		pkg, ident("name_record"), ident("expiration_timestamp_ms"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record")},
+		nil,
+		[]string{"expiration"},
+	)
+
+	res, err := builder.DryRun(true)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to dry run: %v", err)
+	}
+
+	if res.Error != nil {
+		log.Fatalf("Name record query failed: %v", *res.Error)
+	}
+
+	fmt.Printf("  Name record details for '%s':\n", name)
+
+	// Extract expiration (u64)
+	for _, effect := range res.Results {
+		for _, rv := range effect.ReturnValues {
+			if rv.TypeTag.IsU64() && len(rv.Bcs) == 8 {
+				timestamp := binary.LittleEndian.Uint64(rv.Bcs)
+				fmt.Printf("  Expiration timestamp (ms): %d\n", timestamp)
+			}
+		}
+	}
+
+	// Extract target address from Option<address> (5th move call, index 4)
+	if len(res.Results) > 4 {
+		effect := res.Results[4]
+		if len(effect.ReturnValues) > 0 {
+			rv := effect.ReturnValues[0]
+			if len(rv.Bcs) == 33 && rv.Bcs[0] == 1 {
+				addr, err := iota_sdk.AddressFromBytes(rv.Bcs[1:33])
+				if err == nil {
+					fmt.Printf("  Target address: %s\n", addr.ToHex())
+				}
+			} else {
+				fmt.Println("  Target address: not set")
+			}
+		}
+	}
+}
+
+// Example 4: Check if a name exists in the registry.
+func checkNameExists(client *iota_sdk.GraphQlClient, name string) bool {
+	pkg := mustAddr(iotaNamesPackageHex)
+	obj := mustObjId(iotaNamesObjectHex)
+	sender := iota_sdk.AddressZero()
+
+	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
+
+	// Get the shared registry
+	builder.MoveCall(
+		pkg, ident("iota_names"), ident("registry"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentSharedMut(obj)},
+		[]*iota_sdk.TypeTag{registryTypeTag(pkg)},
+		[]string{"registry"},
+	)
+
+	// Create the name object
+	builder.MoveCall(
+		pkg, ident("name"), ident("new"),
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentString(name)},
+		nil,
+		[]string{"name"},
+	)
+
+	// Check if the name has a record
+	builder.MoveCall(
+		pkg, ident("registry"), ident("has_record"),
+		[]*iota_sdk.PtbArgument{
+			iota_sdk.PtbArgumentAssigned("registry"),
+			iota_sdk.PtbArgumentAssigned("name"),
+		},
+		nil,
+		[]string{"exists"},
+	)
+
+	res, err := builder.DryRun(true)
+	if err.(*iota_sdk.SdkFfiError) != nil {
+		log.Fatalf("Failed to dry run: %v", err)
+	}
+
+	if res.Error != nil {
+		log.Fatalf("has_record check failed: %v", *res.Error)
+	}
+
+	if len(res.Results) > 0 {
+		lastEffect := res.Results[len(res.Results)-1]
+		if len(lastEffect.ReturnValues) > 0 {
+			rv := lastEffect.ReturnValues[0]
+			if rv.TypeTag.IsBool() && len(rv.Bcs) > 0 {
+				return rv.Bcs[0] == 1
+			}
+		}
+	}
+	return false
+}
+
+func main() {
+	client := iota_sdk.GraphQlClientNewDevnet()
+	name := "name.iota"
+
+	fmt.Println("=== IOTA Names Examples ===")
+	fmt.Println()
+
+	// Example 1: Name lookup (name -> address)
+	fmt.Printf("1. Looking up '%s'...\n", name)
+	address := lookupName(client, name)
+	if address != nil {
+		fmt.Printf("   Resolved to: %s\n\n", address.ToHex())
+
+		// Example 2: Reverse lookup (address -> name)
+		fmt.Printf("2. Reverse lookup for %s...\n", address.ToHex())
+		reverseLookup(client, address)
+		fmt.Println()
+	} else {
+		fmt.Println("   Name not found or expired")
+		fmt.Println()
+		fmt.Println("2. Skipping reverse lookup (no address to look up)")
+		fmt.Println()
+	}
+
+	// Example 3: Name record details
+	fmt.Printf("3. Querying name record details for '%s'...\n", name)
+	nameRecordDetails(client, name)
+	fmt.Println()
+
+	// Example 4: Check if names exist
+	fmt.Println("4. Checking name existence...")
+	exists := checkNameExists(client, name)
+	fmt.Printf("   '%s' exists: %v\n", name, exists)
+
+	fakeName := "this-name-probably-does-not-exist-12345.iota"
+	fakeExists := checkNameExists(client, fakeName)
+	fmt.Printf("   '%s' exists: %v\n", fakeName, fakeExists)
+}

--- a/bindings/kotlin/examples/IotaNames.kt
+++ b/bindings/kotlin/examples/IotaNames.kt
@@ -1,0 +1,338 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This example demonstrates the major IOTA Names operations:
+//
+// 1. Name lookup: resolve an IOTA name to an address
+// 2. Reverse lookup: resolve an address back to its IOTA name
+// 3. Name record details: query expiration timestamp
+// 4. Check existence: verify if a name is registered
+//
+// All operations use dev_inspect (dry run) so no gas or signing is needed.
+
+import iota_sdk.*
+import kotlin.collections.emptyList
+import kotlinx.coroutines.runBlocking
+
+// IOTA Names package address and shared object ID on devnet
+const val IOTA_NAMES_PACKAGE = "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba"
+const val IOTA_NAMES_OBJECT = "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342"
+
+fun registryTypeTag(pkg: Address): TypeTag {
+    return TypeTag.newStruct(
+        StructTag(pkg, Identifier("registry"), Identifier("Registry"))
+    )
+}
+
+fun nameRecordTypeTag(pkg: Address): TypeTag {
+    return TypeTag.newStruct(
+        StructTag(pkg, Identifier("name_record"), Identifier("NameRecord"))
+    )
+}
+
+/** Example 1: Look up an IOTA name to get the associated address. */
+suspend fun lookupName(client: GraphQlClient, name: String): Address? {
+    val pkg = Address.fromHex(IOTA_NAMES_PACKAGE)
+    val obj = ObjectId.fromHex(IOTA_NAMES_OBJECT)
+    val std = Address.std()
+    val sender = Address.zero()
+
+    val builder = TransactionBuilder(sender).withClient(client)
+
+    // 1. Get the registry
+    builder.moveCall(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        listOf(PtbArgument.sharedMut(obj)),
+        listOf(registryTypeTag(pkg)),
+        listOf("iota_names"),
+    )
+
+    // 2. Create name from string
+    builder.moveCall(
+        pkg, Identifier("name"), Identifier("new"),
+        listOf(PtbArgument.string(name)),
+        emptyList(),
+        listOf("name"),
+    )
+
+    // 3. Lookup name record
+    builder.moveCall(
+        pkg, Identifier("registry"), Identifier("lookup"),
+        listOf(PtbArgument.assigned("iota_names"), PtbArgument.assigned("name")),
+        emptyList(),
+        listOf("name_record_opt"),
+    )
+
+    // 4. Borrow name record from option
+    builder.moveCall(
+        std, Identifier("option"), Identifier("borrow"),
+        listOf(PtbArgument.assigned("name_record_opt")),
+        listOf(nameRecordTypeTag(pkg)),
+        listOf("name_record"),
+    )
+
+    // 5. Get target address from name record
+    builder.moveCall(
+        pkg, Identifier("name_record"), Identifier("target_address"),
+        listOf(PtbArgument.assigned("name_record")),
+        emptyList(),
+        listOf("target_address_opt"),
+    )
+
+    // 6. Borrow address from option
+    builder.moveCall(
+        std, Identifier("option"), Identifier("borrow"),
+        listOf(PtbArgument.assigned("target_address_opt")),
+        listOf(TypeTag.newAddress()),
+        listOf("target_address"),
+    )
+
+    val res = builder.dryRun(true)
+
+    if (res.error != null) {
+        if (res.error!!.contains("None") || res.error!!.contains("option")) {
+            return null
+        }
+        throw Exception("Name lookup failed: ${res.error}")
+    }
+
+    if (res.results.isNotEmpty()) {
+        val lastEffect = res.results.last()
+        if (lastEffect.returnValues.isNotEmpty()) {
+            val rv = lastEffect.returnValues.first()
+            if (rv.typeTag.isAddress() && rv.bcs.size == 32) {
+                return Address.fromBytes(rv.bcs)
+            }
+        }
+    }
+    return null
+}
+
+/** Example 2: Reverse lookup - resolve an address to its IOTA name. */
+suspend fun reverseLookup(client: GraphQlClient, address: Address) {
+    val pkg = Address.fromHex(IOTA_NAMES_PACKAGE)
+    val obj = ObjectId.fromHex(IOTA_NAMES_OBJECT)
+    val sender = Address.zero()
+
+    val builder = TransactionBuilder(sender).withClient(client)
+
+    // Get the shared registry
+    builder.moveCall(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        listOf(PtbArgument.sharedMut(obj)),
+        listOf(registryTypeTag(pkg)),
+        listOf("registry"),
+    )
+
+    // Reverse lookup: address -> Option<Name>
+    builder.moveCall(
+        pkg, Identifier("registry"), Identifier("reverse_lookup"),
+        listOf(PtbArgument.assigned("registry"), PtbArgument.address(address)),
+        emptyList(),
+        listOf("name_opt"),
+    )
+
+    val res = builder.dryRun(true)
+
+    if (res.error != null) {
+        println("  Reverse lookup failed: ${res.error}")
+        return
+    }
+
+    if (res.results.isNotEmpty()) {
+        val lastEffect = res.results.last()
+        if (lastEffect.returnValues.isNotEmpty()) {
+            val rv = lastEffect.returnValues.first()
+            if (rv.bcs.isNotEmpty() && rv.bcs[0] == 1.toByte()) {
+                println("  Address ${address.toHex()} has a reverse name record")
+            } else {
+                println("  Address ${address.toHex()} does not have a reverse name record")
+            }
+        }
+    }
+}
+
+/** Example 3: Query name record details (target address, expiration). */
+suspend fun nameRecordDetails(client: GraphQlClient, name: String) {
+    val pkg = Address.fromHex(IOTA_NAMES_PACKAGE)
+    val obj = ObjectId.fromHex(IOTA_NAMES_OBJECT)
+    val std = Address.std()
+    val sender = Address.zero()
+
+    val builder = TransactionBuilder(sender).withClient(client)
+
+    // Get the shared registry
+    builder.moveCall(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        listOf(PtbArgument.sharedMut(obj)),
+        listOf(registryTypeTag(pkg)),
+        listOf("registry"),
+    )
+
+    // Create the name object
+    builder.moveCall(
+        pkg, Identifier("name"), Identifier("new"),
+        listOf(PtbArgument.string(name)),
+        emptyList(),
+        listOf("name"),
+    )
+
+    // Look up the name record
+    builder.moveCall(
+        pkg, Identifier("registry"), Identifier("lookup"),
+        listOf(PtbArgument.assigned("registry"), PtbArgument.assigned("name")),
+        emptyList(),
+        listOf("name_record_opt"),
+    )
+
+    // Borrow the name record from Option
+    builder.moveCall(
+        std, Identifier("option"), Identifier("borrow"),
+        listOf(PtbArgument.assigned("name_record_opt")),
+        listOf(nameRecordTypeTag(pkg)),
+        listOf("name_record"),
+    )
+
+    // Get the target address
+    builder.moveCall(
+        pkg, Identifier("name_record"), Identifier("target_address"),
+        listOf(PtbArgument.assigned("name_record")),
+        emptyList(),
+        listOf("target_address_opt"),
+    )
+
+    // Get the expiration timestamp
+    builder.moveCall(
+        pkg, Identifier("name_record"), Identifier("expiration_timestamp_ms"),
+        listOf(PtbArgument.assigned("name_record")),
+        emptyList(),
+        listOf("expiration"),
+    )
+
+    val res = builder.dryRun(true)
+
+    if (res.error != null) {
+        throw Exception("Name record query failed: ${res.error}")
+    }
+
+    println("  Name record details for '$name':")
+
+    // Extract expiration (u64) from results
+    for (effect in res.results) {
+        for (rv in effect.returnValues) {
+            if (rv.typeTag.isU64() && rv.bcs.size == 8) {
+                var timestamp: Long = 0
+                for (i in 0 until 8) {
+                    timestamp = timestamp or ((rv.bcs[i].toLong() and 0xFF) shl (i * 8))
+                }
+                println("  Expiration timestamp (ms): $timestamp")
+            }
+        }
+    }
+
+    // Extract target address from Option<address> result (5th move call, index 4)
+    if (res.results.size > 4) {
+        val effect = res.results[4]
+        if (effect.returnValues.isNotEmpty()) {
+            val rv = effect.returnValues.first()
+            if (rv.bcs.size == 33 && rv.bcs[0] == 1.toByte()) {
+                val addrBytes = rv.bcs.sliceArray(1..32)
+                val addr = Address.fromBytes(addrBytes)
+                println("  Target address: ${addr.toHex()}")
+            } else {
+                println("  Target address: not set")
+            }
+        }
+    }
+}
+
+/** Example 4: Check if a name exists in the registry. */
+suspend fun checkNameExists(client: GraphQlClient, name: String): Boolean {
+    val pkg = Address.fromHex(IOTA_NAMES_PACKAGE)
+    val obj = ObjectId.fromHex(IOTA_NAMES_OBJECT)
+    val sender = Address.zero()
+
+    val builder = TransactionBuilder(sender).withClient(client)
+
+    // Get the shared registry
+    builder.moveCall(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        listOf(PtbArgument.sharedMut(obj)),
+        listOf(registryTypeTag(pkg)),
+        listOf("registry"),
+    )
+
+    // Create the name object
+    builder.moveCall(
+        pkg, Identifier("name"), Identifier("new"),
+        listOf(PtbArgument.string(name)),
+        emptyList(),
+        listOf("name"),
+    )
+
+    // Check if the name has a record
+    builder.moveCall(
+        pkg, Identifier("registry"), Identifier("has_record"),
+        listOf(PtbArgument.assigned("registry"), PtbArgument.assigned("name")),
+        emptyList(),
+        listOf("exists"),
+    )
+
+    val res = builder.dryRun(true)
+
+    if (res.error != null) {
+        throw Exception("has_record check failed: ${res.error}")
+    }
+
+    if (res.results.isNotEmpty()) {
+        val lastEffect = res.results.last()
+        if (lastEffect.returnValues.isNotEmpty()) {
+            val rv = lastEffect.returnValues.first()
+            if (rv.typeTag.isBool()) {
+                return rv.bcs.firstOrNull() == 1.toByte()
+            }
+        }
+    }
+    return false
+}
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newDevnet()
+        val name = "name.iota"
+
+        println("=== IOTA Names Examples ===\n")
+
+        // Example 1: Name lookup (name -> address)
+        println("1. Looking up '$name'...")
+        val address = lookupName(client, name)
+        if (address != null) {
+            println("   Resolved to: ${address.toHex()}\n")
+
+            // Example 2: Reverse lookup (address -> name)
+            println("2. Reverse lookup for ${address.toHex()}...")
+            reverseLookup(client, address)
+            println()
+        } else {
+            println("   Name not found or expired\n")
+            println("2. Skipping reverse lookup (no address to look up)\n")
+        }
+
+        // Example 3: Name record details
+        println("3. Querying name record details for '$name'...")
+        nameRecordDetails(client, name)
+        println()
+
+        // Example 4: Check if names exist
+        println("4. Checking name existence...")
+        val exists = checkNameExists(client, name)
+        println("   '$name' exists: $exists")
+
+        val fakeName = "this-name-probably-does-not-exist-12345.iota"
+        val fakeExists = checkNameExists(client, fakeName)
+        println("   '$fakeName' exists: $fakeExists")
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/iota_names.py
+++ b/bindings/python/examples/iota_names.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+# This example demonstrates the major IOTA Names operations:
+#
+# 1. Name lookup: resolve an IOTA name to an address
+# 2. Reverse lookup: resolve an address back to its IOTA name
+# 3. Name record details: query expiration timestamp
+# 4. Check existence: verify if a name is registered
+#
+# All operations use dev_inspect (dry run) so no gas or signing is needed.
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+# IOTA Names package address and shared object ID on devnet
+IOTA_NAMES_PACKAGE = "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba"
+IOTA_NAMES_OBJECT = "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342"
+
+
+def registry_type_tag(pkg):
+    return TypeTag.new_struct(
+        StructTag(pkg, Identifier("registry"), Identifier("Registry")))
+
+
+def name_record_type_tag(pkg):
+    return TypeTag.new_struct(
+        StructTag(pkg, Identifier("name_record"), Identifier("NameRecord")))
+
+
+async def lookup_name(client, name):
+    """Example 1: Look up an IOTA name to get the associated address."""
+    pkg = Address.from_hex(IOTA_NAMES_PACKAGE)
+    obj = ObjectId.from_hex(IOTA_NAMES_OBJECT)
+    std = Address.std()
+    sender = Address.zero()
+
+    builder = TransactionBuilder(sender).with_client(client)
+
+    # 1. Get the registry
+    builder.move_call(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        [PtbArgument.shared_mut(obj)],
+        [registry_type_tag(pkg)],
+        ["iota_names"],
+    )
+
+    # 2. Create name from string
+    builder.move_call(
+        pkg, Identifier("name"), Identifier("new"),
+        [PtbArgument.string(name)],
+        names=["name"],
+    )
+
+    # 3. Lookup name record
+    builder.move_call(
+        pkg, Identifier("registry"), Identifier("lookup"),
+        [PtbArgument.assigned("iota_names"), PtbArgument.assigned("name")],
+        names=["name_record_opt"],
+    )
+
+    # 4. Borrow name record from option
+    builder.move_call(
+        std, Identifier("option"), Identifier("borrow"),
+        [PtbArgument.assigned("name_record_opt")],
+        [name_record_type_tag(pkg)],
+        ["name_record"],
+    )
+
+    # 5. Get target address from name record
+    builder.move_call(
+        pkg, Identifier("name_record"), Identifier("target_address"),
+        [PtbArgument.assigned("name_record")],
+        names=["target_address_opt"],
+    )
+
+    # 6. Borrow address from option
+    builder.move_call(
+        std, Identifier("option"), Identifier("borrow"),
+        [PtbArgument.assigned("target_address_opt")],
+        [TypeTag.new_address()],
+        ["target_address"],
+    )
+
+    res = await builder.dry_run(True)
+
+    if res.error is not None:
+        if "None" in res.error or "option" in res.error:
+            return None
+        raise Exception(f"Name lookup failed: {res.error}")
+
+    if len(res.results) > 0:
+        last_effect = res.results[-1]
+        if len(last_effect.return_values) > 0:
+            rv = last_effect.return_values[0]
+            if rv.type_tag.is_address() and len(rv.bcs) == 32:
+                return Address.from_bytes(rv.bcs)
+    return None
+
+
+async def reverse_lookup(client, address):
+    """Example 2: Reverse lookup - resolve an address to its IOTA name."""
+    pkg = Address.from_hex(IOTA_NAMES_PACKAGE)
+    obj = ObjectId.from_hex(IOTA_NAMES_OBJECT)
+    sender = Address.zero()
+
+    builder = TransactionBuilder(sender).with_client(client)
+
+    # Get the shared registry
+    builder.move_call(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        [PtbArgument.shared_mut(obj)],
+        [registry_type_tag(pkg)],
+        ["registry"],
+    )
+
+    # Reverse lookup: address -> Option<Name>
+    builder.move_call(
+        pkg, Identifier("registry"), Identifier("reverse_lookup"),
+        [PtbArgument.assigned("registry"), PtbArgument.address(address)],
+        names=["name_opt"],
+    )
+
+    res = await builder.dry_run(True)
+
+    if res.error is not None:
+        print(f"  Reverse lookup failed: {res.error}")
+        return
+
+    if len(res.results) > 0:
+        rv = res.results[-1].return_values[0] if len(
+            res.results[-1].return_values) > 0 else None
+        if rv and len(rv.bcs) > 0 and rv.bcs[0] == 1:
+            print(f"  Address {address.to_hex()} has a reverse name record")
+        else:
+            print(
+                f"  Address {address.to_hex()} does not have a reverse name record"
+            )
+
+
+async def name_record_details(client, name):
+    """Example 3: Query name record details (target address, expiration)."""
+    pkg = Address.from_hex(IOTA_NAMES_PACKAGE)
+    obj = ObjectId.from_hex(IOTA_NAMES_OBJECT)
+    std = Address.std()
+    sender = Address.zero()
+
+    builder = TransactionBuilder(sender).with_client(client)
+
+    # Get the shared registry
+    builder.move_call(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        [PtbArgument.shared_mut(obj)],
+        [registry_type_tag(pkg)],
+        ["registry"],
+    )
+
+    # Create the name object
+    builder.move_call(
+        pkg, Identifier("name"), Identifier("new"),
+        [PtbArgument.string(name)],
+        names=["name"],
+    )
+
+    # Look up the name record
+    builder.move_call(
+        pkg, Identifier("registry"), Identifier("lookup"),
+        [PtbArgument.assigned("registry"), PtbArgument.assigned("name")],
+        names=["name_record_opt"],
+    )
+
+    # Borrow the name record from Option
+    builder.move_call(
+        std, Identifier("option"), Identifier("borrow"),
+        [PtbArgument.assigned("name_record_opt")],
+        [name_record_type_tag(pkg)],
+        ["name_record"],
+    )
+
+    # Get the target address
+    builder.move_call(
+        pkg, Identifier("name_record"), Identifier("target_address"),
+        [PtbArgument.assigned("name_record")],
+        names=["target_address_opt"],
+    )
+
+    # Get the expiration timestamp
+    builder.move_call(
+        pkg, Identifier("name_record"), Identifier("expiration_timestamp_ms"),
+        [PtbArgument.assigned("name_record")],
+        names=["expiration"],
+    )
+
+    res = await builder.dry_run(True)
+
+    if res.error is not None:
+        raise Exception(f"Name record query failed: {res.error}")
+
+    print(f"  Name record details for '{name}':")
+
+    # Extract expiration (u64) from results
+    for effect in res.results:
+        for rv in effect.return_values:
+            if rv.type_tag.is_u64() and len(rv.bcs) == 8:
+                timestamp = int.from_bytes(rv.bcs, byteorder='little')
+                print(f"  Expiration timestamp (ms): {timestamp}")
+
+    # Extract target address from the Option<address> result (5th move call)
+    if len(res.results) > 4:
+        rv = res.results[4].return_values[0] if len(
+            res.results[4].return_values) > 0 else None
+        if rv and len(rv.bcs) == 33 and rv.bcs[0] == 1:
+            addr = Address.from_bytes(rv.bcs[1:33])
+            print(f"  Target address: {addr.to_hex()}")
+        else:
+            print("  Target address: not set")
+
+
+async def check_name_exists(client, name):
+    """Example 4: Check if a name exists in the registry."""
+    pkg = Address.from_hex(IOTA_NAMES_PACKAGE)
+    obj = ObjectId.from_hex(IOTA_NAMES_OBJECT)
+    sender = Address.zero()
+
+    builder = TransactionBuilder(sender).with_client(client)
+
+    # Get the shared registry
+    builder.move_call(
+        pkg, Identifier("iota_names"), Identifier("registry"),
+        [PtbArgument.shared_mut(obj)],
+        [registry_type_tag(pkg)],
+        ["registry"],
+    )
+
+    # Create the name object
+    builder.move_call(
+        pkg, Identifier("name"), Identifier("new"),
+        [PtbArgument.string(name)],
+        names=["name"],
+    )
+
+    # Check if the name has a record
+    builder.move_call(
+        pkg, Identifier("registry"), Identifier("has_record"),
+        [PtbArgument.assigned("registry"), PtbArgument.assigned("name")],
+        names=["exists"],
+    )
+
+    res = await builder.dry_run(True)
+
+    if res.error is not None:
+        raise Exception(f"has_record check failed: {res.error}")
+
+    if len(res.results) > 0:
+        rv = res.results[-1].return_values[0] if len(
+            res.results[-1].return_values) > 0 else None
+        if rv and rv.type_tag.is_bool():
+            return rv.bcs[0] == 1
+    return False
+
+
+async def main():
+    client = GraphQlClient.new_devnet()
+    name = "name.iota"
+
+    print("=== IOTA Names Examples ===\n")
+
+    # Example 1: Name lookup (name -> address)
+    print(f"1. Looking up '{name}'...")
+    address = await lookup_name(client, name)
+    if address:
+        print(f"   Resolved to: {address.to_hex()}\n")
+
+        # Example 2: Reverse lookup (address -> name)
+        print(f"2. Reverse lookup for {address.to_hex()}...")
+        await reverse_lookup(client, address)
+        print()
+    else:
+        print("   Name not found or expired\n")
+        print("2. Skipping reverse lookup (no address to look up)\n")
+
+    # Example 3: Name record details
+    print(f"3. Querying name record details for '{name}'...")
+    await name_record_details(client, name)
+    print()
+
+    # Example 4: Check if names exist
+    print("4. Checking name existence...")
+    exists = await check_name_exists(client, name)
+    print(f"   '{name}' exists: {exists}")
+
+    fake_name = "this-name-probably-does-not-exist-12345.iota"
+    exists = await check_name_exists(client, fake_name)
+    print(f"   '{fake_name}' exists: {exists}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bindings/swift/examples/iota_names.swift
+++ b/bindings/swift/examples/iota_names.swift
@@ -1,0 +1,368 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+// This example demonstrates the major IOTA Names operations:
+//
+// 1. Name lookup: resolve an IOTA name to an address
+// 2. Reverse lookup: resolve an address back to its IOTA name
+// 3. Name record details: query expiration timestamp
+// 4. Check existence: verify if a name is registered
+//
+// All operations use dev_inspect (dry run) so no gas or signing is needed.
+
+import Foundation
+import IotaSDK
+
+// IOTA Names package address and shared object ID on devnet
+let iotaNamesPackageHex =
+  "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba"
+let iotaNamesObjectHex =
+  "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342"
+
+func registryTypeTag(_ pkg: Address) -> TypeTag {
+  return TypeTag.newStruct(
+    structTag: StructTag(
+      address: pkg,
+      module: Identifier(identifier: "registry"),
+      name: Identifier(identifier: "Registry")
+    ))
+}
+
+func nameRecordTypeTag(_ pkg: Address) -> TypeTag {
+  return TypeTag.newStruct(
+    structTag: StructTag(
+      address: pkg,
+      module: Identifier(identifier: "name_record"),
+      name: Identifier(identifier: "NameRecord")
+    ))
+}
+
+/// Example 1: Look up an IOTA name to get the associated address.
+func lookupName(client: GraphQlClient, name: String) async throws -> Address? {
+  let pkg = try Address.fromHex(hex: iotaNamesPackageHex)
+  let obj = try ObjectId.fromHex(hex: iotaNamesObjectHex)
+  let std = Address.std()
+  let sender = Address.zero()
+
+  let builder = TransactionBuilder(sender: sender).withClient(client: client)
+
+  // 1. Get the registry
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "iota_names"),
+    function: Identifier(identifier: "registry"),
+    arguments: [PtbArgument.sharedMut(id: obj)],
+    typeArgs: [registryTypeTag(pkg)],
+    names: ["iota_names"]
+  )
+
+  // 2. Create name from string
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name"),
+    function: Identifier(identifier: "new"),
+    arguments: [PtbArgument.string(string: name)],
+    names: ["name"]
+  )
+
+  // 3. Lookup name record
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "registry"),
+    function: Identifier(identifier: "lookup"),
+    arguments: [PtbArgument.assigned(name: "iota_names"), PtbArgument.assigned(name: "name")],
+    names: ["name_record_opt"]
+  )
+
+  // 4. Borrow name record from option
+  _ = try builder.moveCall(
+    package: std,
+    module: Identifier(identifier: "option"),
+    function: Identifier(identifier: "borrow"),
+    arguments: [PtbArgument.assigned(name: "name_record_opt")],
+    typeArgs: [nameRecordTypeTag(pkg)],
+    names: ["name_record"]
+  )
+
+  // 5. Get target address from name record
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name_record"),
+    function: Identifier(identifier: "target_address"),
+    arguments: [PtbArgument.assigned(name: "name_record")],
+    names: ["target_address_opt"]
+  )
+
+  // 6. Borrow address from option
+  _ = try builder.moveCall(
+    package: std,
+    module: Identifier(identifier: "option"),
+    function: Identifier(identifier: "borrow"),
+    arguments: [PtbArgument.assigned(name: "target_address_opt")],
+    typeArgs: [TypeTag.newAddress()],
+    names: ["target_address"]
+  )
+
+  let res = try await builder.dryRun(skipChecks: true)
+
+  if let error = res.error {
+    if error.contains("None") || error.contains("option") {
+      return nil
+    }
+    throw NSError(
+      domain: "IotaNames", code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "Name lookup failed: \(error)"])
+  }
+
+  if let lastEffect = res.results.last,
+    let rv = lastEffect.returnValues.first,
+    rv.typeTag.isAddress() && rv.bcs.count == 32
+  {
+    return try Address.fromBytes(bytes: rv.bcs)
+  }
+  return nil
+}
+
+/// Example 2: Reverse lookup - resolve an address to its IOTA name.
+func reverseLookup(client: GraphQlClient, address: Address) async throws {
+  let pkg = try Address.fromHex(hex: iotaNamesPackageHex)
+  let obj = try ObjectId.fromHex(hex: iotaNamesObjectHex)
+  let sender = Address.zero()
+
+  let builder = TransactionBuilder(sender: sender).withClient(client: client)
+
+  // Get the shared registry
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "iota_names"),
+    function: Identifier(identifier: "registry"),
+    arguments: [PtbArgument.sharedMut(id: obj)],
+    typeArgs: [registryTypeTag(pkg)],
+    names: ["registry"]
+  )
+
+  // Reverse lookup: address -> Option<Name>
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "registry"),
+    function: Identifier(identifier: "reverse_lookup"),
+    arguments: [
+      PtbArgument.assigned(name: "registry"),
+      PtbArgument.address(address: address),
+    ],
+    names: ["name_opt"]
+  )
+
+  let res = try await builder.dryRun(skipChecks: true)
+
+  if let error = res.error {
+    print("  Reverse lookup failed: \(error)")
+    return
+  }
+
+  if let lastEffect = res.results.last,
+    let rv = lastEffect.returnValues.first
+  {
+    if !rv.bcs.isEmpty && rv.bcs[0] == 1 {
+      print("  Address \(address.toHex()) has a reverse name record")
+    } else {
+      print("  Address \(address.toHex()) does not have a reverse name record")
+    }
+  }
+}
+
+/// Example 3: Query name record details (target address, expiration).
+func nameRecordDetails(client: GraphQlClient, name: String) async throws {
+  let pkg = try Address.fromHex(hex: iotaNamesPackageHex)
+  let obj = try ObjectId.fromHex(hex: iotaNamesObjectHex)
+  let std = Address.std()
+  let sender = Address.zero()
+
+  let builder = TransactionBuilder(sender: sender).withClient(client: client)
+
+  // Get the shared registry
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "iota_names"),
+    function: Identifier(identifier: "registry"),
+    arguments: [PtbArgument.sharedMut(id: obj)],
+    typeArgs: [registryTypeTag(pkg)],
+    names: ["registry"]
+  )
+
+  // Create the name object
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name"),
+    function: Identifier(identifier: "new"),
+    arguments: [PtbArgument.string(string: name)],
+    names: ["name"]
+  )
+
+  // Look up the name record
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "registry"),
+    function: Identifier(identifier: "lookup"),
+    arguments: [
+      PtbArgument.assigned(name: "registry"), PtbArgument.assigned(name: "name"),
+    ],
+    names: ["name_record_opt"]
+  )
+
+  // Borrow the name record from Option
+  _ = try builder.moveCall(
+    package: std,
+    module: Identifier(identifier: "option"),
+    function: Identifier(identifier: "borrow"),
+    arguments: [PtbArgument.assigned(name: "name_record_opt")],
+    typeArgs: [nameRecordTypeTag(pkg)],
+    names: ["name_record"]
+  )
+
+  // Get the target address
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name_record"),
+    function: Identifier(identifier: "target_address"),
+    arguments: [PtbArgument.assigned(name: "name_record")],
+    names: ["target_address_opt"]
+  )
+
+  // Get the expiration timestamp
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name_record"),
+    function: Identifier(identifier: "expiration_timestamp_ms"),
+    arguments: [PtbArgument.assigned(name: "name_record")],
+    names: ["expiration"]
+  )
+
+  let res = try await builder.dryRun(skipChecks: true)
+
+  if let error = res.error {
+    throw NSError(
+      domain: "IotaNames", code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "Name record query failed: \(error)"])
+  }
+
+  print("  Name record details for '\(name)':")
+
+  // Extract expiration (u64)
+  for effect in res.results {
+    for rv in effect.returnValues {
+      if rv.typeTag.isU64() && rv.bcs.count == 8 {
+        let timestamp = rv.bcs.withUnsafeBytes { $0.load(as: UInt64.self) }
+        print("  Expiration timestamp (ms): \(timestamp)")
+      }
+    }
+  }
+
+  // Extract target address from Option<address> (5th move call, index 4)
+  if res.results.count > 4 {
+    let effect = res.results[4]
+    if let rv = effect.returnValues.first {
+      if rv.bcs.count == 33 && rv.bcs[0] == 1 {
+        let addrBytes = Array(rv.bcs[1...32])
+        let addr = try Address.fromBytes(bytes: addrBytes)
+        print("  Target address: \(addr.toHex())")
+      } else {
+        print("  Target address: not set")
+      }
+    }
+  }
+}
+
+/// Example 4: Check if a name exists in the registry.
+func checkNameExists(client: GraphQlClient, name: String) async throws -> Bool {
+  let pkg = try Address.fromHex(hex: iotaNamesPackageHex)
+  let obj = try ObjectId.fromHex(hex: iotaNamesObjectHex)
+  let sender = Address.zero()
+
+  let builder = TransactionBuilder(sender: sender).withClient(client: client)
+
+  // Get the shared registry
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "iota_names"),
+    function: Identifier(identifier: "registry"),
+    arguments: [PtbArgument.sharedMut(id: obj)],
+    typeArgs: [registryTypeTag(pkg)],
+    names: ["registry"]
+  )
+
+  // Create the name object
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "name"),
+    function: Identifier(identifier: "new"),
+    arguments: [PtbArgument.string(string: name)],
+    names: ["name"]
+  )
+
+  // Check if the name has a record
+  _ = try builder.moveCall(
+    package: pkg,
+    module: Identifier(identifier: "registry"),
+    function: Identifier(identifier: "has_record"),
+    arguments: [
+      PtbArgument.assigned(name: "registry"), PtbArgument.assigned(name: "name"),
+    ],
+    names: ["exists"]
+  )
+
+  let res = try await builder.dryRun(skipChecks: true)
+
+  if let error = res.error {
+    throw NSError(
+      domain: "IotaNames", code: 1,
+      userInfo: [NSLocalizedDescriptionKey: "has_record check failed: \(error)"])
+  }
+
+  if let lastEffect = res.results.last,
+    let rv = lastEffect.returnValues.first,
+    rv.typeTag.isBool()
+  {
+    return rv.bcs.first == 1
+  }
+  return false
+}
+
+@main
+struct IotaNamesExample {
+  static func main() async throws {
+    let client = GraphQlClient.newDevnet()
+    let name = "name.iota"
+
+    print("=== IOTA Names Examples ===\n")
+
+    // Example 1: Name lookup (name -> address)
+    print("1. Looking up '\(name)'...")
+    let address = try await lookupName(client: client, name: name)
+    if let address = address {
+      print("   Resolved to: \(address.toHex())\n")
+
+      // Example 2: Reverse lookup (address -> name)
+      print("2. Reverse lookup for \(address.toHex())...")
+      try await reverseLookup(client: client, address: address)
+      print("")
+    } else {
+      print("   Name not found or expired\n")
+      print("2. Skipping reverse lookup (no address to look up)\n")
+    }
+
+    // Example 3: Name record details
+    print("3. Querying name record details for '\(name)'...")
+    try await nameRecordDetails(client: client, name: name)
+    print("")
+
+    // Example 4: Check if names exist
+    print("4. Checking name existence...")
+    let exists = try await checkNameExists(client: client, name: name)
+    print("   '\(name)' exists: \(exists)")
+
+    let fakeName = "this-name-probably-does-not-exist-12345.iota"
+    let fakeExists = try await checkNameExists(client: client, name: fakeName)
+    print("   '\(fakeName)' exists: \(fakeExists)")
+  }
+}

--- a/crates/iota-sdk/examples/iota_names.rs
+++ b/crates/iota-sdk/examples/iota_names.rs
@@ -1,0 +1,338 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! This example demonstrates the major IOTA Names operations using dev_inspect
+//! transactions:
+//!
+//! 1. **Name lookup**: resolve an IOTA name (e.g. "name.iota") to an address
+//! 2. **Reverse lookup**: resolve an address back to its IOTA name
+//! 3. **Name record details**: query expiration timestamp and custom data
+//! 4. **Check existence**: verify if a name is registered
+//!
+//! All operations use `dev_inspect` (dry run) so no gas or signing is needed.
+
+use std::str::FromStr;
+
+use eyre::Result;
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{SharedMut, TransactionBuilder, assigned},
+    types::{Address, Identifier, ObjectId, StructTag, TypeTag},
+};
+
+/// IOTA Names package address on devnet.
+const IOTA_NAMES_PACKAGE: &str =
+    "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba";
+
+/// IOTA Names shared object ID on devnet.
+const IOTA_NAMES_OBJECT: &str =
+    "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342";
+
+/// Helper to create the Registry type tag.
+fn registry_type_tag(pkg: Address) -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag::new(
+        pkg,
+        Identifier::new("registry").unwrap(),
+        Identifier::new("Registry").unwrap(),
+        vec![],
+    )))
+}
+
+/// Helper to create the NameRecord type tag.
+fn name_record_type_tag(pkg: Address) -> TypeTag {
+    TypeTag::Struct(Box::new(StructTag::new(
+        pkg,
+        Identifier::new("name_record").unwrap(),
+        Identifier::new("NameRecord").unwrap(),
+        vec![],
+    )))
+}
+
+/// Example 1: Look up an IOTA name to get the associated address.
+///
+/// Gets the registry from the IotaNames object, creates a Name from
+/// a string, looks up the NameRecord, and extracts the target address.
+async fn lookup_name(client: &Client, name: &str) -> Result<Option<Address>> {
+    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
+    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+    let sender = Address::from_str("0x0")?;
+
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+
+    // Step 1: Get the shared registry object
+    builder
+        .move_call(pkg, "iota_names", "registry")
+        .arguments([SharedMut(obj)])
+        .type_tags([registry_type_tag(pkg)])
+        .assign("iota_names");
+
+    // Step 2: Create the name object from the string
+    builder
+        .move_call(pkg, "name", "new")
+        .arguments([name])
+        .assign("name");
+
+    // Step 3: Look up the name record in the registry
+    builder
+        .move_call(pkg, "registry", "lookup")
+        .arguments((assigned("iota_names"), assigned("name")))
+        .assign("name_record_opt");
+
+    // Step 4: Borrow the name record from the option
+    builder
+        .move_call(Address::STD, "option", "borrow")
+        .arguments([assigned("name_record_opt")])
+        .type_tags([name_record_type_tag(pkg)])
+        .assign("name_record");
+
+    // Step 5: Get the target address from the name record
+    builder
+        .move_call(pkg, "name_record", "target_address")
+        .arguments([assigned("name_record")])
+        .assign("target_address_opt");
+
+    // Step 6: Borrow the address from the option
+    builder
+        .move_call(Address::STD, "option", "borrow")
+        .arguments([assigned("target_address_opt")])
+        .generics::<Address>()
+        .assign("target_address");
+
+    let res = builder.dry_run(true).await?;
+
+    if let Some(err) = &res.error {
+        if err.contains("None") || err.contains("option") {
+            return Ok(None);
+        }
+        eyre::bail!("Name lookup failed: {err}");
+    }
+
+    Ok(res
+        .results
+        .last()
+        .and_then(|effect| effect.return_values.first())
+        .filter(|rv| matches!(rv.type_tag, TypeTag::Address))
+        .and_then(|rv| TryInto::<[u8; 32]>::try_into(rv.bcs.as_slice()).ok())
+        .map(Address::from))
+}
+
+/// Example 2: Reverse lookup - resolve an address to its IOTA name.
+///
+/// Gets the registry from the IotaNames object and calls
+/// `reverse_lookup` to find the name associated with a given address.
+async fn reverse_lookup(client: &Client, address: Address) -> Result<()> {
+    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
+    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+    let sender = Address::from_str("0x0")?;
+
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+
+    // Get the shared registry (mutable access needed)
+    builder
+        .move_call(pkg, "iota_names", "registry")
+        .arguments([SharedMut(obj)])
+        .type_tags([registry_type_tag(pkg)])
+        .assign("registry");
+
+    // Reverse lookup: address -> Option<Name>
+    builder
+        .move_call(pkg, "registry", "reverse_lookup")
+        .arguments((assigned("registry"), address))
+        .assign("name_opt");
+
+    let res = builder.dry_run(true).await?;
+
+    if let Some(err) = res.error {
+        println!("  Reverse lookup failed (address may not have a name set): {err}");
+    } else {
+        // The result is an Option<Name>. We can check if it's Some by
+        // inspecting the BCS bytes. A non-empty Option in BCS starts with 0x01.
+        if let Some(rv) = res
+            .results
+            .last()
+            .and_then(|effect| effect.return_values.first())
+        {
+            if rv.bcs.first() == Some(&1) {
+                println!("  Address {address} has a reverse name record");
+            } else {
+                println!("  Address {address} does not have a reverse name record");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 3: Query name record details.
+///
+/// Retrieves the full NameRecord for a given name, including:
+/// - Target address
+/// - Expiration timestamp (milliseconds since epoch)
+async fn name_record_details(client: &Client, name: &str) -> Result<()> {
+    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
+    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+    let sender = Address::from_str("0x0")?;
+
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+
+    // Get the shared registry (mutable access needed for lookup)
+    builder
+        .move_call(pkg, "iota_names", "registry")
+        .arguments([SharedMut(obj)])
+        .type_tags([registry_type_tag(pkg)])
+        .assign("registry");
+
+    // Create the name object
+    builder
+        .move_call(pkg, "name", "new")
+        .arguments([name])
+        .assign("name");
+
+    // Look up the name record
+    builder
+        .move_call(pkg, "registry", "lookup")
+        .arguments((assigned("registry"), assigned("name")))
+        .assign("name_record_opt");
+
+    // Borrow the name record from Option
+    builder
+        .move_call(Address::STD, "option", "borrow")
+        .arguments([assigned("name_record_opt")])
+        .type_tags([name_record_type_tag(pkg)])
+        .assign("name_record");
+
+    // Get the target address
+    builder
+        .move_call(pkg, "name_record", "target_address")
+        .arguments([assigned("name_record")])
+        .assign("target_address_opt");
+
+    // Get the expiration timestamp
+    builder
+        .move_call(pkg, "name_record", "expiration_timestamp_ms")
+        .arguments([assigned("name_record")])
+        .assign("expiration");
+
+    let res = builder.dry_run(true).await?;
+
+    if let Some(err) = res.error {
+        eyre::bail!("Name record query failed: {err}");
+    }
+
+    println!("  Name record details for '{name}':");
+
+    for effect in &res.results {
+        for rv in &effect.return_values {
+            if let TypeTag::U64 = &rv.type_tag {
+                if rv.bcs.len() == 8 {
+                    let timestamp =
+                        u64::from_le_bytes(rv.bcs.as_slice().try_into().unwrap_or_default());
+                    println!("  Expiration timestamp (ms): {timestamp}");
+                }
+            }
+        }
+    }
+
+    // Extract the target address from the Option<address> result
+    // The target_address_opt result is the 5th move call (index 4)
+    if let Some(rv) = res
+        .results
+        .get(4)
+        .and_then(|effect| effect.return_values.first())
+    {
+        // Option<address> in BCS: 0x01 + 32 bytes if Some, 0x00 if None
+        if rv.bcs.first() == Some(&1) && rv.bcs.len() == 33 {
+            let addr = Address::from(
+                TryInto::<[u8; 32]>::try_into(&rv.bcs[1..33]).unwrap_or_default(),
+            );
+            println!("  Target address: {addr}");
+        } else {
+            println!("  Target address: not set");
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 4: Check if a name exists in the registry.
+async fn check_name_exists(client: &Client, name: &str) -> Result<bool> {
+    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
+    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+    let sender = Address::from_str("0x0")?;
+
+    let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
+
+    // Get the shared registry (mutable access needed)
+    builder
+        .move_call(pkg, "iota_names", "registry")
+        .arguments([SharedMut(obj)])
+        .type_tags([registry_type_tag(pkg)])
+        .assign("registry");
+
+    // Create the name object
+    builder
+        .move_call(pkg, "name", "new")
+        .arguments([name])
+        .assign("name");
+
+    // Check if the name has a record
+    builder
+        .move_call(pkg, "registry", "has_record")
+        .arguments((assigned("registry"), assigned("name")))
+        .assign("exists");
+
+    let res = builder.dry_run(true).await?;
+
+    if let Some(err) = res.error {
+        eyre::bail!("has_record check failed: {err}");
+    }
+
+    Ok(res
+        .results
+        .last()
+        .and_then(|effect| effect.return_values.first())
+        .filter(|rv| matches!(rv.type_tag, TypeTag::Bool))
+        .map(|rv| rv.bcs.first().copied() == Some(1))
+        .unwrap_or(false))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_devnet();
+    let name = "name.iota";
+
+    println!("=== IOTA Names Examples ===\n");
+
+    // Example 1: Name lookup (name -> address)
+    println!("1. Looking up '{name}'...");
+    match lookup_name(&client, name).await? {
+        Some(address) => {
+            println!("   Resolved to: {address}\n");
+
+            // Example 2: Reverse lookup (address -> name)
+            println!("2. Reverse lookup for {address}...");
+            reverse_lookup(&client, address).await?;
+            println!();
+        }
+        None => {
+            println!("   Name not found or expired\n");
+            println!("2. Skipping reverse lookup (no address to look up)\n");
+        }
+    }
+
+    // Example 3: Name record details
+    println!("3. Querying name record details for '{name}'...");
+    name_record_details(&client, name).await?;
+    println!();
+
+    // Example 4: Check if names exist
+    println!("4. Checking name existence...");
+    let exists = check_name_exists(&client, name).await?;
+    println!("   '{name}' exists: {exists}");
+
+    let fake_name = "this-name-probably-does-not-exist-12345.iota";
+    let exists = check_name_exists(&client, fake_name).await?;
+    println!("   '{fake_name}' exists: {exists}");
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/iota_names.rs
+++ b/crates/iota-sdk/examples/iota_names.rs
@@ -10,8 +10,12 @@
 //! 4. **Check existence**: verify if a name is registered
 //!
 //! All operations use `dev_inspect` (dry run) so no gas or signing is needed.
+//!
+//! Usage:
+//!   cargo run --example iota_names                          # devnet, "name.iota"
+//!   cargo run --example iota_names -- giverep.iota mainnet  # mainnet, "giverep.iota"
 
-use std::str::FromStr;
+use std::{env, str::FromStr};
 
 use eyre::Result;
 use iota_sdk::{
@@ -20,13 +24,35 @@ use iota_sdk::{
     types::{Address, Identifier, ObjectId, StructTag, TypeTag},
 };
 
-/// IOTA Names package address on devnet.
-const IOTA_NAMES_PACKAGE: &str =
-    "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba";
+/// IOTA Names configuration per network.
+struct IotaNamesConfig {
+    package: Address,
+    object_id: ObjectId,
+}
 
-/// IOTA Names shared object ID on devnet.
-const IOTA_NAMES_OBJECT: &str =
-    "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342";
+impl IotaNamesConfig {
+    fn devnet() -> Result<Self> {
+        Ok(Self {
+            package: Address::from_str(
+                "0xb9d617f24c84826bf660a2f4031951678cc80c264aebc4413459fb2a95ada9ba",
+            )?,
+            object_id: ObjectId::from_str(
+                "0x07c59b37bd7d036bf78fa30561a2ab9f7a970837487656ec29466e817f879342",
+            )?,
+        })
+    }
+
+    fn mainnet() -> Result<Self> {
+        Ok(Self {
+            package: Address::from_str(
+                "0x6d2c743607ef275bd6934fe5c2a7e5179cca6fbd2049cfa79de2310b74f3cf83",
+            )?,
+            object_id: ObjectId::from_str(
+                "0xa14e5d0481a7aa346157078e6facba3cd895d97038cd87b9f2cc24b0c6102d75",
+            )?,
+        })
+    }
+}
 
 /// Helper to create the Registry type tag.
 fn registry_type_tag(pkg: Address) -> TypeTag {
@@ -52,9 +78,13 @@ fn name_record_type_tag(pkg: Address) -> TypeTag {
 ///
 /// Gets the registry from the IotaNames object, creates a Name from
 /// a string, looks up the NameRecord, and extracts the target address.
-async fn lookup_name(client: &Client, name: &str) -> Result<Option<Address>> {
-    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
-    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+async fn lookup_name(
+    client: &Client,
+    config: &IotaNamesConfig,
+    name: &str,
+) -> Result<Option<Address>> {
+    let pkg = config.package;
+    let obj = config.object_id;
     let sender = Address::from_str("0x0")?;
 
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
@@ -101,7 +131,8 @@ async fn lookup_name(client: &Client, name: &str) -> Result<Option<Address>> {
     let res = builder.dry_run(true).await?;
 
     if let Some(err) = &res.error {
-        if err.contains("None") || err.contains("option") {
+        // option::borrow abort means the name doesn't exist
+        if err.contains("option") && err.contains("borrow") {
             return Ok(None);
         }
         eyre::bail!("Name lookup failed: {err}");
@@ -120,9 +151,13 @@ async fn lookup_name(client: &Client, name: &str) -> Result<Option<Address>> {
 ///
 /// Gets the registry from the IotaNames object and calls
 /// `reverse_lookup` to find the name associated with a given address.
-async fn reverse_lookup(client: &Client, address: Address) -> Result<()> {
-    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
-    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+async fn reverse_lookup(
+    client: &Client,
+    config: &IotaNamesConfig,
+    address: Address,
+) -> Result<()> {
+    let pkg = config.package;
+    let obj = config.object_id;
     let sender = Address::from_str("0x0")?;
 
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
@@ -168,9 +203,13 @@ async fn reverse_lookup(client: &Client, address: Address) -> Result<()> {
 /// Retrieves the full NameRecord for a given name, including:
 /// - Target address
 /// - Expiration timestamp (milliseconds since epoch)
-async fn name_record_details(client: &Client, name: &str) -> Result<()> {
-    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
-    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+async fn name_record_details(
+    client: &Client,
+    config: &IotaNamesConfig,
+    name: &str,
+) -> Result<()> {
+    let pkg = config.package;
+    let obj = config.object_id;
     let sender = Address::from_str("0x0")?;
 
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
@@ -255,9 +294,13 @@ async fn name_record_details(client: &Client, name: &str) -> Result<()> {
 }
 
 /// Example 4: Check if a name exists in the registry.
-async fn check_name_exists(client: &Client, name: &str) -> Result<bool> {
-    let pkg = Address::from_str(IOTA_NAMES_PACKAGE)?;
-    let obj = ObjectId::from_str(IOTA_NAMES_OBJECT)?;
+async fn check_name_exists(
+    client: &Client,
+    config: &IotaNamesConfig,
+    name: &str,
+) -> Result<bool> {
+    let pkg = config.package;
+    let obj = config.object_id;
     let sender = Address::from_str("0x0")?;
 
     let mut builder = TransactionBuilder::new(sender).with_client(client.clone());
@@ -298,20 +341,26 @@ async fn check_name_exists(client: &Client, name: &str) -> Result<bool> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client = Client::new_devnet();
-    let name = "name.iota";
+    let args: Vec<String> = env::args().collect();
+    let name = args.get(1).map(|s| s.as_str()).unwrap_or("name.iota");
+    let network = args.get(2).map(|s| s.as_str()).unwrap_or("devnet");
 
-    println!("=== IOTA Names Examples ===\n");
+    let (client, config) = match network {
+        "mainnet" => (Client::new_mainnet(), IotaNamesConfig::mainnet()?),
+        _ => (Client::new_devnet(), IotaNamesConfig::devnet()?),
+    };
+
+    println!("=== IOTA Names Examples ({network}) ===\n");
 
     // Example 1: Name lookup (name -> address)
     println!("1. Looking up '{name}'...");
-    match lookup_name(&client, name).await? {
+    match lookup_name(&client, &config, name).await? {
         Some(address) => {
             println!("   Resolved to: {address}\n");
 
             // Example 2: Reverse lookup (address -> name)
             println!("2. Reverse lookup for {address}...");
-            reverse_lookup(&client, address).await?;
+            reverse_lookup(&client, &config, address).await?;
             println!();
         }
         None => {
@@ -322,16 +371,19 @@ async fn main() -> Result<()> {
 
     // Example 3: Name record details
     println!("3. Querying name record details for '{name}'...");
-    name_record_details(&client, name).await?;
+    match name_record_details(&client, &config, name).await {
+        Ok(()) => {}
+        Err(e) => println!("   {e}"),
+    }
     println!();
 
     // Example 4: Check if names exist
     println!("4. Checking name existence...");
-    let exists = check_name_exists(&client, name).await?;
+    let exists = check_name_exists(&client, &config, name).await?;
     println!("   '{name}' exists: {exists}");
 
     let fake_name = "this-name-probably-does-not-exist-12345.iota";
-    let exists = check_name_exists(&client, fake_name).await?;
+    let exists = check_name_exists(&client, &config, fake_name).await?;
     println!("   '{fake_name}' exists: {exists}");
 
     Ok(())


### PR DESCRIPTION
## Summary

Add comprehensive IOTA Names example demonstrating all major operations, implemented in Rust and all 4 language bindings.

### Operations covered:

1. **Name lookup**: resolve an IOTA name (e.g. `name.iota`) to an address using `resolve_address`
2. **Reverse lookup**: resolve an address back to its IOTA name
3. **Name record details**: query expiration timestamp and target address
4. **Check existence**: verify if a name is registered using `has_record`

All operations use `dev_inspect` (dry run) so no gas or signing is needed.

### Files added:

- `crates/iota-sdk/examples/iota_names.rs` (Rust)
- `bindings/python/examples/iota_names.py` (Python)
- `bindings/kotlin/examples/IotaNames.kt` (Kotlin)
- `bindings/go/examples/iota_names/main.go` (Go)
- `bindings/swift/examples/iota_names.swift` (Swift)

### Checklist from #514:

- [x] Add example to Rust
- [x] Add example to all bindings (Python, Kotlin, Go, Swift)
- [ ] Optional: change dev_inspect example so it doesn't use IOTA names (can do in follow-up if desired)

Closes #514