### PR TITLE
fix: feature gate error and warnings

### DIFF
--- a/crates/iota-sdk-types/Cargo.toml
+++ b/crates/iota-sdk-types/Cargo.toml
@@ -33,7 +33,6 @@ serde = [
   "dep:bcs",
   "dep:serde_json",
   "roaring/std",
-  "dep:itertools",
   "dep:serde_repr",
 ]
 schemars = ["serde", "dep:schemars", "dep:serde_json"]
@@ -48,6 +47,7 @@ bs58 = "0.5.1"
 bytestring = "1.5.0"
 derive_more = { version = "2.1.1", features = ["full"] }
 hex.workspace = true
+itertools.workspace = true
 paste.workspace = true
 roaring.workspace = true
 strum = { workspace = true, features = ["derive"] }
@@ -56,7 +56,6 @@ winnow = "0.7"
 
 # Serialization and Deserialization support
 bcs = { workspace = true, optional = true }
-itertools = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }
 serde_repr = { version = "0.1", optional = true }

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -2,11 +2,12 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "serde")]
+use std::collections::BTreeMap;
+
 use super::{Address, Digest, MovePackage, ObjectId, StructTag, Version};
 #[cfg(feature = "serde")]
 use super::{Identifier, TypeOrigin, UpgradeInfo};
-#[cfg(feature = "serde")]
-use std::collections::BTreeMap;
 
 /// Reference to an object
 ///

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -2,11 +2,11 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{Address, Digest, MovePackage, ObjectId, StructTag, Version};
+#[cfg(feature = "serde")]
+use super::{Identifier, TypeOrigin, UpgradeInfo};
+#[cfg(feature = "serde")]
 use std::collections::BTreeMap;
-
-use super::{
-    Address, Digest, Identifier, MovePackage, ObjectId, StructTag, TypeOrigin, UpgradeInfo, Version,
-};
 
 /// Reference to an object
 ///


### PR DESCRIPTION
There is curently a compilation error and some warning when compiling the `iota-sdk-types` crate alone. 


Run:
```
cargo check -p `iota-sdk-types`
```
yields currently:

```
 --> crates/iota-sdk-types/src/transaction/mod.rs:7:5
  |
7 | use itertools::Either;
  |     ^^^^^^^^^ use of unresolved module or unlinked crate `itertools`
  |
  = help: if you wanted to use a crate named `itertools`, use `cargo add itertools` to add it to your `Cargo.toml`

warning: unused import: `std::collections::BTreeMap`
 --> crates/iota-sdk-types/src/object.rs:5:5
  |
5 | use std::collections::BTreeMap;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: unused imports: `Identifier`, `TypeOrigin`, and `UpgradeInfo`
 --> crates/iota-sdk-types/src/object.rs:8:22
  |
8 |     Address, Digest, Identifier, MovePackage, ObjectId, StructTag, TypeOrigin, UpgradeInfo, Version,
  |                      ^^^^^^^^^^                                    ^^^^^^^^^^  ^^^^^^^^^^^
  ```

and this fixes it.

Due to feature unification in regular builds this doesn't show up, but when you run on the monorepo:

```
cargo test --doc -p iota-grpc-client
```

currently that yields:

```
error[E0432]: unresolved import `itertools`
 --> /home/me/.cargo/git/checkouts/iota-rust-sdk-f297342d45e7a7ed/7eb6e8e/crates/iota-sdk-types/src/transaction/mod.rs:7:5
  |
7 | use itertools::Either;
  |     ^^^^^^^^^ use of unresolved module or unlinked crate `itertools`
  |
  = help: if you wanted to use a crate named `itertools`, use `cargo add itertools` to add it to your `Cargo.toml`
```

The reason for this is that `itertools` is only avalable with the `serde` feature, but it's actually needed outside of the `serde` context.
