### PR TITLE
feat(types): Skip validation of identifiers in `MoveCall` for BCS

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -1472,11 +1472,7 @@ pub struct MakeMoveVector {
     ///
     /// This is required to be set when the type can't be inferred, for example
     /// when the set of provided arguments are all pure input values.
-    #[cfg_attr(
-        feature = "serde",
-        serde(rename = "type"),
-        serde(deserialize_with = "serialization::deserialize_type_tag_unchecked")
-    )]
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
     pub type_: Option<TypeTag>,
     /// The set individual elements to build the vector with
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -1644,10 +1644,6 @@ pub struct MoveCall {
     )]
     pub module: Identifier,
     /// The function to be called.
-    #[cfg_attr(
-        feature = "serde",
-        serde(deserialize_with = "serialization::deserialize_ident_unchecked")
-    )]
     pub function: Identifier,
     /// The type arguments to the function.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -1472,7 +1472,11 @@ pub struct MakeMoveVector {
     ///
     /// This is required to be set when the type can't be inferred, for example
     /// when the set of provided arguments are all pure input values.
-    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(rename = "type"),
+        serde(deserialize_with = "serialization::deserialize_type_tag_unchecked")
+    )]
     pub type_: Option<TypeTag>,
     /// The set individual elements to build the vector with
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]
@@ -1638,8 +1642,16 @@ pub struct MoveCall {
     /// The package containing the module and function.
     pub package: ObjectId,
     /// The specific module in the package containing the function.
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "serialization::deserialize_ident_unchecked")
+    )]
     pub module: Identifier,
     /// The function to be called.
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "serialization::deserialize_ident_unchecked")
+    )]
     pub function: Identifier,
     /// The type arguments to the function.
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(0..=2).lift()))]

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
 use super::Argument;
-use crate::{Address, Identifier, ObjectId, ObjectReference, StructTag, TypeTag};
+use crate::{Identifier, ObjectId, ObjectReference};
 
 mod transaction_kind {
     use super::*;
@@ -1051,78 +1051,6 @@ mod transaction_expiration {
         ) -> schemars::schema::Schema {
             ReadableTransactionExpiration::json_schema(generator)
         }
-    }
-}
-
-/// Deserialize a `TypeTag` without validating the identifiers in struct tags.
-/// This is used for deserializing type tags in `MoveCall` arguments, where BCS
-/// bytes could contain invalid identifiers but we still want to be able to
-/// deserialize them and let the move VM handle the validation.
-pub(super) fn deserialize_type_tag_unchecked<'de, D>(d: D) -> Result<Option<TypeTag>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::Deserialize;
-
-    if d.is_human_readable() {
-        <Option<TypeTag>>::deserialize(d)
-    } else {
-        #[derive(Deserialize)]
-        enum UncheckedTypeTag {
-            U8,
-            U64,
-            U128,
-            Bool,
-            Address,
-            Signer,
-            Vector(Box<UncheckedTypeTag>),
-            Struct(Box<UncheckedStructTag>),
-            U16,
-            U32,
-            U256,
-        }
-
-        #[derive(Deserialize)]
-        #[serde(rename = "StructTag")]
-        struct UncheckedStructTag {
-            address: Address,
-            #[serde(deserialize_with = "deserialize_ident_unchecked")]
-            module: Identifier,
-            #[serde(deserialize_with = "deserialize_ident_unchecked")]
-            name: Identifier,
-            type_params: Vec<UncheckedTypeTag>,
-        }
-
-        impl From<UncheckedTypeTag> for TypeTag {
-            fn from(t: UncheckedTypeTag) -> Self {
-                match t {
-                    UncheckedTypeTag::U8 => TypeTag::U8,
-                    UncheckedTypeTag::U64 => TypeTag::U64,
-                    UncheckedTypeTag::U128 => TypeTag::U128,
-                    UncheckedTypeTag::Bool => TypeTag::Bool,
-                    UncheckedTypeTag::Address => TypeTag::Address,
-                    UncheckedTypeTag::Signer => TypeTag::Signer,
-                    UncheckedTypeTag::Vector(elem) => TypeTag::Vector(Box::new((*elem).into())),
-                    UncheckedTypeTag::Struct(st) => TypeTag::Struct(Box::new((*st).into())),
-                    UncheckedTypeTag::U16 => TypeTag::U16,
-                    UncheckedTypeTag::U32 => TypeTag::U32,
-                    UncheckedTypeTag::U256 => TypeTag::U256,
-                }
-            }
-        }
-
-        impl From<UncheckedStructTag> for StructTag {
-            fn from(st: UncheckedStructTag) -> Self {
-                StructTag {
-                    address: st.address,
-                    module: st.module.into(),
-                    name: st.name.into(),
-                    type_params: st.type_params.into_iter().map(Into::into).collect(),
-                }
-            }
-        }
-
-        <Option<UncheckedTypeTag>>::deserialize(d).map(|opt| opt.map(Into::into))
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -1055,10 +1055,9 @@ mod transaction_expiration {
 }
 
 /// Deserialize an `Identifier` without validating that it is a valid Move
-/// identifier. This is used for deserializing type tags in `MakeMoveVector`
-/// type arguments, where BCS bytes could contain invalid identifiers but we
-/// still want to be able to deserialize them and let the move VM handle the
-/// validation.
+/// identifier. This is used for deserializing type tags in `MoveCall` commands,
+/// where BCS bytes could contain invalid identifiers but we still want to be
+/// able to deserialize them and let the move VM handle the validation.
 pub(super) fn deserialize_ident_unchecked<'de, D>(d: D) -> Result<Identifier, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -1055,9 +1055,10 @@ mod transaction_expiration {
 }
 
 /// Deserialize an `Identifier` without validating that it is a valid Move
-/// identifier. This is used for deserializing type tags in `MoveCall` commands,
-/// where BCS bytes could contain invalid identifiers but we still want to be
-/// able to deserialize them and let the move VM handle the validation.
+/// identifier. This is used for deserializing the module in `MoveCall`
+/// commands, where BCS bytes could contain invalid identifiers but we still
+/// want to be able to deserialize them and let the move VM handle the
+/// validation.
 pub(super) fn deserialize_ident_unchecked<'de, D>(d: D) -> Result<Identifier, D::Error>
 where
     D: serde::Deserializer<'de>,

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
 use super::Argument;
-use crate::{ObjectId, ObjectReference};
+use crate::{Address, Identifier, ObjectId, ObjectReference, StructTag, TypeTag};
 
 mod transaction_kind {
     use super::*;
@@ -1051,6 +1051,95 @@ mod transaction_expiration {
         ) -> schemars::schema::Schema {
             ReadableTransactionExpiration::json_schema(generator)
         }
+    }
+}
+
+/// Deserialize a `TypeTag` without validating the identifiers in struct tags.
+/// This is used for deserializing type tags in `MoveCall` arguments, where BCS
+/// bytes could contain invalid identifiers but we still want to be able to
+/// deserialize them and let the move VM handle the validation.
+pub(super) fn deserialize_type_tag_unchecked<'de, D>(d: D) -> Result<Option<TypeTag>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+
+    if d.is_human_readable() {
+        <Option<TypeTag>>::deserialize(d)
+    } else {
+        #[derive(Deserialize)]
+        enum UncheckedTypeTag {
+            U8,
+            U64,
+            U128,
+            Bool,
+            Address,
+            Signer,
+            Vector(Box<UncheckedTypeTag>),
+            Struct(Box<UncheckedStructTag>),
+            U16,
+            U32,
+            U256,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(rename = "StructTag")]
+        struct UncheckedStructTag {
+            address: Address,
+            #[serde(deserialize_with = "deserialize_ident_unchecked")]
+            module: Identifier,
+            #[serde(deserialize_with = "deserialize_ident_unchecked")]
+            name: Identifier,
+            type_params: Vec<UncheckedTypeTag>,
+        }
+
+        impl From<UncheckedTypeTag> for TypeTag {
+            fn from(t: UncheckedTypeTag) -> Self {
+                match t {
+                    UncheckedTypeTag::U8 => TypeTag::U8,
+                    UncheckedTypeTag::U64 => TypeTag::U64,
+                    UncheckedTypeTag::U128 => TypeTag::U128,
+                    UncheckedTypeTag::Bool => TypeTag::Bool,
+                    UncheckedTypeTag::Address => TypeTag::Address,
+                    UncheckedTypeTag::Signer => TypeTag::Signer,
+                    UncheckedTypeTag::Vector(elem) => TypeTag::Vector(Box::new((*elem).into())),
+                    UncheckedTypeTag::Struct(st) => TypeTag::Struct(Box::new((*st).into())),
+                    UncheckedTypeTag::U16 => TypeTag::U16,
+                    UncheckedTypeTag::U32 => TypeTag::U32,
+                    UncheckedTypeTag::U256 => TypeTag::U256,
+                }
+            }
+        }
+
+        impl From<UncheckedStructTag> for StructTag {
+            fn from(st: UncheckedStructTag) -> Self {
+                StructTag {
+                    address: st.address,
+                    module: st.module.into(),
+                    name: st.name.into(),
+                    type_params: st.type_params.into_iter().map(Into::into).collect(),
+                }
+            }
+        }
+
+        <Option<UncheckedTypeTag>>::deserialize(d).map(|opt| opt.map(Into::into))
+    }
+}
+
+/// Deserialize an `Identifier` without validating that it is a valid Move
+/// identifier. This is used for deserializing type tags in `MakeMoveVector`
+/// type arguments, where BCS bytes could contain invalid identifiers but we
+/// still want to be able to deserialize them and let the move VM handle the
+/// validation.
+pub(super) fn deserialize_ident_unchecked<'de, D>(d: D) -> Result<Identifier, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    if d.is_human_readable() {
+        serde::Deserialize::deserialize(d)
+    } else {
+        let s: String = serde::Deserialize::deserialize(d)?;
+        Ok(Identifier::new_unchecked(s))
     }
 }
 


### PR DESCRIPTION
## Description

Skips validation of Identifiers in BCS bytes for `MoveCall` commands. This is necessary because these fields were not previously validated and is invalid in some failed transactions on the network.