### PR TITLE
fix: release go with v prefixed tag

### DIFF
--- a/.github/workflows/go_publish.yml
+++ b/.github/workflows/go_publish.yml
@@ -134,7 +134,7 @@ jobs:
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add .
-          git commit -m "Update Go SDK to version ${{ steps.set-version.outputs.version }}"
+          git commit -m "Update Go SDK to version v${{ steps.set-version.outputs.version }}"
           git push
           git tag v${{ steps.set-version.outputs.version }} -m "v${{ steps.set-version.outputs.version }}"
           git push --tags

--- a/.github/workflows/go_publish.yml
+++ b/.github/workflows/go_publish.yml
@@ -122,11 +122,12 @@ jobs:
         id: set-version
         run: |
           if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+            version="${{ inputs.version }}"
           else
             version=$(echo "${{ github.event.release.tag_name }}" | sed -nr 's|iota-go-sdk-v(.*)|\1|p')
-            echo "version=$version" >> $GITHUB_OUTPUT
           fi
+          version="${version#v}" # Remove leading 'v' if present
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Tag the Go SDK
         run: |
@@ -135,5 +136,5 @@ jobs:
           git add .
           git commit -m "Update Go SDK to version ${{ steps.set-version.outputs.version }}"
           git push
-          git tag ${{ steps.set-version.outputs.version }} -m "${{ steps.set-version.outputs.version }}"
+          git tag v${{ steps.set-version.outputs.version }} -m "v${{ steps.set-version.outputs.version }}"
           git push --tags


### PR DESCRIPTION
As per https://go.dev/ref/mod#versions

> Each version starts with the letter v, followed by a semantic version

We are currently not https://github.com/iotaledger/iota-sdk-go/tags