### PR TITLE
fix(transaction-builder): send TransactionMetadata in dry-run to avoid gas_budget=0

### DIFF
--- a/crates/iota-sdk-graphql-client/src/api/dry_run.rs
+++ b/crates/iota-sdk-graphql-client/src/api/dry_run.rs
@@ -24,7 +24,7 @@ impl Client {
     /// checks.
     pub async fn dry_run_tx(&self, tx: &Transaction, skip_checks: bool) -> Result<DryRunResult> {
         let Transaction::V1(v1) = tx else {
-            unimplemented!("a new enum variant was added and needs to be handled")
+            unimplemented!("a new Transaction enum variant was added and needs to be handled")
         };
         let gas_objects = v1
             .gas_payment

--- a/crates/iota-sdk-graphql-client/src/api/dry_run.rs
+++ b/crates/iota-sdk-graphql-client/src/api/dry_run.rs
@@ -11,7 +11,7 @@ use iota_types::{SignedTransaction, Transaction, TransactionEffects, Transaction
 use crate::{
     Client, DryRunEffect, DryRunResult,
     error::Result,
-    query_types::{DryRunArgs, DryRunQuery, TransactionMetadata},
+    query_types::{DryRunArgs, DryRunQuery, ObjectRef, TransactionMetadata},
 };
 
 impl Client {
@@ -23,8 +23,31 @@ impl Client {
     /// sender, and calling non-public, non-entry functions, and some other
     /// checks.
     pub async fn dry_run_tx(&self, tx: &Transaction, skip_checks: bool) -> Result<DryRunResult> {
-        let tx_bytes = base64ct::Base64::encode_string(&bcs::to_bytes(&tx)?);
-        self.dry_run(tx_bytes, skip_checks, None).await
+        let Transaction::V1(v1) = tx else {
+            unimplemented!("a new enum variant was added and needs to be handled")
+        };
+        let gas_objects = v1
+            .gas_payment
+            .objects
+            .iter()
+            .map(|r| ObjectRef {
+                address: *r.object_id(),
+                version: r.version(),
+                digest: r.digest().to_base58(),
+            })
+            .collect::<Vec<_>>();
+        self.dry_run_tx_kind(
+            &v1.kind,
+            skip_checks,
+            TransactionMetadata {
+                gas_budget: (v1.gas_payment.budget > 0).then_some(v1.gas_payment.budget),
+                gas_objects: (!gas_objects.is_empty()).then_some(gas_objects),
+                gas_price: Some(v1.gas_payment.price),
+                gas_sponsor: Some(v1.gas_payment.owner),
+                sender: Some(v1.sender),
+            },
+        )
+        .await
     }
 
     /// Dry run a [`TransactionKind`] and return the transaction effects and dry

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -223,7 +223,7 @@ impl ClientMethods for iota_graphql_client::Client {
     }
 
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-        let res = self.dry_run_tx(tx, true).await?;
+        let res = self.dry_run_tx(tx, false).await?;
         Ok(res.effects.map(|e| e.gas_summary().gas_used()))
     }
 

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -232,7 +232,6 @@ impl ClientMethods for iota_graphql_client::Client {
         tx: &Transaction,
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
-        // Forward to the inherent method on Client
         (*self).dry_run_tx(tx, skip_checks).await
     }
 

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -223,7 +223,7 @@ impl ClientMethods for iota_graphql_client::Client {
     }
 
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-        let res = self.dry_run_tx(tx, false).await?;
+        let res = self.dry_run_tx(tx, true).await?;
         Ok(res.effects.map(|e| e.gas_summary().gas_used()))
     }
 

--- a/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client_methods.rs
@@ -4,7 +4,7 @@
 use iota_graphql_client::{
     DryRunResult, WaitForTx,
     pagination::{Direction, PaginationFilter},
-    query_types::{ObjectFilter, TransactionMetadata},
+    query_types::ObjectFilter,
 };
 use iota_types::{
     Address, Digest, Object, ObjectId, SignedTransaction, Transaction, TransactionEffects, TypeTag,
@@ -232,31 +232,8 @@ impl ClientMethods for iota_graphql_client::Client {
         tx: &Transaction,
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
-        let Transaction::V1(tx) = &tx else {
-            unimplemented!("a new enum variant was added and needs to be handled")
-        };
-        let gas_objects = tx
-            .gas_payment
-            .objects
-            .iter()
-            .map(|r| iota_graphql_client::query_types::ObjectRef {
-                address: r.object_id,
-                digest: r.digest.to_base58(),
-                version: r.version,
-            })
-            .collect::<Vec<_>>();
-        self.dry_run_tx_kind(
-            &tx.kind,
-            skip_checks,
-            TransactionMetadata {
-                gas_budget: (tx.gas_payment.budget > 0).then_some(tx.gas_payment.budget),
-                gas_objects: (!gas_objects.is_empty()).then_some(gas_objects),
-                gas_price: Some(tx.gas_payment.price),
-                gas_sponsor: Some(tx.gas_payment.owner),
-                sender: Some(tx.sender),
-            },
-        )
-        .await
+        // Forward to the inherent method on Client
+        (*self).dry_run_tx(tx, skip_checks).await
     }
 
     async fn execute_tx(

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -1132,7 +1132,11 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
             let Transaction::V1(txn) = &mut txn else {
                 unimplemented!("a new enum variant was added and needs to be handled")
             };
-            txn.gas_payment.budget = budget
+            // The network enforces a minimum gas budget of base_tx_cost_fixed
+            // (1000) * gas_price. The dry-run estimate can return a value below
+            // this minimum, so we clamp it.
+            let min_budget = txn.gas_payment.price.saturating_mul(1000);
+            txn.gas_payment.budget = budget.max(min_budget);
         }
 
         Ok(txn)


### PR DESCRIPTION
Client::dry_run_tx was sending the full Transaction BCS with tx_meta=None,
causing the server to read gas_budget=0 directly from the unfinished
transaction. This made dry-run return computation_cost=0, leading to
underestimated gas budgets and transaction failures: https://github.com/iotaledger/iota-rust-sdk/actions/runs/23574556448/job/68644104357

Now dry_run_tx sends TransactionKind + TransactionMetadata via
dry_run_tx_kind, so the server defaults missing gas_budget to max_tx_gas. 
Also adds a min-budget clamp as defense in depth.