### PR TITLE
feat: add `make` cmd to install `uniffi-bindgen-go`

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install uniffi-bindgen-go
-        run: cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5
+        run: make install-uniffi-bindgen-go
       - name: Build the bindings
         run: make go
       - name: Checks for uncommitted changes

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ clean: ## Clean build artifacts
 clean-all: clean ## Clean all generated files, including those ignored by Git. Force removal.
 	git clean -dXf
 
+.PHONY: install-uniffi-bindgen-go
+install-uniffi-bindgen-go: ## Install uniffi-bindgen-go
+	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5
+
 .PHONY: bindings
 bindings: ## Build all bindings
 	@$(MAKE) go


### PR DESCRIPTION
Makes it easier to have the same `uniffi-bindgen-go` version installed in the CI and locally.