### PR TITLE
fix(types): Rename `BinaryEndOfEpochTransactionKindRef` for serde

### DIFF
--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -196,6 +196,7 @@ mod end_of_epoch {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "EndOfEpochTransactionKind")]
     enum BinaryEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),


### PR DESCRIPTION
## Description

Renames the `BinaryEndOfEpochTransactionKindRef` to `EndOfEpochTransactionKind` for serialization.