### PR TITLE
feat(iota-sdk-types): add MoveObjectType

### DIFF
--- a/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
+++ b/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
@@ -275,6 +275,24 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_clone_address(void*_Nonnull ptr, RustCallSt
 void uniffi_iota_sdk_ffi_fn_free_address(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_AUTHENTICATOR_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_authenticator_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_CLOCK
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_clock(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_DENY_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_DENY_LIST
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_deny_list(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FRAMEWORK
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FRAMEWORK
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_framework(RustCallStatus *_Nonnull out_status
@@ -291,9 +309,54 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_from_bytes(RustBuffer b
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_from_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENERATE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENERATE
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_generate(RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_from_prefixed_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_SHORT_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_from_prefixed_short_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_FROM_SHORT_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_from_short_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENESIS_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENESIS_BRIDGE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_genesis_bridge(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENESIS_IOTA_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_GENESIS_IOTA_BRIDGE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_genesis_iota_bridge(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_MAX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_MAX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_max(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_RANDOM
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_random(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_RANDOMNESS_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_RANDOMNESS_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_randomness_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STARDUST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_STARDUST
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_stardust(RustCallStatus *_Nonnull out_status
     
 );
 #endif
@@ -309,10 +372,26 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_system(RustCallStatus *
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_SYSTEM_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_system_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_ZERO
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_ADDRESS_ZERO
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_address_zero(RustCallStatus *_Nonnull out_status
     
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_address_next_lexicographical(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL_OPT
+RustBuffer uniffi_iota_sdk_ffi_fn_method_address_next_lexicographical_opt(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_BYTES
@@ -330,9 +409,19 @@ RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_canonical_string(void*_Nonnu
 RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_SHORT_STRING
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_SHORT_STRING
-RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_short_string(void*_Nonnull ptr, int8_t with_prefix, RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_RAW_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_RAW_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_raw_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_RAW_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_RAW_SHORT_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_raw_short_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_TO_SHORT_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_address_to_short_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_ADDRESS_UNIFFI_TRAIT_DEBUG
@@ -1519,15 +1608,35 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_digest_from_base58(RustBuffer b
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_digest_from_bytes(RustBuffer bytes, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_DIGEST_GENERATE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_DIGEST_GENERATE
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_digest_generate(RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_DIGEST_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_DIGEST_RANDOM
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_digest_random(RustCallStatus *_Nonnull out_status
     
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_ALIVE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_ALIVE
+int8_t uniffi_iota_sdk_ffi_fn_method_digest_is_object_alive(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_DELETED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_DELETED
+int8_t uniffi_iota_sdk_ffi_fn_method_digest_is_object_deleted(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_WRAPPED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_IS_OBJECT_WRAPPED
+int8_t uniffi_iota_sdk_ffi_fn_method_digest_is_object_wrapped(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL
 void*_Nonnull uniffi_iota_sdk_ffi_fn_method_digest_next_lexicographical(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL_OPT
+RustBuffer uniffi_iota_sdk_ffi_fn_method_digest_next_lexicographical_opt(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_DIGEST_TO_BASE58
@@ -2191,7 +2300,7 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_method_genesisobject_owner(void*_Nonnull pt
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GENESISOBJECT_VERSION
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GENESISOBJECT_VERSION
-uint64_t uniffi_iota_sdk_ffi_fn_method_genesisobject_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_genesisobject_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_GENESISOBJECT_UNIFFI_TRAIT_DEBUG
@@ -2568,9 +2677,417 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_clone_identifier(void*_Nonnull ptr, RustCal
 void uniffi_iota_sdk_ffi_fn_free_identifier(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ADDRESS_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ADDRESS_KEY
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_address_key(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ASCII_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ASCII_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_ascii_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_authenticator_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_authenticator_state_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BAG
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_bag(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BAG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BAG_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_bag_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BALANCE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BALANCE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_balance(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BALANCE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_BALANCE_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_balance_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CLOCK
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_clock(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CLOCK_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CLOCK_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_clock_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_coin(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_manager(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_manager_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_METADATA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_METADATA
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_metadata(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_COIN_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_config(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG_KEY
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_config_key(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_CONFIG_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_config_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DENY_LIST_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DENY_LIST_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_deny_list_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DISPLAY_CREATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DISPLAY_CREATED
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_display_created(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DISPLAY_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DISPLAY_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_display_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DYNAMIC_FIELD_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DYNAMIC_FIELD_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_dynamic_field_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DYNAMIC_OBJECT_FIELD_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_DYNAMIC_OBJECT_FIELD_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_dynamic_object_field_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_FIELD
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_field(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_GLOBAL_PAUSE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_GLOBAL_PAUSE_KEY
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_global_pause_key(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_ID
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_id(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_ADMIN_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_ADMIN_CAP
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_admin_cap(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE_INNER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE_INNER_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_state_inner_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_IOTA_TREASURY_CAP
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_treasury_cap(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NAME
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NAME
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_name(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NAME_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NAME_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_name_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_NEW
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_new(RustBuffer identifier, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_object_bag(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_object_bag_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OBJECT_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_object_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OPTION
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_option(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OPTION_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_OPTION_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_option_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_PACKAGE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_PACKAGE_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_package_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_PAY_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_PAY_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_pay_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RANDOM
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_random(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RANDOM_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RANDOM_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_random_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RECEIVING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_RECEIVING
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_receiving(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SETTING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SETTING
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_setting(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STAKED_IOTA
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_staked_iota(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STAKING_POOL_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STAKING_POOL_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_staking_pool_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STRING
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_string(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STRING_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_STRING_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_string_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SYSTEM_ADMIN_CAP_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SYSTEM_ADMIN_CAP_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_system_admin_cap_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SYSTEM_EPOCH_INFO_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_SYSTEM_EPOCH_INFO_EVENT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_system_epoch_info_event(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIME_LOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIME_LOCK
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_time_lock(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCK_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCK_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_timelock_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKED_IOTA
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_timelocked_staked_iota(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKING_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKING_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_timelocked_staking_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TRANSFER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TRANSFER_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_transfer_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TREASURY_CAP
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_treasury_cap(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_tx_context(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_tx_context_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UID
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_uid(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_CAP
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_cap(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_RECEIPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_RECEIPT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_receipt(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_TICKET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_UPGRADE_TICKET
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_ticket(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_URL_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_URL_MODULE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_url_module(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_URL_TYPE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_URL_TYPE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_url_type(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_VERSION_UPDATED
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_version_updated(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_WRAPPER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_IDENTIFIER_WRAPPER
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_identifier_wrapper(RustCallStatus *_Nonnull out_status
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_IDENTIFIER_AS_STR
@@ -2630,7 +3147,7 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_input_new_receiving(RustBuffer 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_INPUT_NEW_SHARED
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_INPUT_NEW_SHARED
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_input_new_shared(void*_Nonnull object_id, uint64_t initial_shared_version, int8_t mutable, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_input_new_shared(void*_Nonnull object_id, void*_Nonnull initial_shared_version, int8_t mutable, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_INPUT_UNIFFI_TRAIT_DEBUG
@@ -2835,6 +3352,11 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movearg_address(void*_Nonnull a
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movearg_address_from_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_SHORT_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movearg_address_from_short_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEARG_ADDRESS_VEC
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEARG_ADDRESS_VEC
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movearg_address_vec(RustBuffer addresses, RustCallStatus *_Nonnull out_status
@@ -2967,7 +3489,7 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_moveauthenticator_new_immutable
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEAUTHENTICATOR_NEW_SHARED
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEAUTHENTICATOR_NEW_SHARED
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_moveauthenticator_new_shared(RustBuffer call_args, RustBuffer type_args, void*_Nonnull object_to_authenticate, uint64_t initial_shared_version, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_moveauthenticator_new_shared(RustBuffer call_args, RustBuffer type_args, void*_Nonnull object_to_authenticate, void*_Nonnull initial_shared_version, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_MOVEAUTHENTICATOR_ADDRESS
@@ -3127,7 +3649,7 @@ void uniffi_iota_sdk_ffi_fn_free_movepackage(void*_Nonnull ptr, RustCallStatus *
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEPACKAGE_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_MOVEPACKAGE_NEW
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movepackage_new(void*_Nonnull id, uint64_t version, RustBuffer modules, RustBuffer type_origin_table, RustBuffer linkage_table, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_movepackage_new(void*_Nonnull id, void*_Nonnull version, RustBuffer modules, RustBuffer type_origin_table, RustBuffer linkage_table, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_MOVEPACKAGE_ID
@@ -3152,7 +3674,7 @@ RustBuffer uniffi_iota_sdk_ffi_fn_method_movepackage_type_origin_table(void*_Non
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_MOVEPACKAGE_VERSION
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_MOVEPACKAGE_VERSION
-uint64_t uniffi_iota_sdk_ffi_fn_method_movepackage_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_movepackage_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_MOVEPACKAGE_UNIFFI_TRAIT_DEBUG
@@ -3909,7 +4431,7 @@ uint64_t uniffi_iota_sdk_ffi_fn_method_object_storage_rebate(void*_Nonnull ptr, 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECT_VERSION
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECT_VERSION
-uint64_t uniffi_iota_sdk_ffi_fn_method_object_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_object_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECT_UNIFFI_TRAIT_DEBUG
@@ -3997,15 +4519,33 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_clone_objectid(void*_Nonnull ptr, RustCallS
 void uniffi_iota_sdk_ffi_fn_free_objectid(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_AUTHENTICATOR_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_authenticator_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_CLOCK
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_CLOCK
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_clock(RustCallStatus *_Nonnull out_status
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_DENY_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_DENY_LIST
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_deny_list(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_DERIVE_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_DERIVE_ID
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_derive_id(void*_Nonnull digest, uint64_t count, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FRAMEWORK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FRAMEWORK
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_framework(RustCallStatus *_Nonnull out_status
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_BYTES
@@ -4018,9 +4558,66 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_from_bytes(RustBuffer 
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_from_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_from_prefixed_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_SHORT_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_from_prefixed_short_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_FROM_SHORT_HEX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_from_short_hex(RustBuffer hex, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_GENESIS_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_GENESIS_BRIDGE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_genesis_bridge(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_GENESIS_IOTA_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_GENESIS_IOTA_BRIDGE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_genesis_iota_bridge(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_MAX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_MAX
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_max(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_RANDOMNESS_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_RANDOMNESS_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_randomness_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_STARDUST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_STARDUST
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_stardust(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_STD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_STD
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_std(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_SYSTEM
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_SYSTEM
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_system(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OBJECTID_SYSTEM_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_system_state(RustCallStatus *_Nonnull out_status
     
 );
 #endif
@@ -4033,6 +4630,16 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_objectid_zero(RustCallStatus *_
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_DERIVE_DYNAMIC_CHILD_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_DERIVE_DYNAMIC_CHILD_ID
 void*_Nonnull uniffi_iota_sdk_ffi_fn_method_objectid_derive_dynamic_child_id(void*_Nonnull ptr, void*_Nonnull key_type_tag, RustBuffer key_bytes, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_objectid_next_lexicographical(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL_OPT
+RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_next_lexicographical_opt(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_ADDRESS
@@ -4055,9 +4662,19 @@ RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_canonical_string(void*_Nonn
 RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_SHORT_STRING
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_SHORT_STRING
-RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_short_string(void*_Nonnull ptr, int8_t with_prefix, RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_RAW_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_RAW_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_raw_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_RAW_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_RAW_SHORT_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_raw_short_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_TO_SHORT_HEX
+RustBuffer uniffi_iota_sdk_ffi_fn_method_objectid_to_short_hex(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OBJECTID_UNIFFI_TRAIT_DEBUG
@@ -4174,7 +4791,12 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(void*_Nonnull 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OWNER_NEW_SHARED
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_OWNER_NEW_SHARED
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(uint64_t version, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(void*_Nonnull version, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
@@ -4199,7 +4821,7 @@ RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_as_object_opt(void*_Nonnull ptr, 
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_SHARED
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_SHARED
-uint64_t uniffi_iota_sdk_ffi_fn_method_owner_as_shared(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_owner_as_shared(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_SHARED_OPT
@@ -5719,6 +6341,18 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_ascii_string(Rust
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_AUTHENTICATOR_STATE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_authenticator_state(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_BAG
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_bag(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_BALANCE
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_BALANCE
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_balance(void*_Nonnull type_tag, RustCallStatus *_Nonnull out_status
@@ -5779,14 +6413,25 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_deny_list_global_
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_display_created(void*_Nonnull struct_tag, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DISPLAY_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DISPLAY_VERSION_UPDATED
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_display_version_updated(void*_Nonnull struct_tag, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_FIELD
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_dynamic_field(void*_Nonnull key, void*_Nonnull value, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_OBJECT_FIELD_WRAPPER
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_OBJECT_FIELD_WRAPPER
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_dynamic_object_field_wrapper(void*_Nonnull type_tag, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_FIELD
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_FIELD
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_field(void*_Nonnull key, void*_Nonnull value, RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_GAS
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_gas(RustCallStatus *_Nonnull out_status
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_GAS_COIN
@@ -5798,12 +6443,6 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_gas_coin(RustCall
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_ID
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_id(RustCallStatus *_Nonnull out_status
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_IOTA_COIN_TYPE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_IOTA_COIN_TYPE
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_iota_coin_type(RustCallStatus *_Nonnull out_status
     
 );
 #endif
@@ -5828,6 +6467,23 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_iota_treasury_cap
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_NAME
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_NAME
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_name(void*_Nonnull address, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_OBJECT_BAG
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_object_bag(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_OPTION
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_option(void*_Nonnull type_tag, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_RANDOM
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_random(RustCallStatus *_Nonnull out_status
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_STAKED_IOTA
@@ -5870,6 +6526,12 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_transfer_receivin
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_treasury_cap(void*_Nonnull struct_tag, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_TX_CONTEXT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_tx_context(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_UID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_UID
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_uid(RustCallStatus *_Nonnull out_status
@@ -5894,9 +6556,10 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_upgrade_ticket(Ru
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_VERSION_UPDATED
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_VERSION_UPDATED
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_version_updated(void*_Nonnull struct_tag, RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_URL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_STRUCTTAG_NEW_URL
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_structtag_new_url(RustCallStatus *_Nonnull out_status
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_ADDRESS
@@ -5912,6 +6575,206 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_method_structtag_coin_type(void*_Nonnull pt
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_COIN_TYPE_OPT
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_COIN_TYPE_OPT
 RustBuffer uniffi_iota_sdk_ffi_fn_method_structtag_coin_type_opt(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_ASCII_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_ASCII_STRING
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_ascii_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_AUTHENTICATOR_STATE
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_authenticator_state(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_BAG
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_bag(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_BALANCE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_BALANCE
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_balance(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CLOCK
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_clock(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_coin(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN_MANAGER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN_MANAGER
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_coin_manager(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN_METADATA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_COIN_METADATA
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_coin_metadata(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CONFIG
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_config(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CONFIG_SETTING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_CONFIG_SETTING
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_config_setting(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_ADDRESS_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_ADDRESS_KEY
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_address_key(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_CONFIG_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_CONFIG_KEY
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_config_key(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_GLOBAL_PAUSE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DENY_LIST_GLOBAL_PAUSE_KEY
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_global_pause_key(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DISPLAY_CREATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DISPLAY_CREATED
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_display_created(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DISPLAY_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DISPLAY_VERSION_UPDATED
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_display_version_updated(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DYNAMIC_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DYNAMIC_FIELD
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_dynamic_field(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DYNAMIC_OBJECT_FIELD_WRAPPER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_DYNAMIC_OBJECT_FIELD_WRAPPER
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_dynamic_object_field_wrapper(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_GAS
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_gas(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_GAS_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_GAS_COIN
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_gas_coin(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_ID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_ID
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_id(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_ADMIN_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_ADMIN_CAP
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_system_admin_cap(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_STATE
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_system_state(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_IOTA_TREASURY_CAP
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_treasury_cap(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_NAME
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_NAME
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_name(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_OBJECT_BAG
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_object_bag(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_OPTION
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_option(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_RANDOM
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_random(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_STAKED_IOTA
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_staked_iota(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_STRING
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_string(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_SYSTEM_EPOCH_INFO_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_SYSTEM_EPOCH_INFO_EVENT
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_system_epoch_info_event(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TIME_LOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TIME_LOCK
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_time_lock(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TIMELOCKED_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TIMELOCKED_STAKED_IOTA
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_timelocked_staked_iota(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TRANSFER_RECEIVING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TRANSFER_RECEIVING
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_transfer_receiving(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TREASURY_CAP
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_treasury_cap(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_TX_CONTEXT
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_tx_context(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UID
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_uid(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_CAP
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_cap(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_RECEIPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_RECEIPT
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_receipt(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_TICKET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_UPGRADE_TICKET
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_ticket(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_URL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_IS_URL
+int8_t uniffi_iota_sdk_ffi_fn_method_structtag_is_url(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_STRUCTTAG_MODULE
@@ -5971,7 +6834,7 @@ void uniffi_iota_sdk_ffi_fn_free_systempackage(void*_Nonnull ptr, RustCallStatus
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_SYSTEMPACKAGE_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_SYSTEMPACKAGE_NEW
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_systempackage_new(uint64_t version, RustBuffer modules, RustBuffer dependencies, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_systempackage_new(void*_Nonnull version, RustBuffer modules, RustBuffer dependencies, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_SYSTEMPACKAGE_DEPENDENCIES
@@ -5986,7 +6849,7 @@ RustBuffer uniffi_iota_sdk_ffi_fn_method_systempackage_modules(void*_Nonnull ptr
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_SYSTEMPACKAGE_VERSION
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_SYSTEMPACKAGE_VERSION
-uint64_t uniffi_iota_sdk_ffi_fn_method_systempackage_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_systempackage_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_SYSTEMPACKAGE_UNIFFI_TRAIT_DEBUG
@@ -7182,6 +8045,96 @@ int8_t uniffi_iota_sdk_ffi_fn_method_validatorsignature_uniffi_trait_eq_eq(void*
 int8_t uniffi_iota_sdk_ffi_fn_method_validatorsignature_uniffi_trait_eq_ne(void*_Nonnull ptr, void*_Nonnull other, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_VERSION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_VERSION
+void*_Nonnull uniffi_iota_sdk_ffi_fn_clone_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FREE_VERSION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_FREE_VERSION
+void uniffi_iota_sdk_ffi_fn_free_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_CANCELLED_READ
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_CANCELLED_READ
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_cancelled_read(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_congested_prior_to_gas_price_feedback(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_FROM_U64
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_FROM_U64
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_from_u64(uint64_t value, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_LAMPORT_INCREMENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_LAMPORT_INCREMENT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_lamport_increment(RustBuffer inputs, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_MAX_VALID_EXCL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_MAX_VALID_EXCL
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_max_valid_excl(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_MIN_VALID_INCL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_MIN_VALID_INCL
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_min_valid_incl(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_NEW_CONGESTED_WITH_SUGGESTED_GAS_PRICE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_NEW_CONGESTED_WITH_SUGGESTED_GAS_PRICE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_new_congested_with_suggested_gas_price(uint64_t suggested_gas_price, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_RANDOMNESS_UNAVAILABLE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSION_RANDOMNESS_UNAVAILABLE
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_version_randomness_unavailable(RustCallStatus *_Nonnull out_status
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_AS_U64
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_AS_U64
+uint64_t uniffi_iota_sdk_ffi_fn_method_version_as_u64(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_GET_CONGESTED_VERSION_SUGGESTED_GAS_PRICE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_GET_CONGESTED_VERSION_SUGGESTED_GAS_PRICE
+uint64_t uniffi_iota_sdk_ffi_fn_method_version_get_congested_version_suggested_gas_price(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_CANCELLED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_CANCELLED
+int8_t uniffi_iota_sdk_ffi_fn_method_version_is_cancelled(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_CONGESTED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_CONGESTED
+int8_t uniffi_iota_sdk_ffi_fn_method_version_is_congested(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_VALID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_IS_VALID
+int8_t uniffi_iota_sdk_ffi_fn_method_version_is_valid(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_NEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_NEXT
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_version_next(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_PREVIOUS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSION_PREVIOUS
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_version_previous(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_VERSIONASSIGNMENT
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CLONE_VERSIONASSIGNMENT
 void*_Nonnull uniffi_iota_sdk_ffi_fn_clone_versionassignment(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -7194,7 +8147,7 @@ void uniffi_iota_sdk_ffi_fn_free_versionassignment(void*_Nonnull ptr, RustCallSt
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSIONASSIGNMENT_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_CONSTRUCTOR_VERSIONASSIGNMENT_NEW
-void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_versionassignment_new(void*_Nonnull object_id, uint64_t version, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_versionassignment_new(void*_Nonnull object_id, void*_Nonnull version, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSIONASSIGNMENT_OBJECT_ID
@@ -7204,7 +8157,7 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_method_versionassignment_object_id(void*_No
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSIONASSIGNMENT_VERSION
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSIONASSIGNMENT_VERSION
-uint64_t uniffi_iota_sdk_ffi_fn_method_versionassignment_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+void*_Nonnull uniffi_iota_sdk_ffi_fn_method_versionassignment_version(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_VERSIONASSIGNMENT_UNIFFI_TRAIT_DEBUG
@@ -12605,6 +13558,18 @@ uint16_t uniffi_iota_sdk_ffi_checksum_func_zk_login_public_identifier_to_json(vo
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL
+uint16_t uniffi_iota_sdk_ffi_checksum_method_address_next_lexicographical(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_NEXT_LEXICOGRAPHICAL_OPT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_address_next_lexicographical_opt(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_BYTES
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_BYTES
 uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_bytes(void
@@ -12623,9 +13588,21 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_hex(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_SHORT_STRING
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_SHORT_STRING
-uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_short_string(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_RAW_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_RAW_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_raw_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_RAW_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_RAW_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_raw_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_ADDRESS_TO_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_address_to_short_hex(void
     
 );
 #endif
@@ -13265,9 +14242,33 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_consensusdeterminedversionassignmen
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_ALIVE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_ALIVE
+uint16_t uniffi_iota_sdk_ffi_checksum_method_digest_is_object_alive(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_DELETED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_DELETED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_digest_is_object_deleted(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_WRAPPED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_IS_OBJECT_WRAPPED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_digest_is_object_wrapped(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL
 uint16_t uniffi_iota_sdk_ffi_checksum_method_digest_next_lexicographical(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_DIGEST_NEXT_LEXICOGRAPHICAL_OPT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_digest_next_lexicographical_opt(void
     
 );
 #endif
@@ -14471,6 +15472,18 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_derive_dynamic_child_id(vo
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL
+uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_next_lexicographical(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL_OPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_NEXT_LEXICOGRAPHICAL_OPT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_next_lexicographical_opt(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_ADDRESS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_ADDRESS
 uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_address(void
@@ -14495,9 +15508,21 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_hex(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_SHORT_STRING
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_SHORT_STRING
-uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_short_string(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_RAW_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_RAW_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_raw_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_RAW_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_RAW_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_raw_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTID_TO_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_method_objectid_to_short_hex(void
     
 );
 #endif
@@ -14522,6 +15547,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address(void
     
 );
 #endif
@@ -15209,6 +16240,246 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_coin_type_opt(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_ASCII_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_ASCII_STRING
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_ascii_string(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_AUTHENTICATOR_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_authenticator_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_bag(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_BALANCE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_BALANCE
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_balance(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CLOCK
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_clock(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN_MANAGER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN_MANAGER
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin_manager(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN_METADATA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_COIN_METADATA
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin_metadata(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CONFIG
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_config(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CONFIG_SETTING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_CONFIG_SETTING
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_config_setting(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_ADDRESS_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_ADDRESS_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_address_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_CONFIG_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_CONFIG_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_config_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_GLOBAL_PAUSE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DENY_LIST_GLOBAL_PAUSE_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_global_pause_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DISPLAY_CREATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DISPLAY_CREATED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_display_created(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DISPLAY_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DISPLAY_VERSION_UPDATED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_display_version_updated(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DYNAMIC_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DYNAMIC_FIELD
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_dynamic_field(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DYNAMIC_OBJECT_FIELD_WRAPPER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_DYNAMIC_OBJECT_FIELD_WRAPPER
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_dynamic_object_field_wrapper(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_GAS
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_gas(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_GAS_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_GAS_COIN
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_gas_coin(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_ID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_ID
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_ADMIN_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_ADMIN_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_system_admin_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_SYSTEM_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_system_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_IOTA_TREASURY_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_treasury_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_NAME
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_NAME
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_name(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_OBJECT_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_object_bag(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_OPTION
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_option(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_RANDOM
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_random(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_STAKED_IOTA
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_staked_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_STRING
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_string(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_SYSTEM_EPOCH_INFO_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_SYSTEM_EPOCH_INFO_EVENT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_system_epoch_info_event(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TIME_LOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TIME_LOCK
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_time_lock(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TIMELOCKED_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TIMELOCKED_STAKED_IOTA
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_timelocked_staked_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TRANSFER_RECEIVING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TRANSFER_RECEIVING
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_transfer_receiving(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TREASURY_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_treasury_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_TX_CONTEXT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_tx_context(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UID
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_uid(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_RECEIPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_RECEIPT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_receipt(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_TICKET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_UPGRADE_TICKET
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_ticket(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_URL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_IS_URL
+uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_is_url(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_MODULE
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_STRUCTTAG_MODULE
 uint16_t uniffi_iota_sdk_ffi_checksum_method_structtag_module(void
@@ -15875,6 +17146,48 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_validatorsignature_signature(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_AS_U64
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_AS_U64
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_as_u64(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_GET_CONGESTED_VERSION_SUGGESTED_GAS_PRICE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_GET_CONGESTED_VERSION_SUGGESTED_GAS_PRICE
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_get_congested_version_suggested_gas_price(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_CANCELLED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_CANCELLED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_is_cancelled(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_CONGESTED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_CONGESTED
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_is_congested(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_VALID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_IS_VALID
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_is_valid(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_NEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_NEXT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_next(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_PREVIOUS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSION_PREVIOUS
+uint16_t uniffi_iota_sdk_ffi_checksum_method_version_previous(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSIONASSIGNMENT_OBJECT_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_VERSIONASSIGNMENT_OBJECT_ID
 uint16_t uniffi_iota_sdk_ffi_checksum_method_versionassignment_object_id(void
@@ -16013,6 +17326,24 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_zkloginverifier_with_jwks(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_AUTHENTICATOR_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_authenticator_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_CLOCK
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_clock(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_DENY_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_DENY_LIST
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_deny_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FRAMEWORK
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FRAMEWORK
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_framework(void
@@ -16031,9 +17362,57 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENERATE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENERATE
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_generate(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_from_prefixed_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_PREFIXED_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_from_prefixed_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_FROM_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_from_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENESIS_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENESIS_BRIDGE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_genesis_bridge(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENESIS_IOTA_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_GENESIS_IOTA_BRIDGE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_genesis_iota_bridge(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_MAX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_MAX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_max(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_RANDOM
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_random(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_RANDOMNESS_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_RANDOMNESS_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_randomness_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STARDUST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_STARDUST
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_stardust(void
     
 );
 #endif
@@ -16046,6 +17425,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_std(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_SYSTEM
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_SYSTEM
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_system(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_ADDRESS_SYSTEM_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_address_system_state(void
     
 );
 #endif
@@ -16283,9 +17668,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_digest_from_bytes(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_DIGEST_GENERATE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_DIGEST_GENERATE
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_digest_generate(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_DIGEST_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_DIGEST_RANDOM
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_digest_random(void
     
 );
 #endif
@@ -16547,9 +17932,417 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_testnet(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ADDRESS_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ADDRESS_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_address_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ASCII_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ASCII_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_ascii_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_authenticator_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_AUTHENTICATOR_STATE_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_authenticator_state_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_bag(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BAG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BAG_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_bag_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BALANCE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BALANCE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_balance(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BALANCE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_BALANCE_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_balance_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CLOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CLOCK
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_clock(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CLOCK_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CLOCK_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_clock_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_manager(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MANAGER_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_manager_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_METADATA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_METADATA
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_metadata(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_COIN_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_config(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_config_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_CONFIG_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_config_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DENY_LIST_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DENY_LIST_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_deny_list_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DISPLAY_CREATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DISPLAY_CREATED
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_display_created(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DISPLAY_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DISPLAY_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_display_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DYNAMIC_FIELD_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DYNAMIC_FIELD_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_dynamic_field_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DYNAMIC_OBJECT_FIELD_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_DYNAMIC_OBJECT_FIELD_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_dynamic_object_field_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_FIELD
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_field(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_GLOBAL_PAUSE_KEY
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_GLOBAL_PAUSE_KEY
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_global_pause_key(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_ID
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_ADMIN_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_ADMIN_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_admin_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE_INNER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_SYSTEM_STATE_INNER_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_state_inner_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_IOTA_TREASURY_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_treasury_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NAME
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NAME
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_name(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NAME_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NAME_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_name_module(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_NEW
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_new(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_bag(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_BAG_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_bag_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OBJECT_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OPTION
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_option(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OPTION_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_OPTION_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_option_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_PACKAGE_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_PACKAGE_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_package_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_PAY_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_PAY_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_pay_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RANDOM
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_random(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RANDOM_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RANDOM_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_random_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RECEIVING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_RECEIVING
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_receiving(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SETTING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SETTING
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_setting(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STAKED_IOTA
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_staked_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STAKING_POOL_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STAKING_POOL_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_staking_pool_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STRING
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STRING
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_string(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STRING_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_STRING_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_string_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SYSTEM_ADMIN_CAP_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SYSTEM_ADMIN_CAP_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_system_admin_cap_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SYSTEM_EPOCH_INFO_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_SYSTEM_EPOCH_INFO_EVENT
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_system_epoch_info_event(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIME_LOCK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIME_LOCK
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_time_lock(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCK_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCK_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelock_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKED_IOTA
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKED_IOTA
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelocked_staked_iota(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKING_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TIMELOCKED_STAKING_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelocked_staking_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TRANSFER_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TRANSFER_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_transfer_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TREASURY_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TREASURY_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_treasury_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_tx_context(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_TX_CONTEXT_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_tx_context_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UID
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UID
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_uid(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_CAP
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_CAP
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_cap(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_RECEIPT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_RECEIPT
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_receipt(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_TICKET
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_UPGRADE_TICKET
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_ticket(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_URL_MODULE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_URL_MODULE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_url_module(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_URL_TYPE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_URL_TYPE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_url_type(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_VERSION_UPDATED
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_version_updated(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_WRAPPER
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_IDENTIFIER_WRAPPER
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_identifier_wrapper(void
     
 );
 #endif
@@ -16640,6 +18433,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_movearg_address(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_HEX
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_HEX
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_movearg_address_from_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_MOVEARG_ADDRESS_FROM_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_movearg_address_from_short_hex(void
     
 );
 #endif
@@ -16979,15 +18778,33 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectdata_new_move_struct(voi
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_AUTHENTICATOR_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_authenticator_state(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_CLOCK
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_CLOCK
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_clock(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_DENY_LIST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_DENY_LIST
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_deny_list(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_DERIVE_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_DERIVE_ID
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_derive_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FRAMEWORK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FRAMEWORK
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_framework(void
     
 );
 #endif
@@ -17003,9 +18820,69 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_hex(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_prefixed_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_PREFIXED_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_prefixed_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_SHORT_HEX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_FROM_SHORT_HEX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_short_hex(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_GENESIS_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_GENESIS_BRIDGE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_genesis_bridge(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_GENESIS_IOTA_BRIDGE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_GENESIS_IOTA_BRIDGE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_genesis_iota_bridge(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_MAX
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_MAX
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_max(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_RANDOMNESS_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_RANDOMNESS_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_randomness_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_STARDUST
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_STARDUST
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_stardust(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_STD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_STD
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_std(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_SYSTEM
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_SYSTEM
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_system(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_SYSTEM_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_OBJECTID_SYSTEM_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_objectid_system_state(void
     
 );
 #endif
@@ -17597,6 +19474,18 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_ascii_string(voi
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_AUTHENTICATOR_STATE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_AUTHENTICATOR_STATE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_authenticator_state(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_bag(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_BALANCE
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_BALANCE
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_balance(void
@@ -17663,15 +19552,27 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_display_created(
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DISPLAY_VERSION_UPDATED
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DISPLAY_VERSION_UPDATED
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_display_version_updated(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_FIELD
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_FIELD
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_dynamic_field(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_OBJECT_FIELD_WRAPPER
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_DYNAMIC_OBJECT_FIELD_WRAPPER
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_dynamic_object_field_wrapper(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_FIELD
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_FIELD
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_field(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_GAS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_GAS
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_gas(void
     
 );
 #endif
@@ -17684,12 +19585,6 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_gas_coin(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_ID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_ID
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_id(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_IOTA_COIN_TYPE
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_IOTA_COIN_TYPE
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_iota_coin_type(void
     
 );
 #endif
@@ -17714,6 +19609,24 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_iota_treasury_ca
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_NAME
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_NAME
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_name(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_OBJECT_BAG
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_OBJECT_BAG
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_object_bag(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_OPTION
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_OPTION
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_option(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_RANDOM
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_RANDOM
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_random(void
     
 );
 #endif
@@ -17759,6 +19672,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_treasury_cap(voi
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_TX_CONTEXT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_TX_CONTEXT
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_tx_context(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_UID
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_UID
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_uid(void
@@ -17783,9 +19702,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_upgrade_ticket(v
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_VERSION_UPDATED
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_VERSION_UPDATED
-uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_version_updated(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_URL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_STRUCTTAG_NEW_URL
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_url(void
     
 );
 #endif
@@ -18080,6 +19999,54 @@ uint16_t uniffi_iota_sdk_ffi_checksum_constructor_validatorexecutiontimeobservat
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VALIDATORSIGNATURE_NEW
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VALIDATORSIGNATURE_NEW
 uint16_t uniffi_iota_sdk_ffi_checksum_constructor_validatorsignature_new(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_CANCELLED_READ
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_CANCELLED_READ
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_cancelled_read(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_CONGESTED_PRIOR_TO_GAS_PRICE_FEEDBACK
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_congested_prior_to_gas_price_feedback(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_FROM_U64
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_FROM_U64
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_from_u64(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_LAMPORT_INCREMENT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_LAMPORT_INCREMENT
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_lamport_increment(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_MAX_VALID_EXCL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_MAX_VALID_EXCL
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_max_valid_excl(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_MIN_VALID_INCL
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_MIN_VALID_INCL
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_min_valid_incl(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_NEW_CONGESTED_WITH_SUGGESTED_GAS_PRICE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_NEW_CONGESTED_WITH_SUGGESTED_GAS_PRICE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_new_congested_with_suggested_gas_price(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_RANDOMNESS_UNAVAILABLE
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_CONSTRUCTOR_VERSION_RANDOMNESS_UNAVAILABLE
+uint16_t uniffi_iota_sdk_ffi_checksum_constructor_version_randomness_unavailable(void
     
 );
 #endif

--- a/bindings/swift/Sources/IotaSDK/IotaSDK.swift
+++ b/bindings/swift/Sources/IotaSDK/IotaSDK.swift
@@ -689,6 +689,17 @@ fileprivate struct FfiConverterDuration: FfiConverterRustBuffer {
  */
 public protocol AddressProtocol: AnyObject, Sendable {
     
+    /**
+     * Returns the next digest in byte-increasing order.
+     */
+    func nextLexicographical()  -> Address
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+    func nextLexicographicalOpt()  -> Address?
+    
     func toBytes()  -> Data
     
     /**
@@ -697,13 +708,29 @@ public protocol AddressProtocol: AnyObject, Sendable {
      */
     func toCanonicalString(withPrefix: Bool)  -> String
     
+    /**
+     * Returns the string representation of this address in hex format with
+     * `0x` prefix.
+     */
     func toHex()  -> String
+    
+    /**
+     * Returns the string representation of this address in hex format without
+     * `0x` prefix.
+     */
+    func toRawHex()  -> String
+    
+    /**
+     * Returns the shortest possible string representation of the address (i.e.
+     * with leading zeroes trimmed), without `0x` prefix.
+     */
+    func toRawShortHex()  -> String
     
     /**
      * Returns the shortest possible string representation of the address (i.e.
      * with leading zeroes trimmed).
      */
-    func toShortString(withPrefix: Bool)  -> String
+    func toShortHex()  -> String
     
 }
 /**
@@ -798,6 +825,27 @@ open class Address: AddressProtocol, @unchecked Sendable {
     }
 
     
+public static func authenticatorState() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_authenticator_state($0
+    )
+})
+}
+    
+public static func clock() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_clock($0
+    )
+})
+}
+    
+public static func denyList() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_deny_list($0
+    )
+})
+}
+    
 public static func framework() -> Address  {
     return try!  FfiConverterTypeAddress_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_address_framework($0
@@ -814,9 +862,9 @@ public static func fromBytes(bytes: Data)throws  -> Address  {
 }
     
     /**
-     * Parses an Address from a hex string, with or without a `0x` prefix.
-     * The string can be of variable length; if it's shorter than 64 hex
-     * characters, it will be left-padded with `0`s.
+     * Parses an Address from a full-length hex string (64 hex characters),
+     * with or without a `0x` prefix. Will return an error if the string is not
+     * exactly 64 hex characters long (excluding the `0x` prefix).
      */
 public static func fromHex(hex: String)throws  -> Address  {
     return try  FfiConverterTypeAddress_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
@@ -826,9 +874,83 @@ public static func fromHex(hex: String)throws  -> Address  {
 })
 }
     
-public static func generate() -> Address  {
+    /**
+     * Parses an Address from a full-length hex string (64 hex characters),
+     * with a mandatory `0x` prefix. Will return an error if the string is not
+     * exactly 64 hex characters long (excluding the `0x` prefix).
+     */
+public static func fromPrefixedHex(hex: String)throws  -> Address  {
+    return try  FfiConverterTypeAddress_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_address_from_prefixed_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+    /**
+     * Parses an Address from a hex string with a mandatory `0x` prefix.
+     * The string can be of variable length; if it's shorter than 64 hex
+     * characters, it will be left-padded with `0`s.
+     */
+public static func fromPrefixedShortHex(hex: String)throws  -> Address  {
+    return try  FfiConverterTypeAddress_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_address_from_prefixed_short_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+    /**
+     * Parses an Address from a hex string, with or without a `0x` prefix.
+     * The string can be of variable length; if it's shorter than 64 hex
+     * characters, it will be left-padded with `0`s.
+     */
+public static func fromShortHex(hex: String)throws  -> Address  {
+    return try  FfiConverterTypeAddress_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_address_from_short_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+public static func genesisBridge() -> Address  {
     return try!  FfiConverterTypeAddress_lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_constructor_address_generate($0
+    uniffi_iota_sdk_ffi_fn_constructor_address_genesis_bridge($0
+    )
+})
+}
+    
+public static func genesisIotaBridge() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_genesis_iota_bridge($0
+    )
+})
+}
+    
+public static func max() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_max($0
+    )
+})
+}
+    
+public static func random() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_random($0
+    )
+})
+}
+    
+public static func randomnessState() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_randomness_state($0
+    )
+})
+}
+    
+public static func stardust() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_stardust($0
     )
 })
 }
@@ -847,6 +969,13 @@ public static func system() -> Address  {
 })
 }
     
+public static func systemState() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_address_system_state($0
+    )
+})
+}
+    
 public static func zero() -> Address  {
     return try!  FfiConverterTypeAddress_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_address_zero($0
@@ -855,6 +984,27 @@ public static func zero() -> Address  {
 }
     
 
+    
+    /**
+     * Returns the next digest in byte-increasing order.
+     */
+open func nextLexicographical() -> Address  {
+    return try!  FfiConverterTypeAddress_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_address_next_lexicographical(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+open func nextLexicographicalOpt() -> Address?  {
+    return try!  FfiConverterOptionTypeAddress.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_address_next_lexicographical_opt(self.uniffiClonePointer(),$0
+    )
+})
+}
     
 open func toBytes() -> Data  {
     return try!  FfiConverterData.lift(try! rustCall() {
@@ -875,6 +1025,10 @@ open func toCanonicalString(withPrefix: Bool) -> String  {
 })
 }
     
+    /**
+     * Returns the string representation of this address in hex format with
+     * `0x` prefix.
+     */
 open func toHex() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_address_to_hex(self.uniffiClonePointer(),$0
@@ -883,13 +1037,34 @@ open func toHex() -> String  {
 }
     
     /**
+     * Returns the string representation of this address in hex format without
+     * `0x` prefix.
+     */
+open func toRawHex() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_address_to_raw_hex(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the shortest possible string representation of the address (i.e.
+     * with leading zeroes trimmed), without `0x` prefix.
+     */
+open func toRawShortHex() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_address_to_raw_short_hex(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
      * Returns the shortest possible string representation of the address (i.e.
      * with leading zeroes trimmed).
      */
-open func toShortString(withPrefix: Bool) -> String  {
+open func toShortHex() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_method_address_to_short_string(self.uniffiClonePointer(),
-        FfiConverterBool.lower(withPrefix),$0
+    uniffi_iota_sdk_ffi_fn_method_address_to_short_hex(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -6318,9 +6493,32 @@ public func FfiConverterTypeConsensusDeterminedVersionAssignments_lower(_ value:
 public protocol DigestProtocol: AnyObject, Sendable {
     
     /**
+     * Returns whether the digest represents an object that is neither deleted
+     * nor wrapped
+     */
+    func isObjectAlive()  -> Bool
+    
+    /**
+     * Returns whether the digest represents a deleted object
+     */
+    func isObjectDeleted()  -> Bool
+    
+    /**
+     * Returns whether the digest represents an object wrapped in another
+     * object.
+     */
+    func isObjectWrapped()  -> Bool
+    
+    /**
      * Returns the next digest in byte-increasing order.
      */
     func nextLexicographical()  -> Digest
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+    func nextLexicographicalOpt()  -> Digest?
     
     func toBase58()  -> String
     
@@ -6409,9 +6607,9 @@ public static func fromBytes(bytes: Data)throws  -> Digest  {
 })
 }
     
-public static func generate() -> Digest  {
+public static func random() -> Digest  {
     return try!  FfiConverterTypeDigest_lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_constructor_digest_generate($0
+    uniffi_iota_sdk_ffi_fn_constructor_digest_random($0
     )
 })
 }
@@ -6419,11 +6617,54 @@ public static func generate() -> Digest  {
 
     
     /**
+     * Returns whether the digest represents an object that is neither deleted
+     * nor wrapped
+     */
+open func isObjectAlive() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_digest_is_object_alive(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns whether the digest represents a deleted object
+     */
+open func isObjectDeleted() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_digest_is_object_deleted(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns whether the digest represents an object wrapped in another
+     * object.
+     */
+open func isObjectWrapped() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_digest_is_object_wrapped(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
      * Returns the next digest in byte-increasing order.
      */
 open func nextLexicographical() -> Digest  {
     return try!  FfiConverterTypeDigest_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_digest_next_lexicographical(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+open func nextLexicographicalOpt() -> Digest?  {
+    return try!  FfiConverterOptionTypeDigest.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_digest_next_lexicographical_opt(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -8850,7 +9091,7 @@ public protocol GenesisObjectProtocol: AnyObject, Sendable {
     
     func owner()  -> Owner
     
-    func version()  -> UInt64
+    func version()  -> Version
     
 }
 /**
@@ -8956,8 +9197,8 @@ open func owner() -> Owner  {
 })
 }
     
-open func version() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func version() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_genesisobject_version(self.uniffiClonePointer(),$0
     )
 })
@@ -9409,7 +9650,7 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-    func moveObjectContents(objectId: ObjectId, version: UInt64?) async throws  -> Value?
+    func moveObjectContents(objectId: ObjectId, version: Version?) async throws  -> Value?
     
     /**
      * Return the BCS of an object that is a Move object.
@@ -9418,7 +9659,7 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-    func moveObjectContentsBcs(objectId: ObjectId, version: UInt64?) async throws  -> Data?
+    func moveObjectContentsBcs(objectId: ObjectId, version: Version?) async throws  -> Data?
     
     /**
      * Execute a Move View Function.
@@ -9479,12 +9720,12 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * Return the normalized Move function data for the provided package,
      * module, and function.
      */
-    func normalizedMoveFunction(package: Address, module: String, function: String, version: UInt64?) async throws  -> MoveFunction?
+    func normalizedMoveFunction(package: Address, module: String, function: String, version: Version?) async throws  -> MoveFunction?
     
     /**
      * Return the normalized Move module data for the provided module.
      */
-    func normalizedMoveModule(package: Address, module: String, version: UInt64?, paginationFilterEnums: PaginationFilter?, paginationFilterFriends: PaginationFilter?, paginationFilterFunctions: PaginationFilter?, paginationFilterStructs: PaginationFilter?) async throws  -> MoveModule?
+    func normalizedMoveModule(package: Address, module: String, version: Version?, paginationFilterEnums: PaginationFilter?, paginationFilterFriends: PaginationFilter?, paginationFilterFunctions: PaginationFilter?, paginationFilterStructs: PaginationFilter?) async throws  -> MoveModule?
     
     /**
      * Return an object based on the provided `Address`.
@@ -9493,7 +9734,7 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-    func object(objectId: ObjectId, version: UInt64?) async throws  -> Object?
+    func object(objectId: ObjectId, version: Version?) async throws  -> Object?
     
     /**
      * Return the object's bcs content `Vec<u8>` based on the provided
@@ -9522,7 +9763,7 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * Note that this interpretation of version is different from a historical
      * object read (the interpretation of version for the object query).
      */
-    func package(address: Address, version: UInt64?) async throws  -> MovePackage?
+    func package(address: Address, version: Version?) async throws  -> MovePackage?
     
     /**
      * Fetch the latest version of the package at address.
@@ -9536,7 +9777,7 @@ public protocol GraphQlClientProtocol: AnyObject, Sendable {
      * package's original ID), optionally bounding the versions exclusively
      * from below with afterVersion, or from above with beforeVersion.
      */
-    func packageVersions(address: Address, afterVersion: UInt64?, beforeVersion: UInt64?, paginationFilter: PaginationFilter?) async throws  -> MovePackagePage
+    func packageVersions(address: Address, afterVersion: Version?, beforeVersion: Version?, paginationFilter: PaginationFilter?) async throws  -> MovePackagePage
     
     /**
      * The Move packages that exist in the network, optionally filtered to be
@@ -10310,13 +10551,13 @@ open func maxPageSize()async throws  -> Int32  {
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-open func moveObjectContents(objectId: ObjectId, version: UInt64? = nil)async throws  -> Value?  {
+open func moveObjectContents(objectId: ObjectId, version: Version? = nil)async throws  -> Value?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_move_object_contents(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionUInt64.lower(version)
+                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionTypeVersion.lower(version)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10334,13 +10575,13 @@ open func moveObjectContents(objectId: ObjectId, version: UInt64? = nil)async th
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-open func moveObjectContentsBcs(objectId: ObjectId, version: UInt64? = nil)async throws  -> Data?  {
+open func moveObjectContentsBcs(objectId: ObjectId, version: Version? = nil)async throws  -> Data?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_move_object_contents_bcs(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionUInt64.lower(version)
+                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionTypeVersion.lower(version)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10440,13 +10681,13 @@ open func moveViewCallJson(functionName: String, typeArguments: [String]? = nil,
      * Return the normalized Move function data for the provided package,
      * module, and function.
      */
-open func normalizedMoveFunction(package: Address, module: String, function: String, version: UInt64? = nil)async throws  -> MoveFunction?  {
+open func normalizedMoveFunction(package: Address, module: String, function: String, version: Version? = nil)async throws  -> MoveFunction?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_normalized_move_function(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeAddress_lower(package),FfiConverterString.lower(module),FfiConverterString.lower(function),FfiConverterOptionUInt64.lower(version)
+                    FfiConverterTypeAddress_lower(package),FfiConverterString.lower(module),FfiConverterString.lower(function),FfiConverterOptionTypeVersion.lower(version)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10460,13 +10701,13 @@ open func normalizedMoveFunction(package: Address, module: String, function: Str
     /**
      * Return the normalized Move module data for the provided module.
      */
-open func normalizedMoveModule(package: Address, module: String, version: UInt64? = nil, paginationFilterEnums: PaginationFilter? = nil, paginationFilterFriends: PaginationFilter? = nil, paginationFilterFunctions: PaginationFilter? = nil, paginationFilterStructs: PaginationFilter? = nil)async throws  -> MoveModule?  {
+open func normalizedMoveModule(package: Address, module: String, version: Version? = nil, paginationFilterEnums: PaginationFilter? = nil, paginationFilterFriends: PaginationFilter? = nil, paginationFilterFunctions: PaginationFilter? = nil, paginationFilterStructs: PaginationFilter? = nil)async throws  -> MoveModule?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_normalized_move_module(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeAddress_lower(package),FfiConverterString.lower(module),FfiConverterOptionUInt64.lower(version),FfiConverterOptionTypePaginationFilter.lower(paginationFilterEnums),FfiConverterOptionTypePaginationFilter.lower(paginationFilterFriends),FfiConverterOptionTypePaginationFilter.lower(paginationFilterFunctions),FfiConverterOptionTypePaginationFilter.lower(paginationFilterStructs)
+                    FfiConverterTypeAddress_lower(package),FfiConverterString.lower(module),FfiConverterOptionTypeVersion.lower(version),FfiConverterOptionTypePaginationFilter.lower(paginationFilterEnums),FfiConverterOptionTypePaginationFilter.lower(paginationFilterFriends),FfiConverterOptionTypePaginationFilter.lower(paginationFilterFunctions),FfiConverterOptionTypePaginationFilter.lower(paginationFilterStructs)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10484,13 +10725,13 @@ open func normalizedMoveModule(package: Address, module: String, version: UInt64
      * `Ok(None)`. Similarly, if this is not an object but an address, it
      * will return `Ok(None)`.
      */
-open func object(objectId: ObjectId, version: UInt64? = nil)async throws  -> Object?  {
+open func object(objectId: ObjectId, version: Version? = nil)async throws  -> Object?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_object(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionUInt64.lower(version)
+                    FfiConverterTypeObjectId_lower(objectId),FfiConverterOptionTypeVersion.lower(version)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10558,13 +10799,13 @@ open func objects(filter: ObjectFilter? = nil, paginationFilter: PaginationFilte
      * Note that this interpretation of version is different from a historical
      * object read (the interpretation of version for the object query).
      */
-open func package(address: Address, version: UInt64? = nil)async throws  -> MovePackage?  {
+open func package(address: Address, version: Version? = nil)async throws  -> MovePackage?  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_package(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeAddress_lower(address),FfiConverterOptionUInt64.lower(version)
+                    FfiConverterTypeAddress_lower(address),FfiConverterOptionTypeVersion.lower(version)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -10602,13 +10843,13 @@ open func packageLatest(address: Address)async throws  -> MovePackage?  {
      * package's original ID), optionally bounding the versions exclusively
      * from below with afterVersion, or from above with beforeVersion.
      */
-open func packageVersions(address: Address, afterVersion: UInt64? = nil, beforeVersion: UInt64? = nil, paginationFilter: PaginationFilter? = nil)async throws  -> MovePackagePage  {
+open func packageVersions(address: Address, afterVersion: Version? = nil, beforeVersion: Version? = nil, paginationFilter: PaginationFilter? = nil)async throws  -> MovePackagePage  {
     return
         try  await uniffiRustCallAsync(
             rustFutureFunc: {
                 uniffi_iota_sdk_ffi_fn_method_graphqlclient_package_versions(
                     self.uniffiClonePointer(),
-                    FfiConverterTypeAddress_lower(address),FfiConverterOptionUInt64.lower(afterVersion),FfiConverterOptionUInt64.lower(beforeVersion),FfiConverterOptionTypePaginationFilter.lower(paginationFilter)
+                    FfiConverterTypeAddress_lower(address),FfiConverterOptionTypeVersion.lower(afterVersion),FfiConverterOptionTypeVersion.lower(beforeVersion),FfiConverterOptionTypePaginationFilter.lower(paginationFilter)
                 )
             },
             pollFunc: ffi_iota_sdk_ffi_rust_future_poll_rust_buffer,
@@ -11128,6 +11369,482 @@ public convenience init(identifier: String)throws  {
     }
 
     
+public static func addressKey() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_address_key($0
+    )
+})
+}
+    
+public static func asciiModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_ascii_module($0
+    )
+})
+}
+    
+public static func authenticatorState() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_authenticator_state($0
+    )
+})
+}
+    
+public static func authenticatorStateModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_authenticator_state_module($0
+    )
+})
+}
+    
+public static func bag() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_bag($0
+    )
+})
+}
+    
+public static func bagModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_bag_module($0
+    )
+})
+}
+    
+public static func balance() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_balance($0
+    )
+})
+}
+    
+public static func balanceModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_balance_module($0
+    )
+})
+}
+    
+public static func clock() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_clock($0
+    )
+})
+}
+    
+public static func clockModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_clock_module($0
+    )
+})
+}
+    
+public static func coin() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_coin($0
+    )
+})
+}
+    
+public static func coinManager() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_manager($0
+    )
+})
+}
+    
+public static func coinManagerModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_manager_module($0
+    )
+})
+}
+    
+public static func coinMetadata() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_metadata($0
+    )
+})
+}
+    
+public static func coinModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_coin_module($0
+    )
+})
+}
+    
+public static func config() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_config($0
+    )
+})
+}
+    
+public static func configKey() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_config_key($0
+    )
+})
+}
+    
+public static func configModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_config_module($0
+    )
+})
+}
+    
+public static func denyListModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_deny_list_module($0
+    )
+})
+}
+    
+public static func displayCreated() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_display_created($0
+    )
+})
+}
+    
+public static func displayModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_display_module($0
+    )
+})
+}
+    
+public static func dynamicFieldModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_dynamic_field_module($0
+    )
+})
+}
+    
+public static func dynamicObjectFieldModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_dynamic_object_field_module($0
+    )
+})
+}
+    
+public static func field() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_field($0
+    )
+})
+}
+    
+public static func globalPauseKey() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_global_pause_key($0
+    )
+})
+}
+    
+public static func id() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_id($0
+    )
+})
+}
+    
+public static func iota() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota($0
+    )
+})
+}
+    
+public static func iotaModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_module($0
+    )
+})
+}
+    
+public static func iotaSystemAdminCap() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_admin_cap($0
+    )
+})
+}
+    
+public static func iotaSystemModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_module($0
+    )
+})
+}
+    
+public static func iotaSystemState() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_state($0
+    )
+})
+}
+    
+public static func iotaSystemStateInnerModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_system_state_inner_module($0
+    )
+})
+}
+    
+public static func iotaTreasuryCap() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_iota_treasury_cap($0
+    )
+})
+}
+    
+public static func name() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_name($0
+    )
+})
+}
+    
+public static func nameModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_name_module($0
+    )
+})
+}
+    
+public static func objectBag() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_object_bag($0
+    )
+})
+}
+    
+public static func objectBagModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_object_bag_module($0
+    )
+})
+}
+    
+public static func objectModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_object_module($0
+    )
+})
+}
+    
+public static func option() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_option($0
+    )
+})
+}
+    
+public static func optionModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_option_module($0
+    )
+})
+}
+    
+public static func packageModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_package_module($0
+    )
+})
+}
+    
+public static func payModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_pay_module($0
+    )
+})
+}
+    
+public static func random() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_random($0
+    )
+})
+}
+    
+public static func randomModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_random_module($0
+    )
+})
+}
+    
+public static func receiving() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_receiving($0
+    )
+})
+}
+    
+public static func setting() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_setting($0
+    )
+})
+}
+    
+public static func stakedIota() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_staked_iota($0
+    )
+})
+}
+    
+public static func stakingPoolModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_staking_pool_module($0
+    )
+})
+}
+    
+public static func string() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_string($0
+    )
+})
+}
+    
+public static func stringModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_string_module($0
+    )
+})
+}
+    
+public static func systemAdminCapModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_system_admin_cap_module($0
+    )
+})
+}
+    
+public static func systemEpochInfoEvent() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_system_epoch_info_event($0
+    )
+})
+}
+    
+public static func timeLock() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_time_lock($0
+    )
+})
+}
+    
+public static func timelockModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_timelock_module($0
+    )
+})
+}
+    
+public static func timelockedStakedIota() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_timelocked_staked_iota($0
+    )
+})
+}
+    
+public static func timelockedStakingModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_timelocked_staking_module($0
+    )
+})
+}
+    
+public static func transferModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_transfer_module($0
+    )
+})
+}
+    
+public static func treasuryCap() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_treasury_cap($0
+    )
+})
+}
+    
+public static func txContext() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_tx_context($0
+    )
+})
+}
+    
+public static func txContextModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_tx_context_module($0
+    )
+})
+}
+    
+public static func uid() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_uid($0
+    )
+})
+}
+    
+public static func upgradeCap() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_cap($0
+    )
+})
+}
+    
+public static func upgradeReceipt() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_receipt($0
+    )
+})
+}
+    
+public static func upgradeTicket() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_upgrade_ticket($0
+    )
+})
+}
+    
+public static func urlModule() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_url_module($0
+    )
+})
+}
+    
+public static func urlType() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_url_type($0
+    )
+})
+}
+    
+public static func versionUpdated() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_version_updated($0
+    )
+})
+}
+    
+public static func wrapper() -> Identifier  {
+    return try!  FfiConverterTypeIdentifier_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_identifier_wrapper($0
+    )
+})
+}
+    
 
     
 open func asStr() -> String  {
@@ -11352,11 +12069,11 @@ public static func newReceiving(objectRef: ObjectReference) -> Input  {
     /**
      * A move object whose owner is "Shared"
      */
-public static func newShared(objectId: ObjectId, initialSharedVersion: UInt64, mutable: Bool) -> Input  {
+public static func newShared(objectId: ObjectId, initialSharedVersion: Version, mutable: Bool) -> Input  {
     return try!  FfiConverterTypeInput_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_input_new_shared(
         FfiConverterTypeObjectId_lower(objectId),
-        FfiConverterUInt64.lower(initialSharedVersion),
+        FfiConverterTypeVersion_lower(initialSharedVersion),
         FfiConverterBool.lower(mutable),$0
     )
 })
@@ -12227,6 +12944,14 @@ public static func addressFromHex(hex: String)throws  -> MoveArg  {
 })
 }
     
+public static func addressFromShortHex(hex: String)throws  -> MoveArg  {
+    return try  FfiConverterTypeMoveArg_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_movearg_address_from_short_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
 public static func addressVec(addresses: [Address]) -> MoveArg  {
     return try!  FfiConverterTypeMoveArg_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_movearg_address_vec(
@@ -12560,13 +13285,13 @@ public static func newImmutable(callArgs: [Input], typeArgs: [TypeTag], objectTo
     /**
      * Create a new move authenticator from a shared object.
      */
-public static func newShared(callArgs: [Input], typeArgs: [TypeTag], objectToAuthenticate: ObjectId, initialSharedVersion: UInt64) -> MoveAuthenticator  {
+public static func newShared(callArgs: [Input], typeArgs: [TypeTag], objectToAuthenticate: ObjectId, initialSharedVersion: Version) -> MoveAuthenticator  {
     return try!  FfiConverterTypeMoveAuthenticator_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_moveauthenticator_new_shared(
         FfiConverterSequenceTypeInput.lower(callArgs),
         FfiConverterSequenceTypeTypeTag.lower(typeArgs),
         FfiConverterTypeObjectId_lower(objectToAuthenticate),
-        FfiConverterUInt64.lower(initialSharedVersion),$0
+        FfiConverterTypeVersion_lower(initialSharedVersion),$0
     )
 })
 }
@@ -13280,7 +14005,7 @@ public protocol MovePackageProtocol: AnyObject, Sendable {
     
     func typeOriginTable()  -> [TypeOrigin]
     
-    func version()  -> UInt64
+    func version()  -> Version
     
 }
 /**
@@ -13337,12 +14062,12 @@ open class MovePackage: MovePackageProtocol, @unchecked Sendable {
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iota_sdk_ffi_fn_clone_movepackage(self.pointer, $0) }
     }
-public convenience init(id: ObjectId, version: UInt64, modules: [Identifier: Data], typeOriginTable: [TypeOrigin], linkageTable: [ObjectId: UpgradeInfo])throws  {
+public convenience init(id: ObjectId, version: Version, modules: [Identifier: Data], typeOriginTable: [TypeOrigin], linkageTable: [ObjectId: UpgradeInfo])throws  {
     let pointer =
         try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
     uniffi_iota_sdk_ffi_fn_constructor_movepackage_new(
         FfiConverterTypeObjectId_lower(id),
-        FfiConverterUInt64.lower(version),
+        FfiConverterTypeVersion_lower(version),
         FfiConverterDictionaryTypeIdentifierData.lower(modules),
         FfiConverterSequenceTypeTypeOrigin.lower(typeOriginTable),
         FfiConverterDictionaryTypeObjectIdTypeUpgradeInfo.lower(linkageTable),$0
@@ -13390,8 +14115,8 @@ open func typeOriginTable() -> [TypeOrigin]  {
 })
 }
     
-open func version() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func version() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_movepackage_version(self.uniffiClonePointer(),$0
     )
 })
@@ -16172,7 +16897,7 @@ public protocol ObjectProtocol: AnyObject, Sendable {
     /**
      * Return this object's version
      */
-    func version()  -> UInt64
+    func version()  -> Version
     
 }
 /**
@@ -16377,8 +17102,8 @@ open func storageRebate() -> UInt64  {
     /**
      * Return this object's version
      */
-open func version() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func version() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_object_version(self.uniffiClonePointer(),$0
     )
 })
@@ -16742,6 +17467,17 @@ public protocol ObjectIdProtocol: AnyObject, Sendable {
      */
     func deriveDynamicChildId(keyTypeTag: TypeTag, keyBytes: Data)  -> ObjectId
     
+    /**
+     * Returns the next digest in byte-increasing order.
+     */
+    func nextLexicographical()  -> ObjectId
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+    func nextLexicographicalOpt()  -> ObjectId?
+    
     func toAddress()  -> Address
     
     func toBytes()  -> Data
@@ -16752,13 +17488,29 @@ public protocol ObjectIdProtocol: AnyObject, Sendable {
      */
     func toCanonicalString(withPrefix: Bool)  -> String
     
+    /**
+     * Returns the string representation of this object id in hex format with
+     * `0x` prefix.
+     */
     func toHex()  -> String
+    
+    /**
+     * Returns the string representation of this object id in hex format
+     * without `0x` prefix.
+     */
+    func toRawHex()  -> String
+    
+    /**
+     * Returns the shortest possible string representation of the object id
+     * (i.e. with leading zeroes trimmed), without `0x` prefix.
+     */
+    func toRawShortHex()  -> String
     
     /**
      * Returns the shortest possible string representation of the object ID
      * (i.e. with leading zeroes trimmed).
      */
-    func toShortString(withPrefix: Bool)  -> String
+    func toShortHex()  -> String
     
 }
 /**
@@ -16831,9 +17583,23 @@ open class ObjectId: ObjectIdProtocol, @unchecked Sendable {
     }
 
     
+public static func authenticatorState() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_authenticator_state($0
+    )
+})
+}
+    
 public static func clock() -> ObjectId  {
     return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_objectid_clock($0
+    )
+})
+}
+    
+public static func denyList() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_deny_list($0
     )
 })
 }
@@ -16851,6 +17617,13 @@ public static func deriveId(digest: Digest, count: UInt64) -> ObjectId  {
 })
 }
     
+public static func framework() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_framework($0
+    )
+})
+}
+    
 public static func fromBytes(bytes: Data)throws  -> ObjectId  {
     return try  FfiConverterTypeObjectId_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
     uniffi_iota_sdk_ffi_fn_constructor_objectid_from_bytes(
@@ -16859,6 +17632,11 @@ public static func fromBytes(bytes: Data)throws  -> ObjectId  {
 })
 }
     
+    /**
+     * Parses an ObjectId from a full-length hex string (64 hex characters),
+     * with or without a `0x` prefix. Will return an error if the string is not
+     * exactly 64 hex characters long (excluding the `0x` prefix).
+     */
 public static func fromHex(hex: String)throws  -> ObjectId  {
     return try  FfiConverterTypeObjectId_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
     uniffi_iota_sdk_ffi_fn_constructor_objectid_from_hex(
@@ -16867,9 +17645,97 @@ public static func fromHex(hex: String)throws  -> ObjectId  {
 })
 }
     
+    /**
+     * Parses an ObjectId from a full-length hex string (64 hex characters),
+     * with a mandatory `0x` prefix. Will return an error if the string is not
+     * exactly 64 hex characters long (excluding the `0x` prefix).
+     */
+public static func fromPrefixedHex(hex: String)throws  -> ObjectId  {
+    return try  FfiConverterTypeObjectId_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_from_prefixed_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+    /**
+     * Parses an ObjectId from a hex string with a mandatory `0x` prefix.
+     * The string can be of variable length; if it's shorter than 64 hex
+     * characters, it will be left-padded with `0`s.
+     */
+public static func fromPrefixedShortHex(hex: String)throws  -> ObjectId  {
+    return try  FfiConverterTypeObjectId_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_from_prefixed_short_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+    /**
+     * Parses an ObjectId from a hex string, with or without a `0x` prefix.
+     * The string can be of variable length; if it's shorter than 64 hex
+     * characters, it will be left-padded with `0`s.
+     */
+public static func fromShortHex(hex: String)throws  -> ObjectId  {
+    return try  FfiConverterTypeObjectId_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_from_short_hex(
+        FfiConverterString.lower(hex),$0
+    )
+})
+}
+    
+public static func genesisBridge() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_genesis_bridge($0
+    )
+})
+}
+    
+public static func genesisIotaBridge() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_genesis_iota_bridge($0
+    )
+})
+}
+    
+public static func max() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_max($0
+    )
+})
+}
+    
+public static func randomnessState() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_randomness_state($0
+    )
+})
+}
+    
+public static func stardust() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_stardust($0
+    )
+})
+}
+    
+public static func std() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_std($0
+    )
+})
+}
+    
 public static func system() -> ObjectId  {
     return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_objectid_system($0
+    )
+})
+}
+    
+public static func systemState() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_objectid_system_state($0
     )
 })
 }
@@ -16893,6 +17759,27 @@ open func deriveDynamicChildId(keyTypeTag: TypeTag, keyBytes: Data) -> ObjectId 
     uniffi_iota_sdk_ffi_fn_method_objectid_derive_dynamic_child_id(self.uniffiClonePointer(),
         FfiConverterTypeTypeTag_lower(keyTypeTag),
         FfiConverterData.lower(keyBytes),$0
+    )
+})
+}
+    
+    /**
+     * Returns the next digest in byte-increasing order.
+     */
+open func nextLexicographical() -> ObjectId  {
+    return try!  FfiConverterTypeObjectId_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_objectid_next_lexicographical(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the next digest in byte-increasing order, or `None` if the
+     * result would overflow.
+     */
+open func nextLexicographicalOpt() -> ObjectId?  {
+    return try!  FfiConverterOptionTypeObjectId.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_objectid_next_lexicographical_opt(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -16923,6 +17810,10 @@ open func toCanonicalString(withPrefix: Bool) -> String  {
 })
 }
     
+    /**
+     * Returns the string representation of this object id in hex format with
+     * `0x` prefix.
+     */
 open func toHex() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_objectid_to_hex(self.uniffiClonePointer(),$0
@@ -16931,13 +17822,34 @@ open func toHex() -> String  {
 }
     
     /**
+     * Returns the string representation of this object id in hex format
+     * without `0x` prefix.
+     */
+open func toRawHex() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_objectid_to_raw_hex(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the shortest possible string representation of the object id
+     * (i.e. with leading zeroes trimmed), without `0x` prefix.
+     */
+open func toRawShortHex() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_objectid_to_raw_short_hex(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
      * Returns the shortest possible string representation of the object ID
      * (i.e. with leading zeroes trimmed).
      */
-open func toShortString(withPrefix: Bool) -> String  {
+open func toShortHex() -> String  {
     return try!  FfiConverterString.lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_method_objectid_to_short_string(self.uniffiClonePointer(),
-        FfiConverterBool.lower(withPrefix),$0
+    uniffi_iota_sdk_ffi_fn_method_objectid_to_short_hex(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -17254,6 +18166,12 @@ public func FfiConverterTypeObjectType_lower(_ value: ObjectType) -> UnsafeMutab
  */
 public protocol OwnerProtocol: AnyObject, Sendable {
     
+    /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */
+    func address()  -> Address?
+    
     func asAddress()  -> Address
     
     func asAddressOpt()  -> Address?
@@ -17262,9 +18180,9 @@ public protocol OwnerProtocol: AnyObject, Sendable {
     
     func asObjectOpt()  -> ObjectId?
     
-    func asShared()  -> UInt64
+    func asShared()  -> Version
     
-    func asSharedOpt()  -> UInt64?
+    func asSharedOpt()  -> Version?
     
     func isAddress()  -> Bool
     
@@ -17364,15 +18282,26 @@ public static func newObject(id: ObjectId) -> Owner  {
 })
 }
     
-public static func newShared(version: UInt64) -> Owner  {
+public static func newShared(version: Version) -> Owner  {
     return try!  FfiConverterTypeOwner_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(
-        FfiConverterUInt64.lower(version),$0
+        FfiConverterTypeVersion_lower(version),$0
     )
 })
 }
     
 
+    
+    /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */
+open func address() -> Address?  {
+    return try!  FfiConverterOptionTypeAddress.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_owner_address(self.uniffiClonePointer(),$0
+    )
+})
+}
     
 open func asAddress() -> Address  {
     return try!  FfiConverterTypeAddress_lift(try! rustCall() {
@@ -17402,15 +18331,15 @@ open func asObjectOpt() -> ObjectId?  {
 })
 }
     
-open func asShared() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func asShared() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_owner_as_shared(self.uniffiClonePointer(),$0
     )
 })
 }
     
-open func asSharedOpt() -> UInt64?  {
-    return try!  FfiConverterOptionUInt64.lift(try! rustCall() {
+open func asSharedOpt() -> Version?  {
+    return try!  FfiConverterOptionTypeVersion.lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_owner_as_shared_opt(self.uniffiClonePointer(),$0
     )
 })
@@ -22785,14 +23714,99 @@ public protocol StructTagProtocol: AnyObject, Sendable {
     func address()  -> Address
     
     /**
-     * Checks if this is a Coin type
+     * Returns the coin type part of a `StructTag`, panics if this is not a
+     * Coin type
      */
     func coinType()  -> TypeTag
     
     /**
-     * Checks if this is a Coin type
+     * Returns the coin type part of a `StructTag`, if this is a Coin type
      */
     func coinTypeOpt()  -> TypeTag?
+    
+    func isAsciiString()  -> Bool
+    
+    func isAuthenticatorState()  -> Bool
+    
+    func isBag()  -> Bool
+    
+    func isBalance()  -> Bool
+    
+    func isClock()  -> Bool
+    
+    func isCoin()  -> Bool
+    
+    func isCoinManager()  -> Bool
+    
+    func isCoinMetadata()  -> Bool
+    
+    func isConfig()  -> Bool
+    
+    func isConfigSetting()  -> Bool
+    
+    func isDenyListAddressKey()  -> Bool
+    
+    func isDenyListConfigKey()  -> Bool
+    
+    func isDenyListGlobalPauseKey()  -> Bool
+    
+    func isDisplayCreated()  -> Bool
+    
+    func isDisplayVersionUpdated()  -> Bool
+    
+    /**
+     * Checks if this is a Dynamic Field type
+     * (`0x2::dynamic_field::Field<KeyType, ValueType>`)
+     */
+    func isDynamicField()  -> Bool
+    
+    func isDynamicObjectFieldWrapper()  -> Bool
+    
+    func isGas()  -> Bool
+    
+    func isGasCoin()  -> Bool
+    
+    func isId()  -> Bool
+    
+    func isIotaSystemAdminCap()  -> Bool
+    
+    func isIotaSystemState()  -> Bool
+    
+    func isIotaTreasuryCap()  -> Bool
+    
+    func isName()  -> Bool
+    
+    func isObjectBag()  -> Bool
+    
+    func isOption()  -> Bool
+    
+    func isRandom()  -> Bool
+    
+    func isStakedIota()  -> Bool
+    
+    func isString()  -> Bool
+    
+    func isSystemEpochInfoEvent()  -> Bool
+    
+    func isTimeLock()  -> Bool
+    
+    func isTimelockedStakedIota()  -> Bool
+    
+    func isTransferReceiving()  -> Bool
+    
+    func isTreasuryCap()  -> Bool
+    
+    func isTxContext()  -> Bool
+    
+    func isUid()  -> Bool
+    
+    func isUpgradeCap()  -> Bool
+    
+    func isUpgradeReceipt()  -> Bool
+    
+    func isUpgradeTicket()  -> Bool
+    
+    func isUrl()  -> Bool
     
     /**
      * Returns the module part of a `StructTag`
@@ -22898,6 +23912,20 @@ public static func newAsciiString() -> StructTag  {
 })
 }
     
+public static func newAuthenticatorState() -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_authenticator_state($0
+    )
+})
+}
+    
+public static func newBag() -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_bag($0
+    )
+})
+}
+    
 public static func newBalance(typeTag: TypeTag) -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_structtag_new_balance(
@@ -22981,6 +24009,27 @@ public static func newDisplayCreated(structTag: StructTag) -> StructTag  {
 })
 }
     
+public static func newDisplayVersionUpdated(structTag: StructTag) -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_display_version_updated(
+        FfiConverterTypeStructTag_lower(structTag),$0
+    )
+})
+}
+    
+    /**
+     * Creates a new dynamic field struct tag
+     * (`0x2::dynamic_field::Field<KeyType, ValueType>`)
+     */
+public static func newDynamicField(key: TypeTag, value: TypeTag) -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_dynamic_field(
+        FfiConverterTypeTypeTag_lower(key),
+        FfiConverterTypeTypeTag_lower(value),$0
+    )
+})
+}
+    
 public static func newDynamicObjectFieldWrapper(typeTag: TypeTag) -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_structtag_new_dynamic_object_field_wrapper(
@@ -22989,11 +24038,9 @@ public static func newDynamicObjectFieldWrapper(typeTag: TypeTag) -> StructTag  
 })
 }
     
-public static func newField(key: TypeTag, value: TypeTag) -> StructTag  {
+public static func newGas() -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_field(
-        FfiConverterTypeTypeTag_lower(key),
-        FfiConverterTypeTypeTag_lower(value),$0
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_gas($0
     )
 })
 }
@@ -23008,13 +24055,6 @@ public static func newGasCoin() -> StructTag  {
 public static func newId() -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_structtag_new_id($0
-    )
-})
-}
-    
-public static func newIotaCoinType() -> StructTag  {
-    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_iota_coin_type($0
     )
 })
 }
@@ -23044,6 +24084,28 @@ public static func newName(address: Address) -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_structtag_new_name(
         FfiConverterTypeAddress_lower(address),$0
+    )
+})
+}
+    
+public static func newObjectBag() -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_object_bag($0
+    )
+})
+}
+    
+public static func newOption(typeTag: TypeTag) -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_option(
+        FfiConverterTypeTypeTag_lower(typeTag),$0
+    )
+})
+}
+    
+public static func newRandom() -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_random($0
     )
 })
 }
@@ -23099,6 +24161,13 @@ public static func newTreasuryCap(structTag: StructTag) -> StructTag  {
 })
 }
     
+public static func newTxContext() -> StructTag  {
+    return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_tx_context($0
+    )
+})
+}
+    
 public static func newUid() -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_structtag_new_uid($0
@@ -23127,10 +24196,9 @@ public static func newUpgradeTicket() -> StructTag  {
 })
 }
     
-public static func newVersionUpdated(structTag: StructTag) -> StructTag  {
+public static func newUrl() -> StructTag  {
     return try!  FfiConverterTypeStructTag_lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_version_updated(
-        FfiConverterTypeStructTag_lower(structTag),$0
+    uniffi_iota_sdk_ffi_fn_constructor_structtag_new_url($0
     )
 })
 }
@@ -23148,7 +24216,8 @@ open func address() -> Address  {
 }
     
     /**
-     * Checks if this is a Coin type
+     * Returns the coin type part of a `StructTag`, panics if this is not a
+     * Coin type
      */
 open func coinType() -> TypeTag  {
     return try!  FfiConverterTypeTypeTag_lift(try! rustCall() {
@@ -23158,11 +24227,295 @@ open func coinType() -> TypeTag  {
 }
     
     /**
-     * Checks if this is a Coin type
+     * Returns the coin type part of a `StructTag`, if this is a Coin type
      */
 open func coinTypeOpt() -> TypeTag?  {
     return try!  FfiConverterOptionTypeTypeTag.lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_structtag_coin_type_opt(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isAsciiString() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_ascii_string(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isAuthenticatorState() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_authenticator_state(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isBag() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_bag(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isBalance() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_balance(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isClock() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_clock(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isCoin() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_coin(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isCoinManager() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_coin_manager(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isCoinMetadata() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_coin_metadata(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isConfig() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_config(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isConfigSetting() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_config_setting(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDenyListAddressKey() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_address_key(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDenyListConfigKey() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_config_key(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDenyListGlobalPauseKey() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_deny_list_global_pause_key(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDisplayCreated() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_display_created(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDisplayVersionUpdated() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_display_version_updated(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Checks if this is a Dynamic Field type
+     * (`0x2::dynamic_field::Field<KeyType, ValueType>`)
+     */
+open func isDynamicField() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_dynamic_field(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isDynamicObjectFieldWrapper() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_dynamic_object_field_wrapper(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isGas() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_gas(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isGasCoin() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_gas_coin(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isId() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_id(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isIotaSystemAdminCap() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_system_admin_cap(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isIotaSystemState() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_system_state(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isIotaTreasuryCap() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_iota_treasury_cap(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isName() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_name(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isObjectBag() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_object_bag(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isOption() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_option(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isRandom() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_random(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isStakedIota() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_staked_iota(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isString() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_string(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isSystemEpochInfoEvent() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_system_epoch_info_event(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isTimeLock() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_time_lock(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isTimelockedStakedIota() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_timelocked_staked_iota(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isTransferReceiving() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_transfer_receiving(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isTreasuryCap() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_treasury_cap(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isTxContext() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_tx_context(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isUid() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_uid(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isUpgradeCap() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_cap(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isUpgradeReceipt() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_receipt(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isUpgradeTicket() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_upgrade_ticket(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+open func isUrl() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_structtag_is_url(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -23324,7 +24677,7 @@ public protocol SystemPackageProtocol: AnyObject, Sendable {
     
     func modules()  -> [Data]
     
-    func version()  -> UInt64
+    func version()  -> Version
     
 }
 /**
@@ -23379,11 +24732,11 @@ open class SystemPackage: SystemPackageProtocol, @unchecked Sendable {
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iota_sdk_ffi_fn_clone_systempackage(self.pointer, $0) }
     }
-public convenience init(version: UInt64, modules: [Data], dependencies: [ObjectId]) {
+public convenience init(version: Version, modules: [Data], dependencies: [ObjectId]) {
     let pointer =
         try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_systempackage_new(
-        FfiConverterUInt64.lower(version),
+        FfiConverterTypeVersion_lower(version),
         FfiConverterSequenceData.lower(modules),
         FfiConverterSequenceTypeObjectId.lower(dependencies),$0
     )
@@ -23416,8 +24769,8 @@ open func modules() -> [Data]  {
 })
 }
     
-open func version() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func version() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_systempackage_version(self.uniffiClonePointer(),$0
     )
 })
@@ -28179,6 +29532,334 @@ public func FfiConverterTypeValidatorSignature_lower(_ value: ValidatorSignature
 
 
 
+public protocol VersionProtocol: AnyObject, Sendable {
+    
+    /**
+     * Get the underlying u64 value of this version
+     */
+    func asU64()  -> UInt64
+    
+    /**
+     * Returns the `suggested_gas_price` embedded in this congested shared
+     * object version. The `suggested_gas_price` here is used for a
+     * gas price feedback mechanism for transactions cancelled due to
+     * shared object congestion.
+     */
+    func getCongestedVersionSuggestedGasPrice() throws  -> UInt64
+    
+    /**
+     * Checks if this version is cancelled, i.e., the corresponding
+     * object appears in a cancelled transaction.
+     */
+    func isCancelled()  -> Bool
+    
+    /**
+     * Check if this version is congested, i.e., the corresponding
+     * object is the reason for transaction cancellation.
+     */
+    func isCongested()  -> Bool
+    
+    /**
+     * Checks if this version is valid, i.e., the corresponding
+     * object does not appear in a cancelled transaction.
+     */
+    func isValid()  -> Bool
+    
+    /**
+     * Returns the next version, or an error if overflow occurs.
+     */
+    func next() throws  -> Version
+    
+    /**
+     * Returns the previous version, or an error if underflow occurs.
+     */
+    func previous() throws  -> Version
+    
+}
+open class Version: VersionProtocol, @unchecked Sendable {
+    fileprivate let pointer: UnsafeMutableRawPointer!
+
+    /// Used to instantiate a [FFIObject] without an actual pointer, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoPointer {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromRawPointer pointer: UnsafeMutableRawPointer) {
+        self.pointer = pointer
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noPointer: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing [Pointer] the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noPointer: NoPointer) {
+        self.pointer = nil
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiClonePointer() -> UnsafeMutableRawPointer {
+        return try! rustCall { uniffi_iota_sdk_ffi_fn_clone_version(self.pointer, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        guard let pointer = pointer else {
+            return
+        }
+
+        try! rustCall { uniffi_iota_sdk_ffi_fn_free_version(pointer, $0) }
+    }
+
+    
+    /**
+     * Special version that is assigned to objects which are accessed
+     * immutably in a cancelled transaction.
+     */
+public static func cancelledRead() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_cancelled_read($0
+    )
+})
+}
+    
+    /**
+     * Special version that was assigned to congested objects which
+     * cause transaction cancellations. Note that this special version
+     * was only used prior to the introduction of a gas price feedback
+     * mechanism, but it is kept for backward compatibility.
+     */
+public static func congestedPriorToGasPriceFeedback() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_congested_prior_to_gas_price_feedback($0
+    )
+})
+}
+    
+    /**
+     * Create a new Version from a u64 value
+     */
+public static func fromU64(value: UInt64) -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_from_u64(
+        FfiConverterUInt64.lower(value),$0
+    )
+})
+}
+    
+    /**
+     * Returns a new version that is greater than all versions
+     * in `inputs`, assuming this operation will not overflow.
+     */
+public static func lamportIncrement(inputs: [Version])throws  -> Version  {
+    return try  FfiConverterTypeVersion_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_version_lamport_increment(
+        FfiConverterSequenceTypeVersion.lower(inputs),$0
+    )
+})
+}
+    
+    /**
+     * An exclusive upper limit on a valid version: versions
+     * strictly smaller than this limit are valid versions.
+     *
+     * A valid version means an object, which this version
+     * is assigned to, does not appear in a cancelled transaction.
+     * Versions larger than this value are "special" and
+     * assigned to objects that appear in cancelled transactions.
+     */
+public static func maxValidExcl() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_max_valid_excl($0
+    )
+})
+}
+    
+    /**
+     * An inclusive lower limit on a valid version.
+     *
+     * A valid version means an object, which this version
+     * is assigned to, does not appear in a cancelled transaction.
+     */
+public static func minValidIncl() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_min_valid_incl($0
+    )
+})
+}
+    
+    /**
+     * Returns a special version used for congested shared objects:
+     * `Version::MIN_CONGESTED + suggested_gas_price`,
+     * where `suggested_gas_price` is embedded into a congested version
+     * to facilitate a gas price feedback mechanism for transactions
+     * cancelled due to shared object congestion.
+     */
+public static func newCongestedWithSuggestedGasPrice(suggestedGasPrice: UInt64)throws  -> Version  {
+    return try  FfiConverterTypeVersion_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_constructor_version_new_congested_with_suggested_gas_price(
+        FfiConverterUInt64.lower(suggestedGasPrice),$0
+    )
+})
+}
+    
+public static func randomnessUnavailable() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_constructor_version_randomness_unavailable($0
+    )
+})
+}
+    
+
+    
+    /**
+     * Get the underlying u64 value of this version
+     */
+open func asU64() -> UInt64  {
+    return try!  FfiConverterUInt64.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_version_as_u64(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the `suggested_gas_price` embedded in this congested shared
+     * object version. The `suggested_gas_price` here is used for a
+     * gas price feedback mechanism for transactions cancelled due to
+     * shared object congestion.
+     */
+open func getCongestedVersionSuggestedGasPrice()throws  -> UInt64  {
+    return try  FfiConverterUInt64.lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_method_version_get_congested_version_suggested_gas_price(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Checks if this version is cancelled, i.e., the corresponding
+     * object appears in a cancelled transaction.
+     */
+open func isCancelled() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_version_is_cancelled(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Check if this version is congested, i.e., the corresponding
+     * object is the reason for transaction cancellation.
+     */
+open func isCongested() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_version_is_congested(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Checks if this version is valid, i.e., the corresponding
+     * object does not appear in a cancelled transaction.
+     */
+open func isValid() -> Bool  {
+    return try!  FfiConverterBool.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_version_is_valid(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the next version, or an error if overflow occurs.
+     */
+open func next()throws  -> Version  {
+    return try  FfiConverterTypeVersion_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_method_version_next(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+    /**
+     * Returns the previous version, or an error if underflow occurs.
+     */
+open func previous()throws  -> Version  {
+    return try  FfiConverterTypeVersion_lift(try rustCallWithError(FfiConverterTypeSdkFfiError_lift) {
+    uniffi_iota_sdk_ffi_fn_method_version_previous(self.uniffiClonePointer(),$0
+    )
+})
+}
+    
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeVersion: FfiConverter {
+
+    typealias FfiType = UnsafeMutableRawPointer
+    typealias SwiftType = Version
+
+    public static func lift(_ pointer: UnsafeMutableRawPointer) throws -> Version {
+        return Version(unsafeFromRawPointer: pointer)
+    }
+
+    public static func lower(_ value: Version) -> UnsafeMutableRawPointer {
+        return value.uniffiClonePointer()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> Version {
+        let v: UInt64 = try readInt(&buf)
+        // The Rust code won't compile if a pointer won't fit in a UInt64.
+        // We have to go via `UInt` because that's the thing that's the size of a pointer.
+        let ptr = UnsafeMutableRawPointer(bitPattern: UInt(truncatingIfNeeded: v))
+        if (ptr == nil) {
+            throw UniffiInternalError.unexpectedNullPointer
+        }
+        return try lift(ptr!)
+    }
+
+    public static func write(_ value: Version, into buf: inout [UInt8]) {
+        // This fiddling is because `Int` is the thing that's the same size as a pointer.
+        // The Rust code won't compile if a pointer won't fit in a `UInt64`.
+        writeInt(&buf, UInt64(bitPattern: Int64(Int(bitPattern: lower(value)))))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeVersion_lift(_ pointer: UnsafeMutableRawPointer) throws -> Version {
+    return try FfiConverterTypeVersion.lift(pointer)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeVersion_lower(_ value: Version) -> UnsafeMutableRawPointer {
+    return FfiConverterTypeVersion.lower(value)
+}
+
+
+
+
+
+
 /**
  * Object version assignment from consensus
  *
@@ -28194,7 +29875,7 @@ public protocol VersionAssignmentProtocol: AnyObject, Sendable {
     
     func objectId()  -> ObjectId
     
-    func version()  -> UInt64
+    func version()  -> Version
     
 }
 /**
@@ -28247,12 +29928,12 @@ open class VersionAssignment: VersionAssignmentProtocol, @unchecked Sendable {
     public func uniffiClonePointer() -> UnsafeMutableRawPointer {
         return try! rustCall { uniffi_iota_sdk_ffi_fn_clone_versionassignment(self.pointer, $0) }
     }
-public convenience init(objectId: ObjectId, version: UInt64) {
+public convenience init(objectId: ObjectId, version: Version) {
     let pointer =
         try! rustCall() {
     uniffi_iota_sdk_ffi_fn_constructor_versionassignment_new(
         FfiConverterTypeObjectId_lower(objectId),
-        FfiConverterUInt64.lower(version),$0
+        FfiConverterTypeVersion_lower(version),$0
     )
 }
     self.init(unsafeFromRawPointer: pointer)
@@ -28276,8 +29957,8 @@ open func objectId() -> ObjectId  {
 })
 }
     
-open func version() -> UInt64  {
-    return try!  FfiConverterUInt64.lift(try! rustCall() {
+open func version() -> Version  {
+    return try!  FfiConverterTypeVersion_lift(try! rustCall() {
     uniffi_iota_sdk_ffi_fn_method_versionassignment_version(self.uniffiClonePointer(),$0
     )
 })
@@ -29633,7 +31314,7 @@ public struct AuthenticatorStateExpire {
     /**
      * The initial version of the authenticator object that it was shared at.
      */
-    public var authenticatorObjInitialSharedVersion: UInt64
+    public var authenticatorObjInitialSharedVersion: Version
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -29643,7 +31324,7 @@ public struct AuthenticatorStateExpire {
          */minEpoch: UInt64, 
         /**
          * The initial version of the authenticator object that it was shared at.
-         */authenticatorObjInitialSharedVersion: UInt64) {
+         */authenticatorObjInitialSharedVersion: Version) {
         self.minEpoch = minEpoch
         self.authenticatorObjInitialSharedVersion = authenticatorObjInitialSharedVersion
     }
@@ -29652,24 +31333,6 @@ public struct AuthenticatorStateExpire {
 #if compiler(>=6)
 extension AuthenticatorStateExpire: Sendable {}
 #endif
-
-
-extension AuthenticatorStateExpire: Equatable, Hashable {
-    public static func ==(lhs: AuthenticatorStateExpire, rhs: AuthenticatorStateExpire) -> Bool {
-        if lhs.minEpoch != rhs.minEpoch {
-            return false
-        }
-        if lhs.authenticatorObjInitialSharedVersion != rhs.authenticatorObjInitialSharedVersion {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(minEpoch)
-        hasher.combine(authenticatorObjInitialSharedVersion)
-    }
-}
 
 
 
@@ -29681,13 +31344,13 @@ public struct FfiConverterTypeAuthenticatorStateExpire: FfiConverterRustBuffer {
         return
             try AuthenticatorStateExpire(
                 minEpoch: FfiConverterUInt64.read(from: &buf), 
-                authenticatorObjInitialSharedVersion: FfiConverterUInt64.read(from: &buf)
+                authenticatorObjInitialSharedVersion: FfiConverterTypeVersion.read(from: &buf)
         )
     }
 
     public static func write(_ value: AuthenticatorStateExpire, into buf: inout [UInt8]) {
         FfiConverterUInt64.write(value.minEpoch, into: &buf)
-        FfiConverterUInt64.write(value.authenticatorObjInitialSharedVersion, into: &buf)
+        FfiConverterTypeVersion.write(value.authenticatorObjInitialSharedVersion, into: &buf)
     }
 }
 
@@ -29734,7 +31397,7 @@ public struct AuthenticatorStateUpdateV1 {
      * newly active jwks
      */
     public var newActiveJwks: [ActiveJwk]
-    public var authenticatorObjInitialSharedVersion: UInt64
+    public var authenticatorObjInitialSharedVersion: Version
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -29747,7 +31410,7 @@ public struct AuthenticatorStateUpdateV1 {
          */round: UInt64, 
         /**
          * newly active jwks
-         */newActiveJwks: [ActiveJwk], authenticatorObjInitialSharedVersion: UInt64) {
+         */newActiveJwks: [ActiveJwk], authenticatorObjInitialSharedVersion: Version) {
         self.epoch = epoch
         self.round = round
         self.newActiveJwks = newActiveJwks
@@ -29758,32 +31421,6 @@ public struct AuthenticatorStateUpdateV1 {
 #if compiler(>=6)
 extension AuthenticatorStateUpdateV1: Sendable {}
 #endif
-
-
-extension AuthenticatorStateUpdateV1: Equatable, Hashable {
-    public static func ==(lhs: AuthenticatorStateUpdateV1, rhs: AuthenticatorStateUpdateV1) -> Bool {
-        if lhs.epoch != rhs.epoch {
-            return false
-        }
-        if lhs.round != rhs.round {
-            return false
-        }
-        if lhs.newActiveJwks != rhs.newActiveJwks {
-            return false
-        }
-        if lhs.authenticatorObjInitialSharedVersion != rhs.authenticatorObjInitialSharedVersion {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(epoch)
-        hasher.combine(round)
-        hasher.combine(newActiveJwks)
-        hasher.combine(authenticatorObjInitialSharedVersion)
-    }
-}
 
 
 
@@ -29797,7 +31434,7 @@ public struct FfiConverterTypeAuthenticatorStateUpdateV1: FfiConverterRustBuffer
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 round: FfiConverterUInt64.read(from: &buf), 
                 newActiveJwks: FfiConverterSequenceTypeActiveJwk.read(from: &buf), 
-                authenticatorObjInitialSharedVersion: FfiConverterUInt64.read(from: &buf)
+                authenticatorObjInitialSharedVersion: FfiConverterTypeVersion.read(from: &buf)
         )
     }
 
@@ -29805,7 +31442,7 @@ public struct FfiConverterTypeAuthenticatorStateUpdateV1: FfiConverterRustBuffer
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterUInt64.write(value.round, into: &buf)
         FfiConverterSequenceTypeActiveJwk.write(value.newActiveJwks, into: &buf)
-        FfiConverterUInt64.write(value.authenticatorObjInitialSharedVersion, into: &buf)
+        FfiConverterTypeVersion.write(value.authenticatorObjInitialSharedVersion, into: &buf)
     }
 }
 
@@ -33007,7 +34644,7 @@ public struct MoveStruct {
      * input This is a lamport timestamp, not a sequentially increasing
      * version
      */
-    public var version: UInt64
+    public var version: Version
     /**
      * BCS bytes of a Move struct value
      */
@@ -33023,7 +34660,7 @@ public struct MoveStruct {
          * Number that increases each time a tx takes this object as a mutable
          * input This is a lamport timestamp, not a sequentially increasing
          * version
-         */version: UInt64, 
+         */version: Version, 
         /**
          * BCS bytes of a Move struct value
          */contents: Data) {
@@ -33047,14 +34684,14 @@ public struct FfiConverterTypeMoveStruct: FfiConverterRustBuffer {
         return
             try MoveStruct(
                 structType: FfiConverterTypeStructTag.read(from: &buf), 
-                version: FfiConverterUInt64.read(from: &buf), 
+                version: FfiConverterTypeVersion.read(from: &buf), 
                 contents: FfiConverterData.read(from: &buf)
         )
     }
 
     public static func write(_ value: MoveStruct, into buf: inout [UInt8]) {
         FfiConverterTypeStructTag.write(value.structType, into: &buf)
-        FfiConverterUInt64.write(value.version, into: &buf)
+        FfiConverterTypeVersion.write(value.version, into: &buf)
         FfiConverterData.write(value.contents, into: &buf)
     }
 }
@@ -33658,12 +35295,12 @@ public func FfiConverterTypeObjectRef_lower(_ value: ObjectRef) -> RustBuffer {
  */
 public struct ObjectReference {
     public var objectId: ObjectId
-    public var version: UInt64
+    public var version: Version
     public var digest: Digest
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(objectId: ObjectId, version: UInt64, digest: Digest) {
+    public init(objectId: ObjectId, version: Version, digest: Digest) {
         self.objectId = objectId
         self.version = version
         self.digest = digest
@@ -33684,14 +35321,14 @@ public struct FfiConverterTypeObjectReference: FfiConverterRustBuffer {
         return
             try ObjectReference(
                 objectId: FfiConverterTypeObjectId.read(from: &buf), 
-                version: FfiConverterUInt64.read(from: &buf), 
+                version: FfiConverterTypeVersion.read(from: &buf), 
                 digest: FfiConverterTypeDigest.read(from: &buf)
         )
     }
 
     public static func write(_ value: ObjectReference, into buf: inout [UInt8]) {
         FfiConverterTypeObjectId.write(value.objectId, into: &buf)
-        FfiConverterUInt64.write(value.version, into: &buf)
+        FfiConverterTypeVersion.write(value.version, into: &buf)
         FfiConverterTypeDigest.write(value.digest, into: &buf)
     }
 }
@@ -34350,7 +35987,7 @@ public struct RandomnessStateUpdate {
     /**
      * The initial version of the randomness object that it was shared at
      */
-    public var randomnessObjInitialSharedVersion: UInt64
+    public var randomnessObjInitialSharedVersion: Version
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
@@ -34366,7 +36003,7 @@ public struct RandomnessStateUpdate {
          */randomBytes: Data, 
         /**
          * The initial version of the randomness object that it was shared at
-         */randomnessObjInitialSharedVersion: UInt64) {
+         */randomnessObjInitialSharedVersion: Version) {
         self.epoch = epoch
         self.randomnessRound = randomnessRound
         self.randomBytes = randomBytes
@@ -34377,32 +36014,6 @@ public struct RandomnessStateUpdate {
 #if compiler(>=6)
 extension RandomnessStateUpdate: Sendable {}
 #endif
-
-
-extension RandomnessStateUpdate: Equatable, Hashable {
-    public static func ==(lhs: RandomnessStateUpdate, rhs: RandomnessStateUpdate) -> Bool {
-        if lhs.epoch != rhs.epoch {
-            return false
-        }
-        if lhs.randomnessRound != rhs.randomnessRound {
-            return false
-        }
-        if lhs.randomBytes != rhs.randomBytes {
-            return false
-        }
-        if lhs.randomnessObjInitialSharedVersion != rhs.randomnessObjInitialSharedVersion {
-            return false
-        }
-        return true
-    }
-
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(epoch)
-        hasher.combine(randomnessRound)
-        hasher.combine(randomBytes)
-        hasher.combine(randomnessObjInitialSharedVersion)
-    }
-}
 
 
 
@@ -34416,7 +36027,7 @@ public struct FfiConverterTypeRandomnessStateUpdate: FfiConverterRustBuffer {
                 epoch: FfiConverterUInt64.read(from: &buf), 
                 randomnessRound: FfiConverterUInt64.read(from: &buf), 
                 randomBytes: FfiConverterData.read(from: &buf), 
-                randomnessObjInitialSharedVersion: FfiConverterUInt64.read(from: &buf)
+                randomnessObjInitialSharedVersion: FfiConverterTypeVersion.read(from: &buf)
         )
     }
 
@@ -34424,7 +36035,7 @@ public struct FfiConverterTypeRandomnessStateUpdate: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.epoch, into: &buf)
         FfiConverterUInt64.write(value.randomnessRound, into: &buf)
         FfiConverterData.write(value.randomBytes, into: &buf)
-        FfiConverterUInt64.write(value.randomnessObjInitialSharedVersion, into: &buf)
+        FfiConverterTypeVersion.write(value.randomnessObjInitialSharedVersion, into: &buf)
     }
 }
 
@@ -35091,7 +36702,7 @@ public struct TransactionEffectsV1 {
     /**
      * The version number of all the written Move objects by this transaction.
      */
-    public var lamportVersion: UInt64
+    public var lamportVersion: Version
     /**
      * Objects whose state are changed in the object store.
      */
@@ -35141,7 +36752,7 @@ public struct TransactionEffectsV1 {
          */dependencies: [Digest], 
         /**
          * The version number of all the written Move objects by this transaction.
-         */lamportVersion: UInt64, 
+         */lamportVersion: Version, 
         /**
          * Objects whose state are changed in the object store.
          */changedObjects: [ChangedObject], 
@@ -35192,7 +36803,7 @@ public struct FfiConverterTypeTransactionEffectsV1: FfiConverterRustBuffer {
                 gasObjectIndex: FfiConverterOptionUInt32.read(from: &buf), 
                 eventsDigest: FfiConverterOptionTypeDigest.read(from: &buf), 
                 dependencies: FfiConverterSequenceTypeDigest.read(from: &buf), 
-                lamportVersion: FfiConverterUInt64.read(from: &buf), 
+                lamportVersion: FfiConverterTypeVersion.read(from: &buf), 
                 changedObjects: FfiConverterSequenceTypeChangedObject.read(from: &buf), 
                 unchangedSharedObjects: FfiConverterSequenceTypeUnchangedSharedObject.read(from: &buf), 
                 auxiliaryDataDigest: FfiConverterOptionTypeDigest.read(from: &buf)
@@ -35207,7 +36818,7 @@ public struct FfiConverterTypeTransactionEffectsV1: FfiConverterRustBuffer {
         FfiConverterOptionUInt32.write(value.gasObjectIndex, into: &buf)
         FfiConverterOptionTypeDigest.write(value.eventsDigest, into: &buf)
         FfiConverterSequenceTypeDigest.write(value.dependencies, into: &buf)
-        FfiConverterUInt64.write(value.lamportVersion, into: &buf)
+        FfiConverterTypeVersion.write(value.lamportVersion, into: &buf)
         FfiConverterSequenceTypeChangedObject.write(value.changedObjects, into: &buf)
         FfiConverterSequenceTypeUnchangedSharedObject.write(value.unchangedSharedObjects, into: &buf)
         FfiConverterOptionTypeDigest.write(value.auxiliaryDataDigest, into: &buf)
@@ -35434,7 +37045,9 @@ public func FfiConverterTypeTransactionsFilter_lower(_ value: TransactionsFilter
 
 
 /**
- * Identifies a struct and the module it was defined in
+ * Stores the origin of a data type where it first appeared in the version
+ * chain. A data type is identified by the name of the module and the name of
+ * the struct/enum in combination.
  *
  * # BCS
  *
@@ -35445,15 +37058,33 @@ public func FfiConverterTypeTransactionsFilter_lower(_ value: TransactionsFilter
  * ```
  */
 public struct TypeOrigin {
+    /**
+     * The name of the module the data type resides in.
+     */
     public var moduleName: Identifier
-    public var structName: Identifier
+    /**
+     * identifier.
+     */
+    public var datatypeName: Identifier
+    /**
+     * ID of the package, where the given type first appeared.
+     */
     public var package: ObjectId
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(moduleName: Identifier, structName: Identifier, package: ObjectId) {
+    public init(
+        /**
+         * The name of the module the data type resides in.
+         */moduleName: Identifier, 
+        /**
+         * identifier.
+         */datatypeName: Identifier, 
+        /**
+         * ID of the package, where the given type first appeared.
+         */package: ObjectId) {
         self.moduleName = moduleName
-        self.structName = structName
+        self.datatypeName = datatypeName
         self.package = package
     }
 }
@@ -35472,14 +37103,14 @@ public struct FfiConverterTypeTypeOrigin: FfiConverterRustBuffer {
         return
             try TypeOrigin(
                 moduleName: FfiConverterTypeIdentifier.read(from: &buf), 
-                structName: FfiConverterTypeIdentifier.read(from: &buf), 
+                datatypeName: FfiConverterTypeIdentifier.read(from: &buf), 
                 package: FfiConverterTypeObjectId.read(from: &buf)
         )
     }
 
     public static func write(_ value: TypeOrigin, into buf: inout [UInt8]) {
         FfiConverterTypeIdentifier.write(value.moduleName, into: &buf)
-        FfiConverterTypeIdentifier.write(value.structName, into: &buf)
+        FfiConverterTypeIdentifier.write(value.datatypeName, into: &buf)
         FfiConverterTypeObjectId.write(value.package, into: &buf)
     }
 }
@@ -35576,23 +37207,23 @@ public func FfiConverterTypeUnchangedSharedObject_lower(_ value: UnchangedShared
  */
 public struct UpgradeInfo {
     /**
-     * Id of the upgraded packages
+     * ID of the upgraded package
      */
     public var upgradedId: ObjectId
     /**
      * Version of the upgraded package
      */
-    public var upgradedVersion: UInt64
+    public var upgradedVersion: Version
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
     public init(
         /**
-         * Id of the upgraded packages
+         * ID of the upgraded package
          */upgradedId: ObjectId, 
         /**
          * Version of the upgraded package
-         */upgradedVersion: UInt64) {
+         */upgradedVersion: Version) {
         self.upgradedId = upgradedId
         self.upgradedVersion = upgradedVersion
     }
@@ -35612,13 +37243,13 @@ public struct FfiConverterTypeUpgradeInfo: FfiConverterRustBuffer {
         return
             try UpgradeInfo(
                 upgradedId: FfiConverterTypeObjectId.read(from: &buf), 
-                upgradedVersion: FfiConverterUInt64.read(from: &buf)
+                upgradedVersion: FfiConverterTypeVersion.read(from: &buf)
         )
     }
 
     public static func write(_ value: UpgradeInfo, into buf: inout [UInt8]) {
         FfiConverterTypeObjectId.write(value.upgradedId, into: &buf)
-        FfiConverterUInt64.write(value.upgradedVersion, into: &buf)
+        FfiConverterTypeVersion.write(value.upgradedVersion, into: &buf)
     }
 }
 
@@ -38687,7 +40318,7 @@ public enum ObjectIn {
     /**
      * The old version, digest and owner.
      */
-    case data(version: UInt64, digest: Digest, owner: Owner
+    case data(version: Version, digest: Digest, owner: Owner
     )
 }
 
@@ -38708,7 +40339,7 @@ public struct FfiConverterTypeObjectIn: FfiConverterRustBuffer {
         
         case 1: return .missing
         
-        case 2: return .data(version: try FfiConverterUInt64.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf), owner: try FfiConverterTypeOwner.read(from: &buf)
+        case 2: return .data(version: try FfiConverterTypeVersion.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf), owner: try FfiConverterTypeOwner.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -38725,7 +40356,7 @@ public struct FfiConverterTypeObjectIn: FfiConverterRustBuffer {
         
         case let .data(version,digest,owner):
             writeInt(&buf, Int32(2))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             FfiConverterTypeDigest.write(digest, into: &buf)
             FfiConverterTypeOwner.write(owner, into: &buf)
             
@@ -38789,7 +40420,7 @@ public enum ObjectOut {
      * Packages writes need to be tracked separately with version because
      * we don't use lamport version for package publish and upgrades.
      */
-    case packageWrite(version: UInt64, digest: Digest
+    case packageWrite(version: Version, digest: Digest
     )
 }
 
@@ -38813,7 +40444,7 @@ public struct FfiConverterTypeObjectOut: FfiConverterRustBuffer {
         case 2: return .objectWrite(digest: try FfiConverterTypeDigest.read(from: &buf), owner: try FfiConverterTypeOwner.read(from: &buf)
         )
         
-        case 3: return .packageWrite(version: try FfiConverterUInt64.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf)
+        case 3: return .packageWrite(version: try FfiConverterTypeVersion.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf)
         )
         
         default: throw UniffiInternalError.unexpectedEnumCase
@@ -38836,7 +40467,7 @@ public struct FfiConverterTypeObjectOut: FfiConverterRustBuffer {
         
         case let .packageWrite(version,digest):
             writeInt(&buf, Int32(3))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             FfiConverterTypeDigest.write(digest, into: &buf)
             
         }
@@ -39649,23 +41280,23 @@ public enum UnchangedSharedKind {
      * ObjectDigest for protocol correctness, but it will make it easier to
      * verify untrusted read.
      */
-    case readOnlyRoot(version: UInt64, digest: Digest
+    case readOnlyRoot(version: Version, digest: Digest
     )
     /**
      * Deleted shared objects that appear mutably/owned in the input.
      */
-    case mutateDeleted(version: UInt64
+    case mutateDeleted(version: Version
     )
     /**
      * Deleted shared objects that appear as read-only in the input.
      */
-    case readDeleted(version: UInt64
+    case readDeleted(version: Version
     )
     /**
      * Shared objects in cancelled transaction. The sequence number embed
      * cancellation reason.
      */
-    case cancelled(version: UInt64
+    case cancelled(version: Version
     )
     /**
      * Read of a per-epoch config object that should remain the same during an
@@ -39689,16 +41320,16 @@ public struct FfiConverterTypeUnchangedSharedKind: FfiConverterRustBuffer {
         let variant: Int32 = try readInt(&buf)
         switch variant {
         
-        case 1: return .readOnlyRoot(version: try FfiConverterUInt64.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf)
+        case 1: return .readOnlyRoot(version: try FfiConverterTypeVersion.read(from: &buf), digest: try FfiConverterTypeDigest.read(from: &buf)
         )
         
-        case 2: return .mutateDeleted(version: try FfiConverterUInt64.read(from: &buf)
+        case 2: return .mutateDeleted(version: try FfiConverterTypeVersion.read(from: &buf)
         )
         
-        case 3: return .readDeleted(version: try FfiConverterUInt64.read(from: &buf)
+        case 3: return .readDeleted(version: try FfiConverterTypeVersion.read(from: &buf)
         )
         
-        case 4: return .cancelled(version: try FfiConverterUInt64.read(from: &buf)
+        case 4: return .cancelled(version: try FfiConverterTypeVersion.read(from: &buf)
         )
         
         case 5: return .perEpochConfig
@@ -39713,23 +41344,23 @@ public struct FfiConverterTypeUnchangedSharedKind: FfiConverterRustBuffer {
         
         case let .readOnlyRoot(version,digest):
             writeInt(&buf, Int32(1))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             FfiConverterTypeDigest.write(digest, into: &buf)
             
         
         case let .mutateDeleted(version):
             writeInt(&buf, Int32(2))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             
         
         case let .readDeleted(version):
             writeInt(&buf, Int32(3))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             
         
         case let .cancelled(version):
             writeInt(&buf, Int32(4))
-            FfiConverterUInt64.write(version, into: &buf)
+            FfiConverterTypeVersion.write(version, into: &buf)
             
         
         case .perEpochConfig:
@@ -40593,6 +42224,30 @@ fileprivate struct FfiConverterOptionTypeTypeTag: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeTypeTag.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeVersion: FfiConverterRustBuffer {
+    typealias SwiftType = Version?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeVersion.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeVersion.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -42620,6 +44275,31 @@ fileprivate struct FfiConverterSequenceTypeValidatorExecutionTimeObservation: Ff
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeValidatorExecutionTimeObservation.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeVersion: FfiConverterRustBuffer {
+    typealias SwiftType = [Version]
+
+    public static func write(_ value: [Version], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeVersion.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [Version] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [Version]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeVersion.read(from: &buf))
         }
         return seq
     }
@@ -49502,16 +51182,28 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_func_zk_login_public_identifier_to_json() != 12096) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_method_address_next_lexicographical() != 10365) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_address_next_lexicographical_opt() != 51160) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_method_address_to_bytes() != 57710) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_address_to_canonical_string() != 50168) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_address_to_hex() != 22032) {
+    if (uniffi_iota_sdk_ffi_checksum_method_address_to_hex() != 2770) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_address_to_short_string() != 56908) {
+    if (uniffi_iota_sdk_ffi_checksum_method_address_to_raw_hex() != 32277) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_address_to_raw_short_hex() != 57104) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_address_to_short_hex() != 9559) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_argument_get_nested_result() != 53358) {
@@ -49832,7 +51524,19 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_consensusdeterminedversionassignments_is_cancelled_transactions() != 10241) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_method_digest_is_object_alive() != 57678) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_digest_is_object_deleted() != 32964) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_digest_is_object_wrapped() != 15502) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_method_digest_next_lexicographical() != 53914) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_digest_next_lexicographical_opt() != 23877) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_digest_to_base58() != 54638) {
@@ -49946,7 +51650,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_genesisobject_owner() != 50201) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_genesisobject_version() != 36305) {
+    if (uniffi_iota_sdk_ffi_checksum_method_genesisobject_version() != 26576) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_genesistransaction_events() != 64664) {
@@ -50030,10 +51734,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_max_page_size() != 44733) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_object_contents() != 40412) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_object_contents() != 42627) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_object_contents_bcs() != 49694) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_object_contents_bcs() != 16500) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_view_call() != 52742) {
@@ -50042,13 +51746,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_move_view_call_json() != 5635) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_normalized_move_function() != 16965) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_normalized_move_function() != 13444) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_normalized_move_module() != 51355) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_normalized_move_module() != 1782) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_object() != 27424) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_object() != 56456) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_object_bcs() != 29653) {
@@ -50057,13 +51761,13 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_objects() != 14040) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_package() != 7913) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_package() != 2773) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_package_latest() != 55024) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_package_versions() != 34213) {
+    if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_package_versions() != 15150) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_graphqlclient_packages() != 45891) {
@@ -50204,7 +51908,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_movepackage_type_origin_table() != 7308) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_movepackage_version() != 22970) {
+    if (uniffi_iota_sdk_ffi_checksum_method_movepackage_version() != 7483) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_movepackagedata_dependencies() != 61113) {
@@ -50417,7 +52121,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_object_storage_rebate() != 24969) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_object_version() != 18433) {
+    if (uniffi_iota_sdk_ffi_checksum_method_object_version() != 59848) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_objectdata_as_package_opt() != 50334) {
@@ -50435,6 +52139,12 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_objectid_derive_dynamic_child_id() != 47819) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_next_lexicographical() != 15534) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_next_lexicographical_opt() != 278) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_address() != 21880) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -50444,10 +52154,16 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_canonical_string() != 62489) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_hex() != 4418) {
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_hex() != 13326) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_short_string() != 63526) {
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_raw_hex() != 56907) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_raw_short_hex() != 17836) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_objectid_to_short_hex() != 29478) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_objecttype_as_struct() != 15094) {
@@ -50462,6 +52178,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 19200) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -50474,10 +52193,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_owner_as_object_opt() != 17159) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_owner_as_shared() != 56096) {
+    if (uniffi_iota_sdk_ffi_checksum_method_owner_as_shared() != 17030) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_owner_as_shared_opt() != 4209) {
+    if (uniffi_iota_sdk_ffi_checksum_method_owner_as_shared_opt() != 58784) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_owner_is_address() != 26982) {
@@ -50798,10 +52517,130 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_structtag_address() != 20393) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_structtag_coin_type() != 37745) {
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_coin_type() != 64023) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_structtag_coin_type_opt() != 65306) {
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_coin_type_opt() != 46821) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_ascii_string() != 768) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_authenticator_state() != 10185) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_bag() != 46309) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_balance() != 61723) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_clock() != 5225) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin() != 61913) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin_manager() != 52348) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_coin_metadata() != 34817) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_config() != 41259) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_config_setting() != 27038) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_address_key() != 64455) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_config_key() != 30183) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_deny_list_global_pause_key() != 4914) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_display_created() != 21370) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_display_version_updated() != 3726) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_dynamic_field() != 59690) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_dynamic_object_field_wrapper() != 8218) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_gas() != 56237) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_gas_coin() != 20314) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_id() != 41991) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_system_admin_cap() != 56508) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_system_state() != 60130) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_iota_treasury_cap() != 32639) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_name() != 5722) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_object_bag() != 8625) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_option() != 10696) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_random() != 4566) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_staked_iota() != 19914) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_string() != 21518) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_system_epoch_info_event() != 20500) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_time_lock() != 6190) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_timelocked_staked_iota() != 14954) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_transfer_receiving() != 5695) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_treasury_cap() != 65088) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_tx_context() != 18584) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_uid() != 1904) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_cap() != 64642) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_receipt() != 4130) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_upgrade_ticket() != 6624) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_structtag_is_url() != 59887) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_structtag_module() != 28022) {
@@ -50822,7 +52661,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_systempackage_modules() != 23597) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_systempackage_version() != 39738) {
+    if (uniffi_iota_sdk_ffi_checksum_method_systempackage_version() != 53823) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_transaction_as_v1() != 53004) {
@@ -51137,10 +52976,31 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_validatorsignature_signature() != 58273) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_as_u64() != 37415) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_get_congested_version_suggested_gas_price() != 50172) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_is_cancelled() != 7823) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_is_congested() != 54746) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_is_valid() != 4593) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_next() != 46748) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_version_previous() != 59091) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_method_versionassignment_object_id() != 50440) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_versionassignment_version() != 51219) {
+    if (uniffi_iota_sdk_ffi_checksum_method_versionassignment_version() != 9820) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_zkloginauthenticator_inputs() != 1512) {
@@ -51206,22 +53066,58 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_zkloginverifier_with_jwks() != 49665) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_authenticator_state() != 23906) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_clock() != 41996) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_deny_list() != 26355) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_address_framework() != 52951) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_bytes() != 58901) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 38044) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_hex() != 59948) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_address_generate() != 48865) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_prefixed_hex() != 61183) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_prefixed_short_hex() != 62018) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_from_short_hex() != 60759) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_genesis_bridge() != 48414) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_genesis_iota_bridge() != 43861) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_max() != 5717) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_random() != 55074) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_randomness_state() != 62353) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_stardust() != 7116) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_address_std() != 28998) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_address_system() != 4297) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_address_system_state() != 26799) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_address_zero() != 46553) {
@@ -51341,7 +53237,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_digest_from_bytes() != 65530) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_digest_generate() != 8094) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_digest_random() != 18621) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_ed25519privatekey_from_bech32() != 16842) {
@@ -51473,7 +53369,211 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_graphqlclient_new_testnet() != 48529) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_address_key() != 24161) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_ascii_module() != 21861) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_authenticator_state() != 16216) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_authenticator_state_module() != 64126) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_bag() != 48457) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_bag_module() != 54361) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_balance() != 45299) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_balance_module() != 34758) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_clock() != 54114) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_clock_module() != 45072) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin() != 52194) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_manager() != 49557) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_manager_module() != 55970) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_metadata() != 40674) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_coin_module() != 34814) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_config() != 4576) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_config_key() != 17555) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_config_module() != 11061) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_deny_list_module() != 25060) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_display_created() != 25565) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_display_module() != 18646) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_dynamic_field_module() != 44243) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_dynamic_object_field_module() != 43439) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_field() != 36751) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_global_pause_key() != 59135) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_id() != 9401) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota() != 34383) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_module() != 20466) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_admin_cap() != 27582) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_module() != 34279) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_state() != 22040) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_system_state_inner_module() != 21899) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_iota_treasury_cap() != 12741) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_name() != 13462) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_name_module() != 11183) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_new() != 9398) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_bag() != 36980) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_bag_module() != 59882) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_object_module() != 16938) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_option() != 5076) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_option_module() != 36087) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_package_module() != 762) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_pay_module() != 31781) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_random() != 50490) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_random_module() != 5588) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_receiving() != 44248) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_setting() != 47313) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_staked_iota() != 39180) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_staking_pool_module() != 45878) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_string() != 22623) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_string_module() != 48728) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_system_admin_cap_module() != 43315) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_system_epoch_info_event() != 17381) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_time_lock() != 63781) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelock_module() != 25559) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelocked_staked_iota() != 44822) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_timelocked_staking_module() != 27461) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_transfer_module() != 617) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_treasury_cap() != 21659) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_tx_context() != 53898) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_tx_context_module() != 6086) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_uid() != 39877) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_cap() != 16692) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_receipt() != 32459) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_upgrade_ticket() != 3228) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_url_module() != 18366) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_url_type() != 23055) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_version_updated() != 55018) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_identifier_wrapper() != 61185) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_input_new_immutable_or_owned() != 33908) {
@@ -51485,7 +53585,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_input_new_receiving() != 28060) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_input_new_shared() != 61970) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_input_new_shared() != 48143) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_intent_from_bytes() != 49795) {
@@ -51519,6 +53619,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_movearg_address_from_hex() != 44452) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_movearg_address_from_short_hex() != 35587) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_movearg_address_vec() != 6097) {
@@ -51593,7 +53696,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_moveauthenticator_new_immutable() != 19047) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_moveauthenticator_new_shared() != 5389) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_moveauthenticator_new_shared() != 57308) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_moveauthenticatorbuilder_new() != 1961) {
@@ -51602,7 +53705,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_movecall_new() != 30411) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_movepackage_new() != 17506) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_movepackage_new() != 31500) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_movepackagedata_from_base64() != 61420) {
@@ -51689,19 +53792,58 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectdata_new_move_struct() != 1861) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_authenticator_state() != 13697) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_clock() != 14732) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_deny_list() != 39911) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_derive_id() != 16970) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_framework() != 24526) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_bytes() != 41789) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_hex() != 30954) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_hex() != 39262) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_prefixed_hex() != 58728) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_prefixed_short_hex() != 12289) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_from_short_hex() != 24855) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_genesis_bridge() != 44008) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_genesis_iota_bridge() != 39804) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_max() != 27865) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_randomness_state() != 39736) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_stardust() != 21114) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_std() != 6468) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_system() != 9600) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_system_state() != 17627) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_objectid_zero() != 40526) {
@@ -51722,7 +53864,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_owner_new_object() != 381) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_owner_new_shared() != 36753) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_owner_new_shared() != 22241) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_ptbargument_address() != 14619) {
@@ -51998,6 +54140,12 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_ascii_string() != 60972) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_authenticator_state() != 59432) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_bag() != 17783) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_balance() != 10874) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -52031,19 +54179,22 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_display_created() != 24465) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_display_version_updated() != 52216) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_dynamic_field() != 51044) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_dynamic_object_field_wrapper() != 48905) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_field() != 4196) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_gas() != 58980) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_gas_coin() != 5754) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_id() != 62017) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_iota_coin_type() != 44499) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_iota_system_admin_cap() != 5595) {
@@ -52056,6 +54207,15 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_name() != 26361) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_object_bag() != 12890) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_option() != 36037) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_random() != 25141) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_staked_iota() != 60970) {
@@ -52079,6 +54239,9 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_treasury_cap() != 2523) {
         return InitializationResult.apiChecksumMismatch
     }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_tx_context() != 39269) {
+        return InitializationResult.apiChecksumMismatch
+    }
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_uid() != 54533) {
         return InitializationResult.apiChecksumMismatch
     }
@@ -52091,10 +54254,10 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_upgrade_ticket() != 43936) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_version_updated() != 40840) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_structtag_new_url() != 23915) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_systempackage_new() != 25070) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_systempackage_new() != 23944) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_transaction_from_base64() != 30255) {
@@ -52241,7 +54404,31 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_constructor_validatorsignature_new() != 2599) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_constructor_versionassignment_new() != 14186) {
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_cancelled_read() != 19561) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_congested_prior_to_gas_price_feedback() != 34609) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_from_u64() != 29677) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_lamport_increment() != 45842) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_max_valid_excl() != 16135) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_min_valid_incl() != 30140) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_new_congested_with_suggested_gas_price() != 14) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_version_randomness_unavailable() != 14185) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_constructor_versionassignment_new() != 50135) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_constructor_zkloginauthenticator_new() != 32812) {

--- a/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
@@ -210,5 +210,11 @@ export_struct_tag_from_struct_tag_ctors!(
     DisplayVersionUpdated,
 );
 
+impl From<iota_sdk::types::MoveObjectType> for StructTag {
+    fn from(value: iota_sdk::types::MoveObjectType) -> Self {
+        Self(iota_sdk::types::StructTag::from(value))
+    }
+}
+
 crate::export_iota_types_objects_bcs_conversion!(Identifier, StructTag);
 crate::export_iota_types_objects_json_conversion!(Identifier, StructTag);

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -563,7 +563,7 @@ pub struct MoveStruct {
 impl From<iota_sdk::types::MoveStruct> for MoveStruct {
     fn from(value: iota_sdk::types::MoveStruct) -> Self {
         Self {
-            struct_type: Arc::new(StructTag(iota_sdk::types::StructTag::from(value.type_))),
+            struct_type: Arc::new(value.type_.into()),
             version: Arc::new(value.version.into()),
             contents: value.contents,
         }
@@ -573,7 +573,7 @@ impl From<iota_sdk::types::MoveStruct> for MoveStruct {
 impl From<MoveStruct> for iota_sdk::types::MoveStruct {
     fn from(value: MoveStruct) -> Self {
         Self {
-            type_: iota_sdk::types::MoveObjectType::from(value.struct_type.0.clone()),
+            type_: value.struct_type.0.clone().into(),
             version: **value.version,
             contents: value.contents,
         }
@@ -706,9 +706,7 @@ impl ObjectType {
 
     #[uniffi::constructor]
     pub fn new_struct(struct_tag: &StructTag) -> Self {
-        Self(iota_sdk::types::ObjectType::Struct(
-            iota_sdk::types::MoveObjectType::from(struct_tag.0.clone()),
-        ))
+        Self(iota_sdk::types::ObjectType::Struct(struct_tag.0.clone().into()))
     }
 
     pub fn is_package(&self) -> bool {
@@ -720,14 +718,14 @@ impl ObjectType {
     }
 
     pub fn as_struct(&self) -> StructTag {
-        StructTag(iota_sdk::types::StructTag::from(self.0.as_struct().clone()))
+        self.0.as_struct().clone().into()
     }
 
     pub fn as_struct_opt(&self) -> Option<Arc<StructTag>> {
         self.0
             .as_struct_opt()
             .cloned()
-            .map(|t| Arc::new(StructTag(iota_sdk::types::StructTag::from(t))))
+            .map(|t| Arc::new(t.into()))
     }
 }
 

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -706,7 +706,9 @@ impl ObjectType {
 
     #[uniffi::constructor]
     pub fn new_struct(struct_tag: &StructTag) -> Self {
-        Self(iota_sdk::types::ObjectType::Struct(struct_tag.0.clone().into()))
+        Self(iota_sdk::types::ObjectType::Struct(
+            struct_tag.0.clone().into(),
+        ))
     }
 
     pub fn is_package(&self) -> bool {
@@ -722,10 +724,7 @@ impl ObjectType {
     }
 
     pub fn as_struct_opt(&self) -> Option<Arc<StructTag>> {
-        self.0
-            .as_struct_opt()
-            .cloned()
-            .map(|t| Arc::new(t.into()))
+        self.0.as_struct_opt().cloned().map(|t| Arc::new(t.into()))
     }
 }
 

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -563,7 +563,7 @@ pub struct MoveStruct {
 impl From<iota_sdk::types::MoveStruct> for MoveStruct {
     fn from(value: iota_sdk::types::MoveStruct) -> Self {
         Self {
-            struct_type: Arc::new(value.type_.into()),
+            struct_type: Arc::new(StructTag(iota_sdk::types::StructTag::from(value.type_))),
             version: Arc::new(value.version.into()),
             contents: value.contents,
         }
@@ -573,7 +573,7 @@ impl From<iota_sdk::types::MoveStruct> for MoveStruct {
 impl From<MoveStruct> for iota_sdk::types::MoveStruct {
     fn from(value: MoveStruct) -> Self {
         Self {
-            type_: value.struct_type.0.clone(),
+            type_: iota_sdk::types::MoveObjectType::from(value.struct_type.0.clone()),
             version: **value.version,
             contents: value.contents,
         }
@@ -706,7 +706,9 @@ impl ObjectType {
 
     #[uniffi::constructor]
     pub fn new_struct(struct_tag: &StructTag) -> Self {
-        Self(iota_sdk::types::ObjectType::Struct(struct_tag.0.clone()))
+        Self(iota_sdk::types::ObjectType::Struct(
+            iota_sdk::types::MoveObjectType::from(struct_tag.0.clone()),
+        ))
     }
 
     pub fn is_package(&self) -> bool {
@@ -718,15 +720,14 @@ impl ObjectType {
     }
 
     pub fn as_struct(&self) -> StructTag {
-        self.0.as_struct().clone().into()
+        StructTag(iota_sdk::types::StructTag::from(self.0.as_struct().clone()))
     }
 
     pub fn as_struct_opt(&self) -> Option<Arc<StructTag>> {
         self.0
             .as_struct_opt()
             .cloned()
-            .map(Into::into)
-            .map(Arc::new)
+            .map(|t| Arc::new(StructTag(iota_sdk::types::StructTag::from(t))))
     }
 }
 

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -161,7 +161,8 @@ pub use gas::GasCostSummary;
 pub use move_core::{Identifier, StructTag, TypeParseError, TypeTag};
 pub use move_package::{MovePackage, MovePackageData, TypeOrigin, UpgradeInfo, UpgradePolicy};
 pub use object::{
-    GenesisObject, MoveStruct, Object, ObjectData, ObjectReference, ObjectType, Owner,
+    GenesisObject, MoveObjectType, MoveStruct, Object, ObjectData, ObjectReference, ObjectType,
+    Owner,
 };
 pub use object_id::ObjectId;
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -379,6 +379,7 @@ impl StructTag {
     );
     add_struct_tag_ctor!(STD, string::String);
     add_struct_tag_ctor!(@with_module STD, ascii::String);
+    add_struct_tag_ctor!(FRAMEWORK, coin::RegulatedCoinMetadata, coin::DenyCapV1);
     add_struct_tag_ctor_from_struct_tag!(
         FRAMEWORK,
         coin::CoinMetadata,
@@ -390,6 +391,32 @@ impl StructTag {
     add_struct_tag_ctor_from_type_tag!(FRAMEWORK, coin::Coin, balance::Balance, timelock::TimeLock);
     add_struct_tag_ctor_from_type_tag!(@with_module FRAMEWORK, config::Setting, dynamic_object_field::Wrapper);
     add_struct_tag_ctor_from_type_tag!(STD, option::Option);
+
+    // Stardust types
+    add_struct_tag_ctor!(
+        STARDUST,
+        alias_output::AliasOutput,
+        basic_output::BasicOutput,
+        nft_output::NftOutput,
+        nft::Nft
+    );
+
+    // Account abstraction types
+    add_struct_tag_ctor!(
+        FRAMEWORK,
+        authenticator_function::AuthenticatorFunctionRefV1
+    );
+
+    /// Checks if this is a `TimeLock<Balance<T>>` type
+    pub fn is_timelocked_balance(&self) -> bool {
+        if !self.is_time_lock() {
+            return false;
+        }
+        match &self.type_params()[0] {
+            TypeTag::Struct(tag) => tag.is_balance(),
+            _ => false,
+        }
+    }
 }
 
 impl std::fmt::Display for StructTag {

--- a/crates/iota-sdk-types/src/move_core/type_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/type_tag.rs
@@ -147,6 +147,19 @@ impl TypeTag {
         Self::Signer
     }
 
+    /// Creates a new gas type tag (`0x2::iota::IOTA`)
+    pub fn gas() -> Self {
+        Self::Struct(Box::new(StructTag::new_gas()))
+    }
+
+    /// Checks if this is the gas type (`0x2::iota::IOTA`)
+    pub fn is_gas_type(&self) -> bool {
+        match self {
+            TypeTag::Struct(s) => s.is_gas(),
+            _ => false,
+        }
+    }
+
     /// Returns the string representation of this type tag using the
     /// canonical display, with or without a `0x` prefix.
     pub fn to_canonical_string(&self, with_prefix: bool) -> String {

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -5,7 +5,8 @@
 use std::collections::BTreeMap;
 
 use super::{
-    Address, Digest, Identifier, MovePackage, ObjectId, StructTag, TypeOrigin, UpgradeInfo, Version,
+    Address, Digest, Identifier, MovePackage, ObjectId, StructTag, TypeOrigin, TypeTag,
+    UpgradeInfo, Version,
 };
 
 /// Reference to an object
@@ -198,11 +199,7 @@ impl ObjectData {
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MoveStruct {
     /// The type of this object
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "::serde_with::As::<serialization::BinaryMoveStructType>")
-    )]
-    pub type_: StructTag,
+    pub type_: MoveObjectType,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
@@ -217,26 +214,302 @@ pub struct MoveStruct {
     pub contents: Vec<u8>,
 }
 
+/// Wrapper around StructTag with a space-efficient representation for common
+/// types like coins. The StructTag for a gas coin is 84 bytes, so using 1 byte
+/// instead is a win. The inner representation is private to prevent incorrectly
+/// constructing an `Other` instead of one of the specialized variants, e.g.
+/// `Other(StructTag::new_gas_coin())` instead of `GasCoin`
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MoveObjectType(MoveObjectType_);
+
+#[cfg(feature = "proptest")]
+impl proptest::arbitrary::Arbitrary for MoveObjectType {
+    type Parameters = ();
+    type Strategy =
+        proptest::strategy::MapInto<<StructTag as proptest::arbitrary::Arbitrary>::Strategy, Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+        proptest::arbitrary::any::<StructTag>().prop_map_into()
+    }
+}
+
+/// Even though it is declared public, it is the "private", internal
+/// representation for `MoveObjectType`
+#[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub(crate) enum MoveObjectType_ {
+    /// A type that is not `0x2::coin::Coin<T>`
+    Other(Box<StructTag>),
+    /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
+    GasCoin,
+    /// A record of a staked IOTA coin (i.e., `0x3::staking_pool::StakedIota`)
+    StakedIota,
+    /// A non-IOTA coin type (i.e., `0x2::coin::Coin<T> where T !=
+    /// 0x2::iota::IOTA`)
+    Coin(TypeTag),
+    // NOTE: if adding a new type here, and there are existing on-chain objects of that
+    // type with Other(_), that is ok, but you must hand-roll PartialEq/Eq/Ord/maybe Hash
+    // to make sure the new type and Other(_) are interpreted consistently.
+}
+
+/// Delegates a boolean check to the inner `StructTag` for `Other` variants.
+/// Returns `false` for `GasCoin`, `StakedIota`, and `Coin` variants.
+macro_rules! delegate_other_check {
+    ($($(#[$meta:meta])* $method:ident),+ $(,)?) => {
+        $(
+            $(#[$meta])*
+            pub fn $method(&self) -> bool {
+                self.other().is_some_and(|s| s.$method())
+            }
+        )+
+    };
+    ($($(#[$meta:meta])* $method:ident => $struct_tag_method:ident),+ $(,)?) => {
+        $(
+            $(#[$meta])*
+            pub fn $method(&self) -> bool {
+                self.other().is_some_and(|s| s.$struct_tag_method())
+            }
+        )+
+    };
+}
+
+impl MoveObjectType {
+    pub fn gas_coin() -> Self {
+        Self(MoveObjectType_::GasCoin)
+    }
+
+    pub fn staked_iota() -> Self {
+        Self(MoveObjectType_::StakedIota)
+    }
+
+    pub fn coin(coin_type: TypeTag) -> Self {
+        Self(if coin_type.is_gas_type() {
+            MoveObjectType_::GasCoin
+        } else {
+            MoveObjectType_::Coin(coin_type)
+        })
+    }
+
+    /// Matches on the known variant, returning `coin` for `GasCoin`/`Coin`,
+    /// `staked` for `StakedIota`, and delegating to `other_fn` for `Other`.
+    fn match_type<T>(&self, coin: T, staked: T, other_fn: impl FnOnce(&StructTag) -> T) -> T {
+        match &self.0 {
+            MoveObjectType_::GasCoin | MoveObjectType_::Coin(_) => coin,
+            MoveObjectType_::StakedIota => staked,
+            MoveObjectType_::Other(s) => other_fn(s),
+        }
+    }
+
+    pub fn address(&self) -> Address {
+        self.match_type(Address::FRAMEWORK, Address::SYSTEM, |s| s.address())
+    }
+
+    pub fn module(&self) -> Identifier {
+        self.match_type(
+            Identifier::COIN_MODULE,
+            Identifier::STAKING_POOL_MODULE,
+            |s| s.module().clone(),
+        )
+    }
+
+    pub fn name(&self) -> Identifier {
+        self.match_type(Identifier::COIN, Identifier::STAKED_IOTA, |s| {
+            s.name().clone()
+        })
+    }
+
+    pub fn type_params(&self) -> Vec<TypeTag> {
+        match &self.0 {
+            MoveObjectType_::GasCoin => vec![TypeTag::gas()],
+            MoveObjectType_::StakedIota => vec![],
+            MoveObjectType_::Coin(inner) => vec![inner.clone()],
+            MoveObjectType_::Other(s) => s.type_params().to_vec(),
+        }
+    }
+
+    pub fn into_type_params(self) -> Vec<TypeTag> {
+        match self.0 {
+            MoveObjectType_::GasCoin => vec![TypeTag::gas()],
+            MoveObjectType_::StakedIota => vec![],
+            MoveObjectType_::Coin(inner) => vec![inner],
+            MoveObjectType_::Other(s) => s.type_params().to_vec(),
+        }
+    }
+
+    pub fn coin_type_opt(&self) -> Option<TypeTag> {
+        match &self.0 {
+            MoveObjectType_::GasCoin => Some(TypeTag::gas()),
+            MoveObjectType_::Coin(inner) => Some(inner.clone()),
+            MoveObjectType_::StakedIota | MoveObjectType_::Other(_) => None,
+        }
+    }
+
+    /// Return true if `self` is `0x2::coin::Coin<T>` for some T (note: T can be
+    /// IOTA)
+    pub fn is_coin(&self) -> bool {
+        matches!(&self.0, MoveObjectType_::GasCoin | MoveObjectType_::Coin(_))
+    }
+
+    /// Return true if `self` is 0x2::coin::Coin<0x2::iota::IOTA>
+    pub fn is_gas_coin(&self) -> bool {
+        matches!(&self.0, MoveObjectType_::GasCoin)
+    }
+
+    /// Return true if `self` is `0x2::coin::Coin<t>`
+    pub fn is_coin_t(&self, t: &TypeTag) -> bool {
+        match &self.0 {
+            MoveObjectType_::GasCoin => t.is_gas_type(),
+            MoveObjectType_::Coin(c) => t == c,
+            MoveObjectType_::StakedIota | MoveObjectType_::Other(_) => false,
+        }
+    }
+
+    pub fn is_staked_iota(&self) -> bool {
+        matches!(&self.0, MoveObjectType_::StakedIota)
+    }
+
+    delegate_other_check! {
+        is_coin_metadata,
+        is_coin_manager,
+        is_treasury_cap,
+        is_dynamic_field,
+        is_timelocked_balance,
+        is_timelocked_staked_iota,
+        is_alias_output,
+        is_basic_output,
+        is_nft_output,
+        is_authenticator_function_ref_v1,
+    }
+
+    delegate_other_check! {
+        is_timelock => is_time_lock,
+    }
+
+    pub fn is(&self, s: &StructTag) -> bool {
+        match &self.0 {
+            MoveObjectType_::GasCoin => s.is_gas_coin(),
+            MoveObjectType_::StakedIota => s.is_staked_iota(),
+            MoveObjectType_::Coin(inner) => s.is_coin() && inner == &s.type_params()[0],
+            MoveObjectType_::Other(o) => s == o.as_ref(),
+        }
+    }
+
+    pub fn other(&self) -> Option<&StructTag> {
+        if let MoveObjectType_::Other(s) = &self.0 {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the string representation of this object's type using the
+    /// canonical display.
+    pub fn to_canonical_string(&self, with_prefix: bool) -> String {
+        StructTag::from(self.clone()).to_canonical_string(with_prefix)
+    }
+
+    pub fn timelocked_iota_balance() -> Self {
+        Self::from(StructTag::new_time_lock(StructTag::new_balance(
+            StructTag::new_gas(),
+        )))
+    }
+
+    pub fn timelocked_staked_iota() -> Self {
+        Self::from(StructTag::new_timelocked_staked_iota())
+    }
+
+    pub fn stardust_nft() -> Self {
+        Self::from(StructTag::new_nft())
+    }
+
+    delegate_other_check! {
+        is_regulated_coin_metadata,
+    }
+
+    delegate_other_check! {
+        is_coin_deny_cap_v1 => is_deny_cap_v1,
+    }
+}
+
+impl From<&StructTag> for MoveObjectType {
+    fn from(s: &StructTag) -> Self {
+        Self::from(s.clone())
+    }
+}
+
+impl From<StructTag> for MoveObjectType {
+    fn from(s: StructTag) -> Self {
+        Self(if s.is_gas_coin() {
+            MoveObjectType_::GasCoin
+        } else if s.is_coin() {
+            let Some(type_param) = s.into_parts().3.into_iter().next() else {
+                unreachable!("a coin has exactly one type parameter");
+            };
+            MoveObjectType_::Coin(type_param)
+        } else if s.is_staked_iota() {
+            MoveObjectType_::StakedIota
+        } else {
+            MoveObjectType_::Other(Box::new(s))
+        })
+    }
+}
+
+impl From<MoveObjectType> for StructTag {
+    fn from(t: MoveObjectType) -> Self {
+        match t.0 {
+            MoveObjectType_::GasCoin => StructTag::new_gas_coin(),
+            MoveObjectType_::StakedIota => StructTag::new_staked_iota(),
+            MoveObjectType_::Coin(inner) => StructTag::new_coin(inner),
+            MoveObjectType_::Other(s) => *s,
+        }
+    }
+}
+
+impl From<MoveObjectType> for TypeTag {
+    fn from(o: MoveObjectType) -> TypeTag {
+        let s: StructTag = o.into();
+        TypeTag::Struct(Box::new(s))
+    }
+}
+
+impl std::fmt::Display for MoveObjectType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s: StructTag = self.clone().into();
+        write!(f, "{s}")
+    }
+}
+
+impl std::str::FromStr for MoveObjectType {
+    type Err = crate::TypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let tag: StructTag = s.parse()?;
+        Ok(MoveObjectType::from(tag))
+    }
+}
+
 /// Type of an IOTA object
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum ObjectType {
     /// Move package containing one or more bytecode modules
     Package,
     /// A Move struct of the given type
-    Struct(StructTag),
+    Struct(MoveObjectType),
 }
 
 impl ObjectType {
     crate::def_is!(Package);
 
-    crate::def_is_as_into_opt!(Struct(StructTag));
+    crate::def_is_as_into_opt!(Struct(MoveObjectType));
 }
 
 impl std::fmt::Display for ObjectType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ObjectType::Package => write!(f, "Package"),
-            ObjectType::Struct(struct_tag) => write!(f, "Struct({struct_tag})"),
+            ObjectType::Struct(move_object_type) => write!(f, "Struct({move_object_type})"),
         }
     }
 }
@@ -447,7 +720,6 @@ mod serialization {
     use serde_with::{DeserializeAs, SerializeAs};
 
     use super::*;
-    use crate::TypeTag;
 
     #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq)]
     #[serde(rename = "Owner")]
@@ -521,105 +793,6 @@ mod serialization {
         }
     }
 
-    /// Wrapper around StructTag with a space-efficient representation for
-    /// common types like coins The StructTag for a gas coin is 84 bytes, so
-    /// using 1 byte instead is a win. The inner representation is private
-    /// to prevent incorrectly constructing an `Other` instead of one of the
-    /// specialized variants, e.g. `Other(GasCoin::type_())` instead of
-    /// `GasCoin`
-    #[derive(serde::Deserialize)]
-    enum MoveStructType {
-        /// A type that is not `0x2::coin::Coin<T>`
-        Other(StructTag),
-        /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
-        GasCoin,
-        /// A record of a staked IOTA coin (i.e.,
-        /// `0x3::staking_pool::StakedIota`)
-        StakedIota,
-        /// A non-IOTA coin type (i.e., `0x2::coin::Coin<T> where T !=
-        /// 0x2::iota::IOTA`)
-        Coin(TypeTag),
-        // NOTE: if adding a new type here, and there are existing on-chain objects of that
-        // type with Other(_), that is ok, but you must hand-roll PartialEq/Eq/Ord/maybe Hash
-        // to make sure the new type and Other(_) are interpreted consistently.
-    }
-
-    /// See `MoveStructType`
-    #[derive(serde::Serialize)]
-    enum MoveStructTypeRef<'a> {
-        /// A type that is not `0x2::coin::Coin<T>`
-        Other(&'a StructTag),
-        /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
-        GasCoin,
-        /// A record of a staked IOTA coin (i.e.,
-        /// `0x3::staking_pool::StakedIota`)
-        StakedIota,
-        /// A non-IOTA coin type (i.e., `0x2::coin::Coin<T> where T !=
-        /// 0x2::iota::IOTA`)
-        Coin(&'a TypeTag),
-        // NOTE: if adding a new type here, and there are existing on-chain objects of that
-        // type with Other(_), that is ok, but you must hand-roll PartialEq/Eq/Ord/maybe Hash
-        // to make sure the new type and Other(_) are interpreted consistently.
-    }
-
-    impl MoveStructType {
-        fn into_struct_tag(self) -> StructTag {
-            match self {
-                MoveStructType::Other(tag) => tag,
-                MoveStructType::GasCoin => StructTag::new_gas_coin(),
-                MoveStructType::StakedIota => StructTag::new_staked_iota(),
-                MoveStructType::Coin(type_tag) => StructTag::new_coin(type_tag),
-            }
-        }
-    }
-
-    impl<'a> MoveStructTypeRef<'a> {
-        fn from_struct_tag(s: &'a StructTag) -> Self {
-            if let Some(coin_type) = s.coin_type_opt() {
-                if let TypeTag::Struct(s_inner) = coin_type
-                    && s_inner.address() == Address::FRAMEWORK
-                    && s_inner.module() == "iota"
-                    && s_inner.name() == "IOTA"
-                    && s_inner.type_params().is_empty()
-                {
-                    return Self::GasCoin;
-                }
-
-                Self::Coin(coin_type)
-            } else if s.address() == Address::SYSTEM
-                && s.module() == "staking_pool"
-                && s.name() == "StakedIota"
-                && s.type_params().is_empty()
-            {
-                Self::StakedIota
-            } else {
-                Self::Other(s)
-            }
-        }
-    }
-
-    pub(super) struct BinaryMoveStructType;
-
-    impl SerializeAs<StructTag> for BinaryMoveStructType {
-        fn serialize_as<S>(source: &StructTag, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            let move_object_type = MoveStructTypeRef::from_struct_tag(source);
-            move_object_type.serialize(serializer)
-        }
-    }
-
-    impl<'de> DeserializeAs<'de, StructTag> for BinaryMoveStructType {
-        fn deserialize_as<D>(deserializer: D) -> Result<StructTag, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let struct_type = MoveStructType::deserialize(deserializer)?;
-            Ok(struct_type.into_struct_tag())
-        }
-    }
-
     struct ReadableObjectType;
 
     impl SerializeAs<ObjectType> for ReadableObjectType {
@@ -629,7 +802,10 @@ mod serialization {
         {
             match source {
                 ObjectType::Package => "package".serialize(serializer),
-                ObjectType::Struct(s) => s.serialize(serializer),
+                ObjectType::Struct(move_type) => {
+                    let struct_tag = StructTag::from(move_type.clone());
+                    struct_tag.serialize(serializer)
+                }
             }
         }
     }
@@ -645,7 +821,7 @@ mod serialization {
             } else {
                 let struct_tag = StructTag::from_str(&s)
                     .map_err(|_| serde::de::Error::custom("invalid object type"))?;
-                Ok(ObjectType::Struct(struct_tag))
+                Ok(ObjectType::Struct(MoveObjectType::from(struct_tag)))
             }
         }
     }
@@ -1044,12 +1220,12 @@ mod serialization {
         fn obj() {
             let o = Object {
                 data: ObjectData::Struct(MoveStruct {
-                    type_: StructTag::new(
+                    type_: MoveObjectType::from(StructTag::new(
                         Address::FRAMEWORK,
                         Identifier::new("bar").unwrap(),
                         Identifier::new("foo").unwrap(),
                         Vec::new(),
-                    ),
+                    )),
                     version: Version::from_u64(12),
                     contents: ObjectId::ZERO.into(),
                 }),

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -235,7 +235,6 @@ impl proptest::arbitrary::Arbitrary for MoveObjectType {
     }
 }
 
-/// Even though it is declared public, it is the "private", internal
 /// representation for `MoveObjectType`
 #[derive(Eq, PartialEq, PartialOrd, Ord, Debug, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -97,11 +97,11 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
 
                 if let Some(object) = object {
                     if object.as_struct().type_.name()
-                        == &Identifier::from_static("PackageMetadataV1")
+                        == Identifier::from_static("PackageMetadataV1")
                     {
                         package_metadata_id.replace(object_id);
                     }
-                    if object.as_struct().type_.name() == &Identifier::from_static("Account") {
+                    if object.as_struct().type_.name() == Identifier::from_static("Account") {
                         account_id.replace(object_id);
                     }
                 }

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -104,7 +104,7 @@ async fn main() -> Result<()> {
                 let Some(obj) = client.object(object_id, None).await? else {
                     bail!("Missing object {object_id}");
                 };
-                if obj.as_struct().type_ == StructTag::new_upgrade_cap() {
+                if obj.as_struct().type_ == StructTag::new_upgrade_cap().into() {
                     println!("UpgradeCap: {object_id}");
                     println!("UpgradeCapOwner: {}", owner.into_address());
                     upgrade_cap.replace(object_id);


### PR DESCRIPTION
  Replace the internal-only BinaryMoveStructType serialization helper
  with a public MoveObjectType enum that provides a space-efficient
  representation of common Move struct types (GasCoin, StakedIota, Coin).

https://github.com/iotaledger/iota/issues/10639