### PR TITLE
fix(examples): segfault in the go `coin_balances` example for addresses without a balance

### DIFF
--- a/bindings/csharp/examples/CoinBalances/Program.cs
+++ b/bindings/csharp/examples/CoinBalances/Program.cs
@@ -20,7 +20,7 @@ class Program
                 Console.WriteLine($"Coin = {coin.Id().ToHex()}, Coin Type = {coin.CoinType().AsStructTag()}, Balance = {coin.Balance()}");
             }
 
-            var balance = await client.Balance(address, null);
+            var balance = await client.Balance(address, null) ?? 0;
             Console.WriteLine($"Total Balance = {balance}");
         }
         catch (SdkFfiException ex)

--- a/bindings/go/examples/coin_balances/main.go
+++ b/bindings/go/examples/coin_balances/main.go
@@ -31,5 +31,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to get balance: %v", err)
 	}
-	fmt.Printf("Total Balance = %d\n", *balance)
+	var totalBalance uint64
+	if balance != nil {
+		totalBalance = *balance
+	}
+	fmt.Printf("Total Balance = %d\n", totalBalance)
 }

--- a/bindings/kotlin/examples/CoinBalances.kt
+++ b/bindings/kotlin/examples/CoinBalances.kt
@@ -18,7 +18,7 @@ fun main() = runBlocking {
             )
         }
 
-        val balance = client.balance(address)
+        val balance = client.balance(address) ?: 0uL
         println("Total Balance = $balance")
     } catch (e: Exception) {
         e.printStackTrace()

--- a/bindings/python/examples/coin_balances.py
+++ b/bindings/python/examples/coin_balances.py
@@ -18,7 +18,7 @@ async def main():
             f"Coin = {coin.id().to_hex()}, Coin Type = {coin.coin_type().as_struct_tag()}, Balance = {coin.balance()}"
         )
 
-    balance = await client.balance(address)
+    balance = await client.balance(address) or 0
     print(f"Total Balance = {balance}")
 
 

--- a/bindings/swift/examples/CoinBalances.swift
+++ b/bindings/swift/examples/CoinBalances.swift
@@ -18,7 +18,7 @@ struct CoinBalancesExample {
       )
     }
 
-    let balance = try await client.balance(address: address)
-    print("Total Balance = \(String(describing: balance))")
+    let balance = try await client.balance(address: address) ?? 0                                                                                             
+    print("Total Balance = \(balance)") 
   }
 }

--- a/bindings/swift/examples/CoinBalances.swift
+++ b/bindings/swift/examples/CoinBalances.swift
@@ -18,7 +18,7 @@ struct CoinBalancesExample {
       )
     }
 
-    let balance = try await client.balance(address: address) ?? 0                                                                                             
-    print("Total Balance = \(balance)") 
+    let balance = try await client.balance(address: address) ?? 0
+    print("Total Balance = \(balance)")
   }
 }


### PR DESCRIPTION
Fixes #999 

Additionally aligns the corresponding other examples to show a `0` balance (like the Rust example) for an address that doesn't hold any coins.