### PR TITLE
test(types, crypto): add unit tests to increase coverage

### DIFF
--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -367,4 +367,93 @@ mod tests {
             .verify_personal_message(&message, &signature)
             .unwrap();
     }
+
+    #[test]
+    fn from_bytes_wrong_length_short() {
+        use crate::ToFromBytes;
+        assert!(Ed25519PrivateKey::from_bytes(&[0u8; 31]).is_err());
+    }
+
+    #[test]
+    fn from_bytes_wrong_length_long() {
+        use crate::ToFromBytes;
+        assert!(Ed25519PrivateKey::from_bytes(&[0u8; 33]).is_err());
+    }
+
+    #[test]
+    fn from_bytes_valid_roundtrip() {
+        use crate::ToFromBytes;
+        let key = Ed25519PrivateKey::new([42u8; 32]);
+        let bytes = key.to_bytes();
+        let restored = Ed25519PrivateKey::from_bytes(&bytes).unwrap();
+        assert_eq!(key, restored);
+    }
+
+    #[test]
+    fn verifying_key_from_invalid_bytes() {
+        // All zeros is not a valid ed25519 public key point
+        let pk = iota_types::Ed25519PublicKey::new([0u8; 32]);
+        // This may or may not be an error depending on the ed25519 implementation;
+        // the important thing is it doesn't panic
+        let _ = Ed25519VerifyingKey::new(&pk);
+    }
+
+    #[test]
+    fn verifier_rejects_non_ed25519_user_signature() {
+        let verifier = Ed25519Verifier::new();
+        // Create a Secp256k1 UserSignature
+        let fake_sig = UserSignature::Simple(SimpleSignature::Secp256k1 {
+            signature: iota_types::Secp256k1Signature::new([0; 64]),
+            public_key: iota_types::Secp256k1PublicKey::new([0; 33]),
+        });
+        assert!(verifier.verify(b"msg", &fake_sig).is_err());
+    }
+
+    #[test]
+    fn verifying_key_rejects_wrong_public_key() {
+        use crate::Signer;
+
+        let key1 = Ed25519PrivateKey::new([1u8; 32]);
+        let key2 = Ed25519PrivateKey::new([2u8; 32]);
+
+        let msg = b"test message";
+        let signature: SimpleSignature = key1.try_sign(msg).unwrap();
+
+        // Verify with key2's verifying key should fail
+        let verifier2 = key2.verifying_key();
+        assert!(verifier2.verify(msg, &signature).is_err());
+    }
+
+    #[test]
+    fn private_key_scheme() {
+        let key = Ed25519PrivateKey::new([0u8; 32]);
+        assert_eq!(key.scheme(), SignatureScheme::Ed25519);
+    }
+
+    #[cfg(feature = "pem")]
+    #[test]
+    fn pem_der_roundtrip_private_key() {
+        let key = Ed25519PrivateKey::new([42u8; 32]);
+        let der = key.to_der().unwrap();
+        let restored = Ed25519PrivateKey::from_der(&der).unwrap();
+        assert_eq!(key, restored);
+
+        let pem = key.to_pem().unwrap();
+        let restored_pem = Ed25519PrivateKey::from_pem(&pem).unwrap();
+        assert_eq!(key, restored_pem);
+    }
+
+    #[cfg(feature = "pem")]
+    #[test]
+    fn pem_der_roundtrip_verifying_key() {
+        let key = Ed25519PrivateKey::new([42u8; 32]);
+        let vk = key.verifying_key();
+        let der = vk.to_der().unwrap();
+        let restored = Ed25519VerifyingKey::from_der(&der).unwrap();
+        assert_eq!(vk, restored);
+
+        let pem = vk.to_pem().unwrap();
+        let restored_pem = Ed25519VerifyingKey::from_pem(&pem).unwrap();
+        assert_eq!(vk, restored_pem);
+    }
 }

--- a/crates/iota-sdk-crypto/src/lib.rs
+++ b/crates/iota-sdk-crypto/src/lib.rs
@@ -449,4 +449,80 @@ mod tests {
             assert_eq!(key.public_key().derive_address().to_string(), address);
         }
     }
+
+    #[test]
+    fn flagged_bytes_roundtrip_ed25519() {
+        use crate::ToFromFlaggedBytes;
+        let key = Ed25519PrivateKey::new([42u8; 32]);
+        let flagged = key.to_flagged_bytes();
+        assert_eq!(flagged[0], iota_types::SignatureScheme::Ed25519.to_u8());
+        assert_eq!(flagged.len(), 33); // 1 flag + 32 key bytes
+        let restored = Ed25519PrivateKey::from_flagged_bytes(&flagged).unwrap();
+        assert_eq!(key, restored);
+    }
+
+    #[test]
+    fn flagged_bytes_empty_input() {
+        use crate::ToFromFlaggedBytes;
+        let result = Ed25519PrivateKey::from_flagged_bytes(&[]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn flagged_bytes_invalid_scheme_flag() {
+        use crate::ToFromFlaggedBytes;
+        let mut bytes = vec![0xFF]; // invalid scheme
+        bytes.extend_from_slice(&[0u8; 32]);
+        let result = Ed25519PrivateKey::from_flagged_bytes(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn flagged_bytes_wrong_scheme_secp256k1_as_ed25519() {
+        use crate::ToFromFlaggedBytes;
+        // Use secp256k1 flag (0x01) but try to parse as Ed25519
+        let mut bytes = vec![iota_types::SignatureScheme::Secp256k1.to_u8()];
+        bytes.extend_from_slice(&[0u8; 32]);
+        let result = Ed25519PrivateKey::from_flagged_bytes(&bytes);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn flagged_bytes_secp256k1_roundtrip() {
+        use crate::ToFromFlaggedBytes;
+        let key = Secp256k1PrivateKey::new([42u8; 32]).unwrap();
+        let flagged = key.to_flagged_bytes();
+        assert_eq!(flagged[0], iota_types::SignatureScheme::Secp256k1.to_u8());
+        let restored = Secp256k1PrivateKey::from_flagged_bytes(&flagged).unwrap();
+        assert_eq!(key, restored);
+    }
+
+    #[cfg(feature = "bech32")]
+    #[test]
+    fn bech32_roundtrip_ed25519() {
+        use crate::ToFromBech32;
+        let key = Ed25519PrivateKey::new([42u8; 32]);
+        let encoded = key.to_bech32().unwrap();
+        assert!(encoded.starts_with("iotaprivkey"));
+        let decoded = Ed25519PrivateKey::from_bech32(&encoded).unwrap();
+        assert_eq!(key, decoded);
+    }
+
+    #[cfg(feature = "bech32")]
+    #[test]
+    fn bech32_wrong_hrp() {
+        use crate::ToFromBech32;
+        // Create a valid bech32 string but with wrong HRP
+        let result =
+            Ed25519PrivateKey::from_bech32("wronghrp1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw");
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "bech32")]
+    #[test]
+    fn bech32_invalid_encoding() {
+        use crate::ToFromBech32;
+        let result = Ed25519PrivateKey::from_bech32("not-a-valid-bech32-string!!!");
+        assert!(result.is_err());
+    }
 }

--- a/crates/iota-sdk-crypto/src/mnemonic.rs
+++ b/crates/iota-sdk-crypto/src/mnemonic.rs
@@ -18,3 +18,45 @@ pub fn generate_mnemonic(word_count: impl Into<Option<MnemonicLength>>) -> Strin
         .expect("mnemonic generation failed") // Safe to unwrap since the word count is controlled
         .to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_default_24_words() {
+        let mnemonic = generate_mnemonic(None);
+        let word_count = mnemonic.split_whitespace().count();
+        assert_eq!(word_count, 24);
+    }
+
+    #[test]
+    fn generate_12_words() {
+        let mnemonic = generate_mnemonic(MnemonicLength::Words12);
+        let word_count = mnemonic.split_whitespace().count();
+        assert_eq!(word_count, 12);
+    }
+
+    #[test]
+    fn generate_24_words_explicit() {
+        let mnemonic = generate_mnemonic(MnemonicLength::Words24);
+        let word_count = mnemonic.split_whitespace().count();
+        assert_eq!(word_count, 24);
+    }
+
+    #[test]
+    fn generated_mnemonic_is_valid_bip39() {
+        let mnemonic_str = generate_mnemonic(None);
+        // If parsing succeeds, the mnemonic is valid BIP-39
+        assert!(
+            bip39::Mnemonic::parse_in_normalized(bip39::Language::English, &mnemonic_str).is_ok()
+        );
+    }
+
+    #[test]
+    fn two_generated_mnemonics_differ() {
+        let m1 = generate_mnemonic(None);
+        let m2 = generate_mnemonic(None);
+        assert_ne!(m1, m2);
+    }
+}

--- a/crates/iota-sdk-crypto/src/multisig.rs
+++ b/crates/iota-sdk-crypto/src/multisig.rs
@@ -404,3 +404,192 @@ fn multisig_pubkey_and_signature_from_user_signature(
         _ => Err(SignatureError::from_source("unknown signature scheme")),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use iota_types::{Ed25519PublicKey, MultisigMember, MultisigMemberPublicKey, PersonalMessage};
+
+    use super::*;
+
+    fn make_member(byte: u8, weight: u8) -> MultisigMember {
+        MultisigMember::new(
+            MultisigMemberPublicKey::Ed25519(Ed25519PublicKey::new([byte; 32])),
+            weight,
+        )
+    }
+
+    #[test]
+    fn bitmap_indices_empty() {
+        let indices: Vec<u8> = BitmapIndices::new(0).collect();
+        assert!(indices.is_empty());
+    }
+
+    #[test]
+    fn bitmap_indices_single_bit() {
+        let indices: Vec<u8> = BitmapIndices::new(0b0001).collect();
+        assert_eq!(indices, vec![0]);
+    }
+
+    #[test]
+    fn bitmap_indices_multiple_bits() {
+        // 0b10110 = 22, bits 1, 2, 4 are set
+        let indices: Vec<u8> = BitmapIndices::new(0b10110).collect();
+        assert_eq!(indices, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn bitmap_indices_10_bits() {
+        let bitmap: u16 = 0b1111111111; // first 10 bits
+        let indices: Vec<u8> = BitmapIndices::new(bitmap).collect();
+        assert_eq!(indices, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn verify_invalid_committee() {
+        let verifier = MultisigVerifier::new();
+        // Empty committee is invalid
+        let committee = MultisigCommittee::new(vec![], 1);
+        let sig = MultisigAggregatedSignature::new(committee, vec![], 0);
+        let result = verifier.verify(b"msg", &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_bitmap_sig_count_mismatch() {
+        let verifier = MultisigVerifier::new();
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 1);
+        // bitmap has bit 0 set (1 signature expected) but no signatures provided
+        let sig = MultisigAggregatedSignature::new(committee, vec![], 0b1);
+        let result = verifier.verify(b"msg", &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verify_more_sigs_than_members() {
+        let verifier = MultisigVerifier::new();
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 1);
+        // Create fake ed25519 signatures
+        let fake_sigs = vec![
+            MultisigMemberSignature::Ed25519(iota_types::Ed25519Signature::new([0; 64])),
+            MultisigMemberSignature::Ed25519(iota_types::Ed25519Signature::new([0; 64])),
+        ];
+        let sig = MultisigAggregatedSignature::new(committee, fake_sigs, 0b11);
+        let result = verifier.verify(b"msg", &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn verifier_rejects_non_multisig_user_signature() {
+        let verifier = MultisigVerifier::new();
+        let fake_simple = iota_types::UserSignature::Simple(iota_types::SimpleSignature::Ed25519 {
+            signature: iota_types::Ed25519Signature::new([0; 64]),
+            public_key: Ed25519PublicKey::new([0; 32]),
+        });
+        let result: Result<(), _> =
+            <MultisigVerifier as Verifier<UserSignature>>::verify(&verifier, b"msg", &fake_simple);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn aggregator_sign_and_verify_roundtrip() {
+        use crate::{IotaSigner, ed25519::Ed25519PrivateKey};
+
+        let key1 = Ed25519PrivateKey::new([1u8; 32]);
+        let key2 = Ed25519PrivateKey::new([2u8; 32]);
+
+        let committee = MultisigCommittee::new(
+            vec![
+                MultisigMember::new(MultisigMemberPublicKey::Ed25519(key1.public_key()), 1),
+                MultisigMember::new(MultisigMemberPublicKey::Ed25519(key2.public_key()), 1),
+            ],
+            2,
+        );
+
+        let message = PersonalMessage(b"hello".to_vec().into());
+        let mut aggregator = MultisigAggregator::new_with_message(committee.clone(), &message);
+
+        let sig1 = key1.sign_personal_message(&message).unwrap();
+        let sig2 = key2.sign_personal_message(&message).unwrap();
+
+        aggregator.add_signature(sig1).unwrap();
+        aggregator.add_signature(sig2).unwrap();
+
+        let multisig = aggregator.finish().unwrap();
+
+        let verifier = MultisigVerifier::new();
+        verifier
+            .verify(&message.signing_digest(), &multisig)
+            .unwrap();
+    }
+
+    #[test]
+    fn aggregator_non_member_rejected() {
+        use crate::{IotaSigner, ed25519::Ed25519PrivateKey};
+
+        let member_key = Ed25519PrivateKey::new([1u8; 32]);
+        let non_member_key = Ed25519PrivateKey::new([99u8; 32]);
+
+        let committee = MultisigCommittee::new(
+            vec![MultisigMember::new(
+                MultisigMemberPublicKey::Ed25519(member_key.public_key()),
+                1,
+            )],
+            1,
+        );
+
+        let message = PersonalMessage(b"hello".to_vec().into());
+        let mut aggregator = MultisigAggregator::new_with_message(committee, &message);
+
+        let sig = non_member_key.sign_personal_message(&message).unwrap();
+        assert!(aggregator.add_signature(sig).is_err());
+    }
+
+    #[test]
+    fn aggregator_duplicate_signature_rejected() {
+        use crate::{IotaSigner, ed25519::Ed25519PrivateKey};
+
+        let key = Ed25519PrivateKey::new([1u8; 32]);
+
+        let committee = MultisigCommittee::new(
+            vec![MultisigMember::new(
+                MultisigMemberPublicKey::Ed25519(key.public_key()),
+                1,
+            )],
+            1,
+        );
+
+        let message = PersonalMessage(b"hello".to_vec().into());
+        let mut aggregator = MultisigAggregator::new_with_message(committee, &message);
+
+        let sig1 = key.sign_personal_message(&message).unwrap();
+        let sig2 = key.sign_personal_message(&message).unwrap();
+
+        aggregator.add_signature(sig1).unwrap();
+        assert!(aggregator.add_signature(sig2).is_err());
+    }
+
+    #[test]
+    fn aggregator_insufficient_weight() {
+        use crate::{IotaSigner, ed25519::Ed25519PrivateKey};
+
+        let key1 = Ed25519PrivateKey::new([1u8; 32]);
+        let key2 = Ed25519PrivateKey::new([2u8; 32]);
+
+        let committee = MultisigCommittee::new(
+            vec![
+                MultisigMember::new(MultisigMemberPublicKey::Ed25519(key1.public_key()), 1),
+                MultisigMember::new(MultisigMemberPublicKey::Ed25519(key2.public_key()), 1),
+            ],
+            2,
+        );
+
+        let message = PersonalMessage(b"hello".to_vec().into());
+        let mut aggregator = MultisigAggregator::new_with_message(committee, &message);
+
+        let sig = key1.sign_personal_message(&message).unwrap();
+        aggregator.add_signature(sig).unwrap();
+
+        // Only weight=1, but threshold=2
+        assert!(aggregator.finish().is_err());
+    }
+}

--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -68,7 +68,7 @@ impl From<ExecutionStatus> for iota_sdk::types::ExecutionStatus {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// 
+///
 /// execution-error =  insufficient-gas
 ///                 =/ invalid-gas-object
 ///                 =/ invariant-violation

--- a/crates/iota-sdk-graphql-client/src/api/dynamic_fields.rs
+++ b/crates/iota-sdk-graphql-client/src/api/dynamic_fields.rs
@@ -46,7 +46,7 @@ impl Client {
     ///
     /// # Example
     /// ```rust,ignore
-    /// 
+    ///
     /// let client = iota_graphql_client::Client::new_devnet();
     /// let address = ObjectId::system().into();
     /// let df = client.dynamic_field_with_name(address, "u64", 2u64).await.unwrap();

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -311,3 +311,236 @@ pub enum HashingIntentScope {
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PersonalMessage<'a>(pub std::borrow::Cow<'a, [u8]>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iota_transaction_intent() {
+        let intent = Intent::iota_transaction();
+        assert_eq!(intent.scope(), IntentScope::TransactionData);
+        assert_eq!(intent.version(), IntentVersion::V0);
+        assert_eq!(intent.app_id(), IntentAppId::Iota);
+    }
+
+    #[test]
+    fn personal_message_intent() {
+        let intent = Intent::personal_message();
+        assert_eq!(intent.scope(), IntentScope::PersonalMessage);
+        assert_eq!(intent.version(), IntentVersion::V0);
+        assert_eq!(intent.app_id(), IntentAppId::Iota);
+    }
+
+    #[test]
+    fn iota_app_intent() {
+        let intent = Intent::iota_app(IntentScope::CheckpointSummary);
+        assert_eq!(intent.scope(), IntentScope::CheckpointSummary);
+        assert_eq!(intent.version(), IntentVersion::V0);
+        assert_eq!(intent.app_id(), IntentAppId::Iota);
+    }
+
+    #[test]
+    fn consensus_app_intent() {
+        let intent = Intent::consensus_app(IntentScope::ConsensusBlock);
+        assert_eq!(intent.scope(), IntentScope::ConsensusBlock);
+        assert_eq!(intent.version(), IntentVersion::V0);
+        assert_eq!(intent.app_id(), IntentAppId::Consensus);
+    }
+
+    #[test]
+    fn intent_new_and_accessors() {
+        let intent = Intent::new(
+            IntentScope::ProofOfPossession,
+            IntentVersion::V0,
+            IntentAppId::Consensus,
+        );
+        assert_eq!(intent.scope(), IntentScope::ProofOfPossession);
+        assert_eq!(intent.version(), IntentVersion::V0);
+        assert_eq!(intent.app_id(), IntentAppId::Consensus);
+    }
+
+    #[test]
+    fn to_bytes_iota_transaction() {
+        let intent = Intent::iota_transaction();
+        assert_eq!(intent.to_bytes(), [0, 0, 0]);
+    }
+
+    #[test]
+    fn to_bytes_personal_message() {
+        let intent = Intent::personal_message();
+        assert_eq!(intent.to_bytes(), [3, 0, 0]);
+    }
+
+    #[test]
+    fn to_bytes_consensus_block() {
+        let intent = Intent::consensus_app(IntentScope::ConsensusBlock);
+        assert_eq!(intent.to_bytes(), [7, 0, 1]);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_roundtrip_iota_transaction() {
+        let intent = Intent::iota_transaction();
+        let bytes = intent.to_bytes();
+        let parsed = Intent::from_bytes(&bytes).unwrap();
+        assert_eq!(intent, parsed);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_roundtrip_personal_message() {
+        let intent = Intent::personal_message();
+        let bytes = intent.to_bytes();
+        let parsed = Intent::from_bytes(&bytes).unwrap();
+        assert_eq!(intent, parsed);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_roundtrip_consensus() {
+        let intent = Intent::consensus_app(IntentScope::ConsensusBlock);
+        let bytes = intent.to_bytes();
+        let parsed = Intent::from_bytes(&bytes).unwrap();
+        assert_eq!(intent, parsed);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_too_short() {
+        assert!(Intent::from_bytes(&[0, 0]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_too_long() {
+        assert!(Intent::from_bytes(&[0, 0, 0, 0]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_empty() {
+        assert!(Intent::from_bytes(&[]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_invalid_scope() {
+        assert!(Intent::from_bytes(&[255, 0, 0]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_invalid_version() {
+        assert!(Intent::from_bytes(&[0, 255, 0]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_bytes_error_invalid_app_id() {
+        assert!(Intent::from_bytes(&[0, 0, 255]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_str_with_0x_prefix() {
+        let intent: Intent = "0x000000".parse().unwrap();
+        assert_eq!(intent, Intent::iota_transaction());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_str_without_prefix() {
+        let intent: Intent = "030000".parse().unwrap();
+        assert_eq!(intent, Intent::personal_message());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_str_invalid_hex() {
+        assert!("0xZZZZZZ".parse::<Intent>().is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_str_wrong_length() {
+        assert!("0x00".parse::<Intent>().is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_str_empty() {
+        assert!("".parse::<Intent>().is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_scope_valid() {
+        assert_eq!(
+            IntentScope::try_from(0u8).unwrap(),
+            IntentScope::TransactionData
+        );
+        assert_eq!(
+            IntentScope::try_from(3u8).unwrap(),
+            IntentScope::PersonalMessage
+        );
+        assert_eq!(
+            IntentScope::try_from(9u8).unwrap(),
+            IntentScope::AuthorityCapabilities
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_scope_invalid() {
+        assert!(IntentScope::try_from(10u8).is_err());
+        assert!(IntentScope::try_from(255u8).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_version_valid() {
+        assert_eq!(IntentVersion::try_from(0u8).unwrap(), IntentVersion::V0);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_version_invalid() {
+        assert!(IntentVersion::try_from(1u8).is_err());
+        assert!(IntentVersion::try_from(255u8).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_app_id_valid() {
+        assert_eq!(IntentAppId::try_from(0u8).unwrap(), IntentAppId::Iota);
+        assert_eq!(IntentAppId::try_from(1u8).unwrap(), IntentAppId::Consensus);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn try_from_u8_intent_app_id_invalid() {
+        assert!(IntentAppId::try_from(2u8).is_err());
+        assert!(IntentAppId::try_from(255u8).is_err());
+    }
+
+    #[test]
+    fn intent_scope_is_accessors() {
+        assert!(IntentScope::TransactionData.is_transaction_data());
+        assert!(!IntentScope::TransactionData.is_personal_message());
+        assert!(IntentScope::PersonalMessage.is_personal_message());
+        assert!(IntentScope::ConsensusBlock.is_consensus_block());
+    }
+
+    #[test]
+    fn intent_version_is_accessor() {
+        assert!(IntentVersion::V0.is_v0());
+    }
+
+    #[test]
+    fn intent_app_id_is_accessors() {
+        assert!(IntentAppId::Iota.is_iota());
+        assert!(!IntentAppId::Iota.is_consensus());
+        assert!(IntentAppId::Consensus.is_consensus());
+    }
+}

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -674,3 +674,131 @@ mod serialization {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_member(byte: u8, weight: WeightUnit) -> MultisigMember {
+        MultisigMember::new(
+            MultisigMemberPublicKey::Ed25519(Ed25519PublicKey::new([byte; 32])),
+            weight,
+        )
+    }
+
+    #[test]
+    fn is_valid_single_member() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 1);
+        assert!(committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_max_members() {
+        let members: Vec<MultisigMember> = (1..=10).map(|i| make_member(i, 1)).collect();
+        let committee = MultisigCommittee::new(members, 5);
+        assert!(committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_threshold_equals_weight_sum() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 3), make_member(2, 2)], 5);
+        assert!(committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_zero_threshold() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 0);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_empty_members() {
+        let committee = MultisigCommittee::new(vec![], 1);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_too_many_members() {
+        let members: Vec<MultisigMember> = (1..=11).map(|i| make_member(i, 1)).collect();
+        let committee = MultisigCommittee::new(members, 1);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_zero_weight() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 0)], 1);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_threshold_exceeds_sum() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1), make_member(2, 1)], 3);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn is_valid_duplicate_members() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1), make_member(1, 1)], 1);
+        assert!(!committee.is_valid());
+    }
+
+    #[test]
+    fn member_public_key_scheme() {
+        let ed = MultisigMemberPublicKey::Ed25519(Ed25519PublicKey::new([0; 32]));
+        assert_eq!(ed.scheme(), SignatureScheme::Ed25519);
+
+        let k1 = MultisigMemberPublicKey::Secp256k1(Secp256k1PublicKey::new([0; 33]));
+        assert_eq!(k1.scheme(), SignatureScheme::Secp256k1);
+
+        let r1 = MultisigMemberPublicKey::Secp256r1(Secp256r1PublicKey::new([0; 33]));
+        assert_eq!(r1.scheme(), SignatureScheme::Secp256r1);
+    }
+
+    #[test]
+    fn committee_accessors() {
+        let members = vec![make_member(1, 3), make_member(2, 2)];
+        let committee = MultisigCommittee::new(members, 4);
+        assert_eq!(committee.threshold(), 4);
+        assert_eq!(committee.members().len(), 2);
+        assert_eq!(committee.scheme(), SignatureScheme::Multisig);
+    }
+
+    #[test]
+    fn aggregated_signature_construction() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 1);
+        let sig = MultisigAggregatedSignature::new(committee.clone(), vec![], 0);
+        assert_eq!(sig.bitmap(), 0);
+        assert!(sig.signatures().is_empty());
+        assert_eq!(*sig.committee(), committee);
+    }
+
+    #[test]
+    fn aggregated_signature_equality() {
+        let committee = MultisigCommittee::new(vec![make_member(1, 1)], 1);
+        let sig1 = MultisigAggregatedSignature::new(committee.clone(), vec![], 0);
+        let sig2 = MultisigAggregatedSignature::new(committee, vec![], 0);
+        assert_eq!(sig1, sig2);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_serialized_bytes_empty() {
+        assert!(MultisigAggregatedSignature::from_serialized_bytes(Vec::<u8>::new()).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_serialized_bytes_wrong_flag() {
+        // 0x00 is Ed25519 flag, not Multisig
+        assert!(MultisigAggregatedSignature::from_serialized_bytes(vec![0x00]).is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn from_serialized_bytes_invalid_bcs() {
+        // 0x03 is the Multisig flag, but the rest is garbage
+        assert!(
+            MultisigAggregatedSignature::from_serialized_bytes(vec![0x03, 0xff, 0xff]).is_err()
+        );
+    }
+}

--- a/crates/iota-sdk-types/src/digest.rs
+++ b/crates/iota-sdk-types/src/digest.rs
@@ -264,4 +264,79 @@ mod tests {
             digest_from_str("0000000000000000000000000000000000000000000000000000000000000000"),
         );
     }
+
+    #[test]
+    fn from_base58_invalid_chars() {
+        // '0', 'O', 'I', 'l' are not valid base58 characters
+        assert!(Digest::from_base58("0OIl0OIl0OIl0OIl0OIl0OIl0OIl0OIl0OIl0OIl0OIl").is_err());
+    }
+
+    #[test]
+    fn from_base58_wrong_length() {
+        // Too long - valid base58 but decodes to more than 32 bytes
+        let too_long = "z".repeat(50);
+        assert!(Digest::from_base58(&too_long).is_err());
+    }
+
+    #[test]
+    fn from_bytes_valid_roundtrip() {
+        let bytes = [42u8; 32];
+        let digest = Digest::from_bytes(bytes).unwrap();
+        assert_eq!(digest.into_inner(), bytes);
+    }
+
+    #[test]
+    fn from_bytes_too_short() {
+        assert!(Digest::from_bytes([0u8; 31]).is_err());
+    }
+
+    #[test]
+    fn from_bytes_too_long() {
+        assert!(Digest::from_bytes([0u8; 33]).is_err());
+    }
+
+    #[test]
+    fn from_bytes_empty() {
+        assert!(Digest::from_bytes(Vec::<u8>::new()).is_err());
+    }
+
+    #[test]
+    fn lower_hex_no_prefix() {
+        let digest = Digest::new([0u8; 32]);
+        let hex = format!("{digest:x}");
+        assert_eq!(hex, "0".repeat(64));
+        assert!(!hex.starts_with("0x"));
+    }
+
+    #[test]
+    fn lower_hex_with_alternate_prefix() {
+        let digest = Digest::new([0u8; 32]);
+        let hex = format!("{digest:#x}");
+        assert!(hex.starts_with("0x"));
+        assert_eq!(hex.len(), 66); // "0x" + 64
+    }
+
+    #[test]
+    fn lower_hex_nonzero() {
+        let mut bytes = [0u8; 32];
+        bytes[0] = 0xab;
+        bytes[31] = 0xcd;
+        let digest = Digest::new(bytes);
+        let hex = format!("{digest:x}");
+        assert!(hex.starts_with("ab"));
+        assert!(hex.ends_with("cd"));
+    }
+
+    #[test]
+    fn zero_constant() {
+        assert_eq!(Digest::ZERO.into_inner(), [0u8; 32]);
+    }
+
+    #[test]
+    fn from_into_array() {
+        let bytes = [7u8; 32];
+        let digest = Digest::from(bytes);
+        let back: [u8; 32] = digest.into();
+        assert_eq!(bytes, back);
+    }
 }

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -65,7 +65,7 @@ impl ExecutionStatus {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// 
+///
 /// execution-error =  insufficient-gas
 ///                 =/ invalid-gas-object
 ///                 =/ invariant-violation

--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -541,4 +541,59 @@ mod tests {
     fn roundtrip_hashing_intent(intent: HashingIntent) {
         assert_eq!(Ok(intent), HashingIntent::from_byte(intent as u8));
     }
+
+    #[test]
+    fn derive_id_deterministic() {
+        let digest = crate::Digest::new([1u8; 32]);
+        let id1 = crate::ObjectId::derive_id(digest, 0);
+        let id2 = crate::ObjectId::derive_id(digest, 0);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn derive_id_different_counts_differ() {
+        let digest = crate::Digest::new([1u8; 32]);
+        let id0 = crate::ObjectId::derive_id(digest, 0);
+        let id1 = crate::ObjectId::derive_id(digest, 1);
+        assert_ne!(id0, id1);
+    }
+
+    #[test]
+    fn derive_id_different_digests_differ() {
+        let d1 = crate::Digest::new([1u8; 32]);
+        let d2 = crate::Digest::new([2u8; 32]);
+        let id1 = crate::ObjectId::derive_id(d1, 0);
+        let id2 = crate::ObjectId::derive_id(d2, 0);
+        assert_ne!(id1, id2);
+    }
+
+    #[cfg(feature = "serde")]
+    #[proptest]
+    fn transaction_bcs_roundtrip(transaction: crate::Transaction) {
+        let bytes = transaction.to_bcs();
+        let parsed = crate::Transaction::from_bcs(&bytes).unwrap();
+        assert_eq!(transaction, parsed);
+    }
+
+    #[cfg(feature = "serde")]
+    #[proptest]
+    fn transaction_base64_roundtrip(transaction: crate::Transaction) {
+        let b64 = transaction.to_base64();
+        let parsed = crate::Transaction::from_base64(&b64).unwrap();
+        assert_eq!(transaction, parsed);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn transaction_from_base64_invalid() {
+        assert!(crate::Transaction::from_base64("not-valid-base64!!!").is_err());
+    }
+
+    #[cfg(feature = "serde")]
+    #[proptest]
+    fn transaction_digest_deterministic(transaction: crate::Transaction) {
+        let d1 = transaction.digest();
+        let d2 = transaction.digest();
+        assert_eq!(d1, d2);
+    }
 }

--- a/crates/iota-sdk-types/src/iota_names/name.rs
+++ b/crates/iota-sdk-types/src/iota_names/name.rs
@@ -336,4 +336,47 @@ mod tests {
         assert!(name.format(NameFormat::Dot) == "test.test.test.test.iota");
         assert!(name.format(NameFormat::At) == "test.test.test@test");
     }
+
+    #[test]
+    fn validate_label_min_length() {
+        assert!(validate_label("a").is_ok());
+    }
+
+    #[test]
+    fn validate_label_max_length() {
+        let label = "a".repeat(63);
+        assert!(validate_label(&label).is_ok());
+    }
+
+    #[test]
+    fn validate_label_over_max() {
+        let label = "a".repeat(64);
+        assert!(validate_label(&label).is_err());
+    }
+
+    #[test]
+    fn validate_label_empty() {
+        assert!(validate_label("").is_err());
+    }
+
+    #[test]
+    fn validate_label_uppercase_rejected() {
+        assert!(validate_label("ABC").is_err());
+    }
+
+    #[test]
+    fn validate_label_valid_chars() {
+        assert!(validate_label("abc123").is_ok());
+        assert!(validate_label("a-b").is_ok());
+    }
+
+    #[test]
+    fn validate_label_hyphen_at_start() {
+        assert!(validate_label("-abc").is_err());
+    }
+
+    #[test]
+    fn validate_label_hyphen_at_end() {
+        assert!(validate_label("abc-").is_err());
+    }
 }

--- a/crates/iota-sdk-types/src/object_id.rs
+++ b/crates/iota-sdk-types/src/object_id.rs
@@ -130,3 +130,111 @@ impl std::fmt::Display for ObjectId {
         self.to_canonical_string(true).fmt(f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn zero_constant() {
+        assert_eq!(ObjectId::ZERO.into_inner(), [0u8; 32]);
+    }
+
+    #[test]
+    fn system_constant() {
+        let mut expected = [0u8; 32];
+        expected[31] = 5;
+        assert_eq!(ObjectId::SYSTEM.into_inner(), expected);
+    }
+
+    #[test]
+    fn clock_constant() {
+        let mut expected = [0u8; 32];
+        expected[31] = 6;
+        assert_eq!(ObjectId::CLOCK.into_inner(), expected);
+    }
+
+    #[test]
+    fn from_hex_with_prefix() {
+        let id = ObjectId::from_hex("0x5").unwrap();
+        assert_eq!(id, ObjectId::SYSTEM);
+    }
+
+    #[test]
+    fn from_hex_without_prefix() {
+        let id = ObjectId::from_hex("6").unwrap();
+        assert_eq!(id, ObjectId::CLOCK);
+    }
+
+    #[test]
+    fn from_hex_full_length() {
+        let hex = "0x0000000000000000000000000000000000000000000000000000000000000005";
+        let id = ObjectId::from_hex(hex).unwrap();
+        assert_eq!(id, ObjectId::SYSTEM);
+    }
+
+    #[test]
+    fn from_hex_invalid() {
+        assert!(ObjectId::from_hex("0xGGGG").is_err());
+    }
+
+    #[test]
+    fn display_fromstr_roundtrip() {
+        let id = ObjectId::SYSTEM;
+        let s = id.to_string();
+        let parsed = ObjectId::from_str(&s).unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn from_address() {
+        let address = Address::from_hex("0x5").unwrap();
+        let id = ObjectId::from(address);
+        assert_eq!(id, ObjectId::SYSTEM);
+    }
+
+    #[test]
+    fn from_byte_array() {
+        let mut bytes = [0u8; 32];
+        bytes[31] = 6;
+        let id = ObjectId::from(bytes);
+        assert_eq!(id, ObjectId::CLOCK);
+    }
+
+    #[test]
+    fn into_vec_u8() {
+        let id = ObjectId::ZERO;
+        let v: Vec<u8> = id.into();
+        assert_eq!(v, vec![0u8; 32]);
+    }
+
+    #[test]
+    fn to_canonical_string_with_prefix() {
+        let id = ObjectId::SYSTEM;
+        let s = id.to_canonical_string(true);
+        assert!(s.starts_with("0x"));
+        assert_eq!(s.len(), 66); // "0x" + 64 hex chars
+    }
+
+    #[test]
+    fn to_canonical_string_without_prefix() {
+        let id = ObjectId::SYSTEM;
+        let s = id.to_canonical_string(false);
+        assert!(!s.starts_with("0x"));
+        assert_eq!(s.len(), 64);
+    }
+
+    #[test]
+    fn to_short_string_with_prefix() {
+        let id = ObjectId::SYSTEM;
+        assert_eq!(id.to_short_string(true), "0x5");
+    }
+
+    #[test]
+    fn to_short_string_without_prefix() {
+        let id = ObjectId::SYSTEM;
+        assert_eq!(id.to_short_string(false), "5");
+    }
+}

--- a/crates/iota-sdk-types/src/type_tag/mod.rs
+++ b/crates/iota-sdk-types/src/type_tag/mod.rs
@@ -678,3 +678,138 @@ impl std::str::FromStr for StructTag {
         parse::parse_struct_tag(s).map_err(|_| TypeParseError { source: s.into() })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_new_valid_alpha_start() {
+        assert!(Identifier::new("abc").is_ok());
+    }
+
+    #[test]
+    fn identifier_new_valid_underscore_then_char() {
+        assert!(Identifier::new("_abc").is_ok());
+    }
+
+    #[test]
+    fn identifier_new_invalid_empty() {
+        assert!(Identifier::new("").is_err());
+    }
+
+    #[test]
+    fn identifier_new_invalid_digit_start() {
+        assert!(Identifier::new("1abc").is_err());
+    }
+
+    #[test]
+    fn identifier_new_invalid_underscore_only() {
+        assert!(Identifier::new("_").is_err());
+    }
+
+    #[test]
+    fn identifier_new_invalid_special_chars() {
+        assert!(Identifier::new("abc!").is_err());
+    }
+
+    #[test]
+    fn identifier_max_length_boundary() {
+        let valid = "a".repeat(128);
+        assert!(Identifier::new(&valid).is_ok());
+
+        let invalid = "a".repeat(129);
+        assert!(Identifier::new(&invalid).is_err());
+    }
+
+    #[test]
+    fn identifier_is_valid_self() {
+        assert!(Identifier::is_valid("<SELF>"));
+    }
+
+    #[test]
+    fn identifier_display_fromstr_roundtrip() {
+        let ident = Identifier::new("hello_world").unwrap();
+        let s = ident.to_string();
+        let parsed: Identifier = s.parse().unwrap();
+        assert_eq!(ident, parsed);
+    }
+
+    #[test]
+    fn struct_tag_coin_type_opt_positive() {
+        let coin = StructTag::new_coin(TypeTag::Struct(Box::new(StructTag::new_iota_coin_type())));
+        assert!(coin.coin_type_opt().is_some());
+    }
+
+    #[test]
+    fn struct_tag_coin_type_opt_wrong_module() {
+        let tag = StructTag::new(
+            Address::FRAMEWORK,
+            Identifier::new("not_coin").unwrap(),
+            Identifier::new("Coin").unwrap(),
+            vec![TypeTag::U8],
+        );
+        assert!(tag.coin_type_opt().is_none());
+    }
+
+    #[test]
+    fn struct_tag_coin_type_opt_wrong_name() {
+        let tag = StructTag::new(
+            Address::FRAMEWORK,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("NotCoin").unwrap(),
+            vec![TypeTag::U8],
+        );
+        assert!(tag.coin_type_opt().is_none());
+    }
+
+    #[test]
+    fn struct_tag_coin_type_opt_no_params() {
+        let tag = StructTag::new(
+            Address::FRAMEWORK,
+            Identifier::new("coin").unwrap(),
+            Identifier::new("Coin").unwrap(),
+            vec![],
+        );
+        assert!(tag.coin_type_opt().is_none());
+    }
+
+    #[test]
+    fn type_tag_canonical_string_primitives() {
+        assert_eq!(TypeTag::U8.to_canonical_string(true), "u8");
+        assert_eq!(TypeTag::U64.to_canonical_string(true), "u64");
+        assert_eq!(TypeTag::Bool.to_canonical_string(true), "bool");
+        assert_eq!(TypeTag::Address.to_canonical_string(true), "address");
+    }
+
+    #[test]
+    fn type_tag_canonical_string_vector() {
+        let vt = TypeTag::Vector(Box::new(TypeTag::U8));
+        assert_eq!(vt.to_canonical_string(true), "vector<u8>");
+    }
+
+    #[test]
+    fn type_tag_canonical_string_struct() {
+        let st = StructTag::new_iota_coin_type();
+        let tt = TypeTag::Struct(Box::new(st));
+        let s = tt.to_canonical_string(true);
+        assert!(s.contains("0x"));
+        assert!(s.contains("::iota::IOTA"));
+    }
+
+    #[test]
+    fn struct_tag_display_fromstr_roundtrip() {
+        let tag = StructTag::new_gas_coin();
+        let s = tag.to_string();
+        let parsed: StructTag = s.parse().unwrap();
+        assert_eq!(tag, parsed);
+    }
+
+    #[test]
+    fn struct_tag_canonical_string_without_prefix() {
+        let tag = StructTag::new_iota_coin_type();
+        let s = tag.to_canonical_string(false);
+        assert!(!s.starts_with("0x"));
+        assert!(s.contains("::iota::IOTA"));
+    }
+}


### PR DESCRIPTION
Resolves
 #504 

Adds unit tests across iota-sdk-types and iota-sdk-crypto targeting uncovered validation, parsing, error paths, and serialization logic.

iota-sdk-types: intent constructors and roundtrips, object_id conversions, multisig is_valid() rules, digest parsing errors, identifier validation, transaction BCS/base64 roundtrips, iota_names label validation.

iota-sdk-crypto: bitmap indices, multisig aggregator sign/verify roundtrip, ed25519 key validation and PEM/DER roundtrips, flagged bytes and bech32 encoding, mnemonic generation.