### PR TITLE
refactor(iota-sdk-types): drop byte-level signature serialization

### DIFF
--- a/crates/iota-sdk-bcs-schema/src/lib.rs
+++ b/crates/iota-sdk-bcs-schema/src/lib.rs
@@ -57,6 +57,7 @@ struct FieldAttrs {
 }
 
 struct VariantAttrs {
+    skip: bool,
     as_type: Option<String>,
 }
 
@@ -89,19 +90,25 @@ fn parse_type_attrs(input: &DeriveInput) -> syn::Result<TypeAttrs> {
 }
 
 fn parse_variant_attrs(variant: &syn::Variant) -> syn::Result<VariantAttrs> {
-    let mut attrs = VariantAttrs { as_type: None };
+    let mut attrs = VariantAttrs {
+        skip: false,
+        as_type: None,
+    };
     for attr in &variant.attrs {
         if !attr.path().is_ident("bcs_schema") {
             continue;
         }
         attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("as_type") {
+            if meta.path.is_ident("skip") {
+                attrs.skip = true;
+                Ok(())
+            } else if meta.path.is_ident("as_type") {
                 let value = meta.value()?;
                 let s: syn::LitStr = value.parse()?;
                 attrs.as_type = Some(s.value());
                 Ok(())
             } else {
-                Err(meta.error("expected `as_type`"))
+                Err(meta.error("expected `skip` or `as_type`"))
             }
         })?;
     }
@@ -376,9 +383,16 @@ fn gen_enum(schema_name: &str, data: &syn::DataEnum) -> syn::Result<String> {
     let mut rows: Vec<(String, String, String)> = Vec::new(); // (prefix, fields_str, variant_name)
 
     for (idx, variant) in data.variants.iter().enumerate() {
+        let va = parse_variant_attrs(variant)?;
+        // A skipped variant is omitted from the grammar but still consumes its
+        // discriminant, so the following variants keep their `%dNN` tags. This
+        // is how reserved/deprecated slots (which deserialization rejects) are
+        // held without appearing as valid input in the schema.
+        if va.skip {
+            continue;
+        }
         let variant_name = variant.ident.to_string();
         let prefix = format!("%d{idx:02}");
-        let va = parse_variant_attrs(variant)?;
 
         let fields_str = match &variant.fields {
             Fields::Unit => {
@@ -618,5 +632,37 @@ mod tests {
         );
         assert_eq!(to_kebab_case("UQ32_32"), "uq32-32");
         assert_eq!(to_kebab_case("UQ64_64"), "uq64-64");
+    }
+
+    fn enum_schema(source: &str) -> String {
+        let input: DeriveInput = syn::parse_str(source).unwrap();
+        let name = to_kebab_case(&input.ident.to_string());
+        let Data::Enum(data) = &input.data else {
+            panic!("expected an enum");
+        };
+        gen_enum(&name, data).unwrap()
+    }
+
+    #[test]
+    fn skip_variant_holds_its_discriminant() {
+        // The skipped variant is omitted from the grammar, but the variants
+        // after it keep the `%dNN` tag matching their discriminant.
+        let schema = enum_schema(
+            r#"
+            enum Scheme {
+                Ed25519(Ed25519Signature),
+                #[bcs_schema(skip)]
+                Bls12381Reserved,
+                Passkey(PasskeyAuthenticator),
+            }
+            "#,
+        );
+        // `Passkey` keeps tag `%d02` even though it is the second emitted
+        // alternative, and the skipped variant contributes no `%d01` line.
+        assert_eq!(
+            schema,
+            "scheme = %d00 ed25519-signature       ; Ed25519\n\
+             \x20      / %d02 passkey-authenticator   ; Passkey"
+        );
     }
 }

--- a/crates/iota-sdk-ffi/src/types/signature.rs
+++ b/crates/iota-sdk-ffi/src/types/signature.rs
@@ -60,8 +60,14 @@ pub enum SignatureScheme {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// user-signature-bcs = bytes ; where the contents of the bytes are defined by <user-signature>
-/// user-signature = simple-signature / multisig / multisig-legacy / passkey / move-authenticator
+/// user-signature = bytes ; where the contents of the bytes are defined by
+///                        ; <user-signature-body>
+/// user-signature-body = (%d00 ed25519-signature ed25519-public-key) /
+///                       (%d01 secp256k1-signature secp256k1-public-key) /
+///                       (%d02 secp256r1-signature secp256r1-public-key) /
+///                       (%d03 multisig-aggregated-signature) /
+///                       (%d06 passkey-authenticator) /
+///                       (%d07 move-authenticator)
 /// ```
 ///
 /// Note: Due to historical reasons, signatures are serialized slightly
@@ -220,10 +226,11 @@ impl UserSignature {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// simple-signature-bcs = bytes ; where the contents of the bytes are defined by <simple-signature>
-/// simple-signature = (ed25519-flag ed25519-signature ed25519-public-key) /
-///                    (secp256k1-flag secp256k1-signature secp256k1-public-key) /
-///                    (secp256r1-flag secp256r1-signature secp256r1-public-key)
+/// simple-signature = bytes ; where the contents of the bytes are defined by
+///                          ; <simple-signature-body>
+/// simple-signature-body = (ed25519-flag ed25519-signature ed25519-public-key) /
+///                         (secp256k1-flag secp256k1-signature secp256k1-public-key) /
+///                         (secp256r1-flag secp256r1-signature secp256r1-public-key)
 /// ```
 ///
 /// Note: Due to historical reasons, signatures are serialized slightly

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -145,6 +145,10 @@ consensus-determined-version-assignments = %d00 (size *cancelled-transaction)   
 
 digest = %d32 32OCTET
 
+ed25519-public-key = 32OCTET
+
+ed25519-signature = 64OCTET
+
 effects-aux-data-digest = digest
 
 end-of-epoch-data = (size *validator-committee-member)   ; next-epoch-committee
@@ -267,7 +271,13 @@ merge-coins = argument           ; coin
 
 misbehavior-report-digest = digest
 
+move-authenticator = %d00 move-authenticator-v1   ; V1
+
 move-authenticator-digest = digest
+
+move-authenticator-v1 = (size *input)      ; call-args
+                        (size *type-tag)   ; type-args
+                        input              ; object-to-authenticate
 
 move-call = object-id          ; package
             identifier         ; module
@@ -290,6 +300,21 @@ move-package = object-id                          ; id
 move-struct = compressed-struct-tag   ; object-type
               version                 ; version
               bytes                   ; contents
+
+multisig-aggregated-signature = (size *multisig-member-signature)   ; signatures
+                                u16                                 ; bitmap
+                                multisig-committee                  ; committee
+
+multisig-committee = (size *multisig-member)   ; members
+                     u16                       ; threshold
+
+multisig-member = public-key   ; public-key
+                  u8           ; weight
+
+multisig-member-signature = %d00 ed25519-signature     ; Ed25519
+                          / %d01 secp256k1-signature   ; Secp256k1
+                          / %d02 secp256r1-signature   ; Secp256r1
+                          / %d04 bytes                 ; Passkey
 
 object = object-data          ; data
          owner                ; owner
@@ -330,8 +355,19 @@ package-upgrade-error = %d00 object-id             ; UnableToFetchPackage
                       / %d04 u8                    ; UnknownUpgradePolicy
                       / %d05 object-id object-id   ; PackageIdDoesNotMatch
 
+passkey-authenticator = bytes              ; authenticator-data
+                        string             ; client-data-json
+                        simple-signature   ; signature
+
+passkey-public-key = secp256r1-public-key
+
 programmable-transaction = (size *input)     ; inputs
                            (size *command)   ; commands
+
+public-key = %d00 ed25519-public-key     ; Ed25519
+           / %d01 secp256k1-public-key   ; Secp256k1
+           / %d02 secp256r1-public-key   ; Secp256r1
+           / %d04 passkey-public-key     ; Passkey
 
 publish = (size *bytes)       ; modules
           (size *object-id)   ; dependencies
@@ -343,6 +379,14 @@ randomness-state-update = u64                ; epoch
                           bytes              ; random-bytes
                           version            ; randomness-obj-initial-shared-version
 
+secp256k1-public-key = 33OCTET
+
+secp256k1-signature = 64OCTET
+
+secp256r1-public-key = 33OCTET
+
+secp256r1-signature = 64OCTET
+
 sender-signed-data-digest = digest
 
 signed-checkpoint-summary = checkpoint-summary               ; checkpoint
@@ -350,6 +394,12 @@ signed-checkpoint-summary = checkpoint-summary               ; checkpoint
 
 signed-transaction = transaction              ; transaction
                      (size *user-signature)   ; signatures
+
+simple-signature = bytes
+
+simple-signature-body = %d00 ed25519-signature ed25519-public-key       ; Ed25519
+                      / %d01 secp256k1-signature secp256k1-public-key   ; Secp256k1
+                      / %d02 secp256r1-signature secp256r1-public-key   ; Secp256r1
 
 size    = uleb128   ; BCS sequence/string length (ULEB128-encoded)
 
@@ -458,6 +508,13 @@ upgrade-info = object-id   ; upgraded-id
                version     ; upgraded-version
 
 user-signature = bytes
+
+user-signature-body = %d00 ed25519-signature ed25519-public-key       ; Ed25519
+                    / %d01 secp256k1-signature secp256k1-public-key   ; Secp256k1
+                    / %d02 secp256r1-signature secp256r1-public-key   ; Secp256r1
+                    / %d03 multisig-aggregated-signature              ; Multisig
+                    / %d06 passkey-authenticator                      ; Passkey
+                    / %d07 move-authenticator                         ; Move
 
 validator-aggregated-signature = u64                  ; epoch
                                  bls12381-signature   ; signature

--- a/crates/iota-sdk-types/src/crypto/ed25519.rs
+++ b/crates/iota-sdk-types/src/crypto/ed25519.rs
@@ -18,6 +18,11 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "32OCTET")
+)]
 pub struct Ed25519PublicKey(
     #[cfg_attr(
         feature = "serde",
@@ -132,6 +137,11 @@ impl std::fmt::Debug for Ed25519PublicKey {
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "64OCTET")
+)]
 pub struct Ed25519Signature(
     #[cfg_attr(
         feature = "serde",

--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -12,6 +12,7 @@ use crate::{Address, Input, ObjectReference, TypeTag, transaction::SharedObjectR
 /// authentication flow.
 #[derive(Clone, Debug, derive_more::From, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
 pub enum MoveAuthenticator {
@@ -42,6 +43,7 @@ impl Hash for MoveAuthenticator {
 /// Version 1 of the [`MoveAuthenticator`].
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MoveAuthenticatorV1 {
     /// Input objects or primitive values

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -1067,24 +1067,31 @@ mod tests {
     fn multisig_standalone_bcs_framing() {
         use base64ct::{Base64, Encoding};
 
-        // A multisig fixture from mainnet, as the `bytes`-wrapped
-        // `UserSignature` form: `[uleb-len][0x03 flag][body]`.
-        let multisig_b64 = "sgIDAwCTLgVngjC4yeuvpAGKVkgcvIKVFUJnL1r6oFZScQVE5DNIz6kfxAGDRcVUczE9CUb7/sN/EuFJ8ot86Sdb8pAFASoQ91stRHXdW5dLy0BQ6v+7XWptawy2ItMyPk508p+PHdtZcm2aKl3lZGIvXe6MPY73E+1Hakv/xJbTYsw5SPMC5dx3gBwxds2GV12c7VUSqkyXamliSF1W/QBMufqrlmdIOZ1ox9gbsvIPtXYahfvKm8ozA7rsZWwRv8atsnyfYgcAAwANfas1jI2tqk76AEmnWwdDZVWxCjaCGbtoD3BXE0nXdQEBAg4XzVk55GsZZkGWjNdZkQuiV34n+nP944dtub7FvOsrAQIDR/uvI/A4q8TDCKJxEXoqTP+u3bxf+Bx1F7xsdKfttDABAgA=";
-        let user_signature_bcs = Base64::decode_vec(multisig_b64).unwrap();
-        let UserSignature::Multisig(sig) =
-            bcs::from_bytes::<UserSignature>(&user_signature_bcs).unwrap()
+        // A multisig `UserSignature` from a mainnet transaction, in the flat
+        // `[0x03 flag][body]` wire form (the `to_bytes` / explorer encoding):
+        // https://explorer.iota.org/txblock/BUPSmkG8QZgr1NtVNjFaJMYsArkaWMECs7RHbEZRZUEU?network=https%3A%2F%2Findexer.mainnet.iota.cafe
+        let multisig_b64 = "AwIA+zI2waYMirpLgCXsqGcuy+VPNToMkxYeBxkQVSgFdIS/TnAHQKs9FFAzHTfV2iSJuO25oIw5dnu9KEBSZwiqBQAf+R79IrKzolrY7mAM6TmE8T9sKk496ztesq0ao6a5BDFeH0QrIXJ68PZFAdEE86k3wh1WkeIYjxAMrIBpy9YBGAAFALurCXoe8wunaE2g6O2CtIZW4lSIf/fImJrdqRvZtlphAQCpMi2gCtRO9jNLl3bwc1x8IB/YYs1P6XpUEQbwzh2lGAEABYLKuo/1LUczMu80FayRheNYXavDC8l+QLX/s4S9i7QBAJYYQ5QWs/aT8+VwA+Vh3wswa90eqAaf6N4yzYUSXuTCAQBR6+eXlJ4GViO9z7QXRPSUaRPR9DlyDjc6S9lz61JNLgECAA==";
+        let flag_and_body = Base64::decode_vec(multisig_b64).unwrap();
+        let UserSignature::Multisig(sig) = UserSignature::from_bytes(&flag_and_body).unwrap()
         else {
             panic!("expected multisig signature");
         };
 
-        // The standalone BCS form of the inner multisig is the same
-        // `bytes`-wrapped `flag || body` blob as the whole `UserSignature`.
+        // `to_bytes` is the flat `flag || body`; the standalone BCS form wraps
+        // that same blob in a ULEB length prefix (identical to BCS-encoding the
+        // bytes themselves).
+        assert_eq!(
+            sig.to_bytes(),
+            flag_and_body,
+            "multisig `to_bytes` must be the flat `flag || body` wire form"
+        );
         assert_eq!(
             bcs::to_bytes(&sig).unwrap(),
-            user_signature_bcs,
-            "standalone BCS must be the length-prefixed `flag || body` wire form"
+            bcs::to_bytes(&flag_and_body).unwrap(),
+            "standalone BCS must be the ULEB-length-prefixed `flag || body` wire form"
         );
-        let decoded: MultisigAggregatedSignature = bcs::from_bytes(&user_signature_bcs).unwrap();
+        let decoded: MultisigAggregatedSignature =
+            bcs::from_bytes(&bcs::to_bytes(&sig).unwrap()).unwrap();
         assert_eq!(sig, decoded);
     }
 

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -74,9 +74,11 @@ pub enum MultisigError {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct MultisigMember {
     public_key: PublicKey,
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u8"))]
     weight: WeightUnit,
 }
 
@@ -124,11 +126,13 @@ impl MultisigMember {
 /// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MultisigCommittee {
     /// A list of committee members and their corresponding weight.
     members: Vec<MultisigMember>,
     /// If the total weight of the public keys corresponding to verified
     /// signatures is larger than threshold, the Multisig is verified.
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u16"))]
     threshold: ThresholdUnit,
 }
 
@@ -273,6 +277,7 @@ impl MultisigCommittee {
 /// See [here](https://github.com/RoaringBitmap/RoaringFormatSpec) for the specification for the
 /// serialized format of RoaringBitmaps.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MultisigAggregatedSignature {
     /// The plain signature encoded with signature scheme.
     ///
@@ -281,6 +286,7 @@ pub struct MultisigAggregatedSignature {
     signatures: Vec<MultisigMemberSignature>,
     /// A bitmap that indicates the position of which public key the signature
     /// should be authenticated with.
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u16"))]
     bitmap: BitmapUnit,
     /// The public key encoded with each public key with its signature scheme
     /// used along with the corresponding weight.
@@ -585,7 +591,7 @@ impl proptest::arbitrary::Arbitrary for MultisigAggregatedSignature {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
-mod serialization {
+pub(crate) mod serialization {
     use std::{
         borrow::Cow,
         hash::{Hash, Hasher},
@@ -599,18 +605,40 @@ mod serialization {
     use super::*;
     use crate::{SignatureScheme, crypto::SignatureFromBytesError};
 
+    /// Owned wire shape of an aggregated multisig: the flat
+    /// `signatures || bitmap || committee` body without the scheme flag or
+    /// length prefix. `UserSignatureBody::Multisig` embeds this type directly
+    /// (the enum tag supplies the flag and the outer `UserSignature` the
+    /// length prefix), while `MultisigAggregatedSignature`'s own serde keeps
+    /// the historical `bytes`-wrapped `flag || body` form.
     #[derive(serde::Deserialize)]
-    pub struct Multisig {
+    pub(crate) struct Multisig {
         signatures: Vec<MultisigMemberSignature>,
         bitmap: BitmapUnit,
         committee: MultisigCommittee,
     }
 
     #[derive(serde::Serialize)]
-    pub struct MultisigRef<'a> {
+    struct MultisigRef<'a> {
         signatures: &'a [MultisigMemberSignature],
         bitmap: BitmapUnit,
         committee: &'a MultisigCommittee,
+    }
+
+    impl TryFrom<Multisig> for MultisigAggregatedSignature {
+        type Error = SignatureFromBytesError;
+
+        fn try_from(multisig: Multisig) -> Result<Self, Self::Error> {
+            let multisig = Self {
+                signatures: multisig.signatures,
+                bitmap: multisig.bitmap,
+                committee: multisig.committee,
+            };
+            multisig
+                .validate()
+                .map_err(|e| SignatureFromBytesError::new(format!("invalid multisig: {e}")))?;
+            Ok(multisig)
+        }
     }
 
     #[derive(serde::Deserialize)]
@@ -668,10 +696,10 @@ mod serialization {
     }
 
     impl MultisigAggregatedSignature {
+        /// Encode this aggregated signature as `flag || bcs-body`, where
+        /// `flag` is the multisig scheme byte (`0x03`).
         pub fn to_bytes(&self) -> Vec<u8> {
-            let mut buf = Vec::new();
-            buf.push(SignatureScheme::Multisig as u8);
-
+            let mut buf = vec![SignatureScheme::Multisig as u8];
             let multisig = MultisigRef {
                 signatures: &self.signatures,
                 bitmap: self.bitmap,
@@ -692,29 +720,33 @@ mod serialization {
                 return Err(SignatureFromBytesError::new("invalid multisig flag"));
             }
 
-            if let Ok(multisig) = bcs::from_bytes::<Multisig>(tail) {
-                let multisig = Self {
-                    signatures: multisig.signatures,
-                    bitmap: multisig.bitmap,
-                    committee: multisig.committee,
-                };
-                multisig
-                    .validate()
-                    .map_err(|e| SignatureFromBytesError::new(format!("invalid multisig: {e}")))?;
-                Ok(multisig)
-            } else {
-                Err(SignatureFromBytesError::new("invalid multisig"))
-            }
+            bcs::from_bytes::<Multisig>(tail)
+                .map_err(|_| SignatureFromBytesError::new("invalid multisig"))?
+                .try_into()
         }
     }
 
+    /// Wire shape for `MultisigMemberSignature`.
+    ///
+    /// The `ZkLoginDeprecated` placeholder pins `Passkey` at flag `%d04`; it
+    /// is rejected on deserialization. The passkey arm serializes through
+    /// `PasskeyAuthenticator`'s own serde, i.e. as length-prefixed `bytes`
+    /// containing `passkey-flag || passkey-authenticator`.
     #[derive(serde::Deserialize, serde::Serialize)]
+    #[cfg_attr(
+        feature = "bcs-schema",
+        derive(iota_bcs_schema::BcsSchema),
+        bcs_schema(name = "multisig-member-signature")
+    )]
     enum MemberSignature {
         Ed25519(Ed25519Signature),
         Secp256k1(Secp256k1Signature),
         Secp256r1(Secp256r1Signature),
+        #[cfg_attr(feature = "bcs-schema", bcs_schema(skip))]
         ZkLoginDeprecated,
-        Passkey(PasskeyAuthenticator),
+        Passkey(
+            #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "bytes"))] PasskeyAuthenticator,
+        ),
     }
 
     #[derive(serde::Deserialize, serde::Serialize)]
@@ -1024,6 +1056,65 @@ mod tests {
         assert_eq!(
             sig, decoded,
             "to_base64/from_base64 must be inverses of each other"
+        );
+    }
+
+    /// A standalone `MultisigAggregatedSignature` BCS-serializes as
+    /// length-prefixed bytes containing `multisig-flag || body`, exactly the
+    /// `to_bytes` form. A round-trip test cannot detect losing (or doubling)
+    /// that framing, so it is pinned here byte-by-byte.
+    #[test]
+    fn multisig_standalone_bcs_framing() {
+        use base64ct::{Base64, Encoding};
+
+        // A multisig fixture from mainnet, as the `bytes`-wrapped
+        // `UserSignature` form: `[uleb-len][0x03 flag][body]`.
+        let multisig_b64 = "sgIDAwCTLgVngjC4yeuvpAGKVkgcvIKVFUJnL1r6oFZScQVE5DNIz6kfxAGDRcVUczE9CUb7/sN/EuFJ8ot86Sdb8pAFASoQ91stRHXdW5dLy0BQ6v+7XWptawy2ItMyPk508p+PHdtZcm2aKl3lZGIvXe6MPY73E+1Hakv/xJbTYsw5SPMC5dx3gBwxds2GV12c7VUSqkyXamliSF1W/QBMufqrlmdIOZ1ox9gbsvIPtXYahfvKm8ozA7rsZWwRv8atsnyfYgcAAwANfas1jI2tqk76AEmnWwdDZVWxCjaCGbtoD3BXE0nXdQEBAg4XzVk55GsZZkGWjNdZkQuiV34n+nP944dtub7FvOsrAQIDR/uvI/A4q8TDCKJxEXoqTP+u3bxf+Bx1F7xsdKfttDABAgA=";
+        let user_signature_bcs = Base64::decode_vec(multisig_b64).unwrap();
+        let UserSignature::Multisig(sig) =
+            bcs::from_bytes::<UserSignature>(&user_signature_bcs).unwrap()
+        else {
+            panic!("expected multisig signature");
+        };
+
+        // The standalone BCS form of the inner multisig is the same
+        // `bytes`-wrapped `flag || body` blob as the whole `UserSignature`.
+        assert_eq!(
+            bcs::to_bytes(&sig).unwrap(),
+            user_signature_bcs,
+            "standalone BCS must be the length-prefixed `flag || body` wire form"
+        );
+        let decoded: MultisigAggregatedSignature = bcs::from_bytes(&user_signature_bcs).unwrap();
+        assert_eq!(sig, decoded);
+    }
+
+    /// A passkey member signature is BCS-framed as `%d04` followed by
+    /// length-prefixed bytes containing `passkey-flag || passkey body` — the
+    /// historical wrapping produced by `PasskeyAuthenticator`'s serde. A
+    /// round-trip test cannot detect losing (or doubling) that framing, so it
+    /// is pinned here byte-by-byte.
+    #[test]
+    fn member_signature_passkey_bcs_framing() {
+        use base64ct::{Base64, Encoding};
+
+        let passkey_b64 = "BiVYDmenOnqS+thmz5m5SrZnWaKXZLVxgh+rri6LHXs25B0AAAAAnQF7InR5cGUiOiJ3ZWJhdXRobi5nZXQiLCAiY2hhbGxlbmdlIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQSIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTE3MyIsImNyb3NzT3JpZ2luIjpmYWxzZSwgInVua25vd24iOiAidW5rbm93biJ9YgJMwqcOmZI7F/N+K5SMe4DRYCb4/cDWW68SFneSHoD2GxKKhksbpZ5rZpdrjSYABTCsFQQBpLORzTvbj4edWKd/AsEBeovrGvHR9Ku7critg6k7qvfFlPUngujXfEzXd8Eg";
+        let passkey_wire = Base64::decode_vec(passkey_b64).unwrap();
+        let UserSignature::PasskeyAuthenticator(passkey_authenticator) =
+            UserSignature::from_base64(passkey_b64).unwrap()
+        else {
+            panic!("expected passkey authenticator");
+        };
+
+        let bytes =
+            bcs::to_bytes(&MultisigMemberSignature::Passkey(passkey_authenticator)).unwrap();
+        // `%d04` member tag, then the passkey as length-prefixed bytes whose
+        // contents are exactly the standalone `flag || body` wire form.
+        assert_eq!(bytes[0], 0x04, "passkey member signature must use tag 4");
+        let expected = bcs::to_bytes(&passkey_wire).unwrap();
+        assert_eq!(
+            bytes[1..],
+            expected[..],
+            "passkey member payload must be the length-prefixed standalone wire form"
         );
     }
 

--- a/crates/iota-sdk-types/src/crypto/passkey.rs
+++ b/crates/iota-sdk-types/src/crypto/passkey.rs
@@ -125,6 +125,11 @@ impl Hash for PasskeyAuthenticator {
     derive(serde::Deserialize, serde::Serialize),
     serde(transparent)
 )]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "secp256r1-public-key")
+)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct PasskeyPublicKey(Secp256r1PublicKey);
 
@@ -147,7 +152,7 @@ impl AsRef<[u8]> for PasskeyPublicKey {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
-mod serialization {
+pub(crate) mod serialization {
     use std::borrow::Cow;
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -163,12 +168,34 @@ mod serialization {
         signature: SimpleSignature,
     }
 
+    /// Owned wire shape of a passkey authenticator: the three fields that
+    /// are actually serialized (the public type's `public_key`, `signature`
+    /// and derived `challenge` are folded into / recovered from these).
+    ///
+    /// `UserSignatureBody::Passkey` decodes through this type so that a
+    /// `UserSignature` carries the flat passkey body behind its own scheme
+    /// tag, while `PasskeyAuthenticator`'s standalone serde keeps the
+    /// historical `bytes`-wrapped `flag || body` form used when a passkey is
+    /// nested in a multisig member signature.
     #[derive(serde::Deserialize)]
     #[serde(rename = "PasskeyAuthenticator")]
-    struct Authenticator {
+    #[cfg_attr(
+        feature = "bcs-schema",
+        derive(iota_bcs_schema::BcsSchema),
+        bcs_schema(name = "passkey-authenticator")
+    )]
+    pub(crate) struct Authenticator {
         authenticator_data: Vec<u8>,
         client_data_json: String,
         signature: SimpleSignature,
+    }
+
+    impl TryFrom<Authenticator> for PasskeyAuthenticator {
+        type Error = SignatureFromBytesError;
+
+        fn try_from(authenticator: Authenticator) -> Result<Self, Self::Error> {
+            Self::try_from_raw(authenticator)
+        }
     }
 
     impl Serialize for PasskeyAuthenticator {

--- a/crates/iota-sdk-types/src/crypto/public_key.rs
+++ b/crates/iota-sdk-types/src/crypto/public_key.rs
@@ -146,16 +146,29 @@ mod serialization {
     use super::*;
     use crate::{Ed25519PublicKey, PasskeyPublicKey, Secp256k1PublicKey, Secp256r1PublicKey};
 
-    #[derive(serde::Deserialize, serde::Serialize)]
-    enum BinaryPublicKey {
+    /// Flat wire shape for `PublicKey`.
+    ///
+    /// The BCS variant tags are `PublicKey`'s own historical flag values
+    /// (0x00 Ed25519, 0x01 Secp256k1, 0x02 Secp256r1, 0x04 Passkey) — note
+    /// that passkey public keys use tag `0x04` here even though the passkey
+    /// *signature scheme* flag is `0x06`. The `ZkLoginDeprecated` placeholder
+    /// holds the `0x03` slot and is rejected by the deserializer.
+    #[derive(Deserialize, Serialize)]
+    #[cfg_attr(
+        feature = "bcs-schema",
+        derive(iota_bcs_schema::BcsSchema),
+        bcs_schema(name = "public-key")
+    )]
+    enum PublicKeyBody {
         Ed25519(Ed25519PublicKey),
         Secp256k1(Secp256k1PublicKey),
         Secp256r1(Secp256r1PublicKey),
+        #[cfg_attr(feature = "bcs-schema", bcs_schema(skip))]
         ZkLoginDeprecated,
         Passkey(PasskeyPublicKey),
     }
 
-    #[derive(serde::Deserialize, serde::Serialize)]
+    #[derive(Deserialize, Serialize)]
     #[serde(tag = "scheme", rename_all = "lowercase")]
     #[serde(rename = "PublicKey")]
     enum ReadablePublicKey {
@@ -188,13 +201,13 @@ mod serialization {
                 };
                 readable.serialize(serializer)
             } else {
-                let binary = match self {
-                    PublicKey::Ed25519(public_key) => BinaryPublicKey::Ed25519(*public_key),
-                    PublicKey::Secp256k1(public_key) => BinaryPublicKey::Secp256k1(*public_key),
-                    PublicKey::Secp256r1(public_key) => BinaryPublicKey::Secp256r1(*public_key),
-                    PublicKey::Passkey(public_key) => BinaryPublicKey::Passkey(public_key.clone()),
+                let body = match self {
+                    PublicKey::Ed25519(public_key) => PublicKeyBody::Ed25519(*public_key),
+                    PublicKey::Secp256k1(public_key) => PublicKeyBody::Secp256k1(*public_key),
+                    PublicKey::Secp256r1(public_key) => PublicKeyBody::Secp256r1(*public_key),
+                    PublicKey::Passkey(public_key) => PublicKeyBody::Passkey(public_key.clone()),
                 };
-                binary.serialize(serializer)
+                body.serialize(serializer)
             }
         }
     }
@@ -218,17 +231,17 @@ mod serialization {
                     ReadablePublicKey::Passkey { public_key } => Self::Passkey(public_key),
                 })
             } else {
-                let binary = BinaryPublicKey::deserialize(deserializer)?;
-                Ok(match binary {
-                    BinaryPublicKey::Ed25519(public_key) => Self::Ed25519(public_key),
-                    BinaryPublicKey::Secp256k1(public_key) => Self::Secp256k1(public_key),
-                    BinaryPublicKey::Secp256r1(public_key) => Self::Secp256r1(public_key),
-                    BinaryPublicKey::ZkLoginDeprecated => {
+                let body = PublicKeyBody::deserialize(deserializer)?;
+                Ok(match body {
+                    PublicKeyBody::Ed25519(public_key) => Self::Ed25519(public_key),
+                    PublicKeyBody::Secp256k1(public_key) => Self::Secp256k1(public_key),
+                    PublicKeyBody::Secp256r1(public_key) => Self::Secp256r1(public_key),
+                    PublicKeyBody::ZkLoginDeprecated => {
                         return Err(serde::de::Error::custom(
                             "zkLoginDeprecated is not supported",
                         ));
                     }
-                    BinaryPublicKey::Passkey(public_key) => Self::Passkey(public_key),
+                    PublicKeyBody::Passkey(public_key) => Self::Passkey(public_key),
                 })
             }
         }

--- a/crates/iota-sdk-types/src/crypto/secp256k1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256k1.rs
@@ -18,6 +18,11 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "33OCTET")
+)]
 pub struct Secp256k1PublicKey(
     #[cfg_attr(
         feature = "serde",
@@ -134,6 +139,11 @@ impl std::fmt::Debug for Secp256k1PublicKey {
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "64OCTET")
+)]
 pub struct Secp256k1Signature(
     #[cfg_attr(
         feature = "serde",

--- a/crates/iota-sdk-types/src/crypto/secp256r1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256r1.rs
@@ -18,6 +18,11 @@ use crate::crypto::{PublicKeyExt, SignatureScheme};
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "33OCTET")
+)]
 pub struct Secp256r1PublicKey(
     #[cfg_attr(
         feature = "serde",
@@ -134,6 +139,11 @@ impl std::fmt::Debug for Secp256r1PublicKey {
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "64OCTET")
+)]
 pub struct Secp256r1Signature(
     #[cfg_attr(
         feature = "serde",

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -19,10 +19,11 @@ use crate::crypto::move_authenticator::MoveAuthenticator;
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// simple-signature-bcs = bytes ; where the contents of the bytes are defined by <simple-signature>
-/// simple-signature = (ed25519-flag ed25519-signature ed25519-public-key) /
-///                    (secp256k1-flag secp256k1-signature secp256k1-public-key) /
-///                    (secp256r1-flag secp256r1-signature secp256r1-public-key)
+/// simple-signature = bytes ; where the contents of the bytes are defined by
+///                          ; <simple-signature-body>
+/// simple-signature-body = (ed25519-flag ed25519-signature ed25519-public-key) /
+///                         (secp256k1-flag secp256k1-signature secp256k1-public-key) /
+///                         (secp256r1-flag secp256r1-signature secp256r1-public-key)
 /// ```
 ///
 /// Note: Due to historical reasons, signatures are serialized slightly
@@ -32,6 +33,11 @@ use crate::crypto::move_authenticator::MoveAuthenticator;
 /// the completely serialized signature.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(
+    feature = "bcs-schema",
+    derive(iota_bcs_schema::BcsSchema),
+    bcs_schema(definition = "bytes")
+)]
 #[non_exhaustive]
 pub enum SimpleSignature {
     Ed25519 {
@@ -327,8 +333,9 @@ impl std::fmt::Display for InvalidSignatureScheme {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// user-signature-bcs = bytes ; where the contents of the bytes are defined by <user-signature>
-/// user-signature = simple-signature / multisig / multisig-legacy / passkey / move-authenticator
+/// user-signature = bytes ; where the contents of the bytes are defined by
+///                        ; <user-signature-body>
+/// user-signature-body = simple-signature-body / multisig / passkey / move-authenticator
 /// ```
 ///
 /// Note: Due to historical reasons, signatures are serialized slightly
@@ -397,44 +404,180 @@ impl UserSignature {
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod serialization {
-    use std::str::FromStr;
+    use std::{borrow::Cow, str::FromStr};
+
+    use serde_with::{Bytes, DeserializeAs};
 
     use super::*;
     use crate::crypto::SignatureFromBytesError;
 
-    impl SimpleSignature {
-        pub fn to_bytes(&self) -> Vec<u8> {
-            let mut buf = Vec::new();
-            match self {
+    // -----------------------------------------------------------------------
+    // SimpleSignature
+    // -----------------------------------------------------------------------
+
+    /// Flat wire shape for `SimpleSignature`.
+    ///
+    /// Variant order matches the scheme flags (0x00 Ed25519, 0x01 Secp256k1,
+    /// 0x02 Secp256r1) so BCS emits the correct byte for each variant
+    /// automatically. All fields are `Copy`, so the same owned enum serves
+    /// both serialization (built by copying) and deserialization.
+    #[derive(serde::Deserialize, serde::Serialize)]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    pub(crate) enum SimpleSignatureBody {
+        Ed25519 {
+            signature: Ed25519Signature,
+            public_key: Ed25519PublicKey,
+        },
+        Secp256k1 {
+            signature: Secp256k1Signature,
+            public_key: Secp256k1PublicKey,
+        },
+        Secp256r1 {
+            signature: Secp256r1Signature,
+            public_key: Secp256r1PublicKey,
+        },
+    }
+
+    impl From<&SimpleSignature> for SimpleSignatureBody {
+        fn from(sig: &SimpleSignature) -> Self {
+            match *sig {
                 SimpleSignature::Ed25519 {
                     signature,
                     public_key,
-                } => {
-                    buf.push(SignatureScheme::Ed25519 as u8);
-                    buf.extend_from_slice(signature.as_ref());
-                    buf.extend_from_slice(public_key.as_ref());
-                }
+                } => Self::Ed25519 {
+                    signature,
+                    public_key,
+                },
                 SimpleSignature::Secp256k1 {
                     signature,
                     public_key,
-                } => {
-                    buf.push(SignatureScheme::Secp256k1 as u8);
-                    buf.extend_from_slice(signature.as_ref());
-                    buf.extend_from_slice(public_key.as_ref());
-                }
+                } => Self::Secp256k1 {
+                    signature,
+                    public_key,
+                },
                 SimpleSignature::Secp256r1 {
                     signature,
                     public_key,
-                } => {
-                    buf.push(SignatureScheme::Secp256r1 as u8);
-                    buf.extend_from_slice(signature.as_ref());
-                    buf.extend_from_slice(public_key.as_ref());
-                }
+                } => Self::Secp256r1 {
+                    signature,
+                    public_key,
+                },
             }
+        }
+    }
 
-            buf
+    impl From<SimpleSignatureBody> for SimpleSignature {
+        fn from(body: SimpleSignatureBody) -> Self {
+            match body {
+                SimpleSignatureBody::Ed25519 {
+                    signature,
+                    public_key,
+                } => Self::Ed25519 {
+                    signature,
+                    public_key,
+                },
+                SimpleSignatureBody::Secp256k1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256k1 {
+                    signature,
+                    public_key,
+                },
+                SimpleSignatureBody::Secp256r1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256r1 {
+                    signature,
+                    public_key,
+                },
+            }
+        }
+    }
+
+    #[derive(serde::Deserialize, serde::Serialize)]
+    #[serde(tag = "scheme", rename_all = "lowercase")]
+    #[serde(rename = "SimpleSignature")]
+    enum ReadableSimpleSignature {
+        Ed25519 {
+            signature: Ed25519Signature,
+            public_key: Ed25519PublicKey,
+        },
+        Secp256k1 {
+            signature: Secp256k1Signature,
+            public_key: Secp256k1PublicKey,
+        },
+        Secp256r1 {
+            signature: Secp256r1Signature,
+            public_key: Secp256r1PublicKey,
+        },
+    }
+
+    impl From<&SimpleSignature> for ReadableSimpleSignature {
+        fn from(sig: &SimpleSignature) -> Self {
+            match *sig {
+                SimpleSignature::Ed25519 {
+                    signature,
+                    public_key,
+                } => Self::Ed25519 {
+                    signature,
+                    public_key,
+                },
+                SimpleSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256k1 {
+                    signature,
+                    public_key,
+                },
+                SimpleSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256r1 {
+                    signature,
+                    public_key,
+                },
+            }
+        }
+    }
+
+    impl From<ReadableSimpleSignature> for SimpleSignature {
+        fn from(r: ReadableSimpleSignature) -> Self {
+            match r {
+                ReadableSimpleSignature::Ed25519 {
+                    signature,
+                    public_key,
+                } => Self::Ed25519 {
+                    signature,
+                    public_key,
+                },
+                ReadableSimpleSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256k1 {
+                    signature,
+                    public_key,
+                },
+                ReadableSimpleSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                } => Self::Secp256r1 {
+                    signature,
+                    public_key,
+                },
+            }
+        }
+    }
+
+    impl SimpleSignature {
+        /// Encode this signature as `<scheme-flag> <signature> <public-key>`.
+        ///
+        /// Note: this is the flat body shape — no outer length prefix.
+        pub fn to_bytes(&self) -> Vec<u8> {
+            bcs::to_bytes(&SimpleSignatureBody::from(self))
+                .expect("BCS serialization of SimpleSignature cannot fail")
         }
 
+        /// Decode a `SimpleSignature` from its flat-body byte encoding.
         pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, SignatureFromBytesError> {
             let bytes = bytes.as_ref();
             let flag =
@@ -443,68 +586,18 @@ mod serialization {
                 })?)
                 .map_err(SignatureFromBytesError::new)?;
             match flag {
-                SignatureScheme::Ed25519 => {
-                    let expected_length = 1 + Ed25519Signature::LENGTH + Ed25519PublicKey::LENGTH;
-
-                    if bytes.len() != expected_length {
-                        return Err(SignatureFromBytesError::new("invalid ed25519 signature"));
-                    }
-
-                    let mut signature = [0; Ed25519Signature::LENGTH];
-                    signature.copy_from_slice(&bytes[1..(1 + Ed25519Signature::LENGTH)]);
-
-                    let mut public_key = [0; Ed25519PublicKey::LENGTH];
-                    public_key.copy_from_slice(&bytes[(1 + Ed25519Signature::LENGTH)..]);
-
-                    Ok(SimpleSignature::Ed25519 {
-                        signature: Ed25519Signature::new(signature),
-                        public_key: Ed25519PublicKey::new(public_key),
-                    })
-                }
-                SignatureScheme::Secp256k1 => {
-                    let expected_length =
-                        1 + Secp256k1Signature::LENGTH + Secp256k1PublicKey::LENGTH;
-
-                    if bytes.len() != expected_length {
-                        return Err(SignatureFromBytesError::new("invalid secp25k1 signature"));
-                    }
-
-                    let mut signature = [0; Secp256k1Signature::LENGTH];
-                    signature.copy_from_slice(&bytes[1..(1 + Secp256k1Signature::LENGTH)]);
-
-                    let mut public_key = [0; Secp256k1PublicKey::LENGTH];
-                    public_key.copy_from_slice(&bytes[(1 + Secp256k1Signature::LENGTH)..]);
-
-                    Ok(SimpleSignature::Secp256k1 {
-                        signature: Secp256k1Signature::new(signature),
-                        public_key: Secp256k1PublicKey::new(public_key),
-                    })
-                }
-                SignatureScheme::Secp256r1 => {
-                    let expected_length =
-                        1 + Secp256r1Signature::LENGTH + Secp256r1PublicKey::LENGTH;
-
-                    if bytes.len() != expected_length {
-                        return Err(SignatureFromBytesError::new("invalid secp25r1 signature"));
-                    }
-
-                    let mut signature = [0; Secp256r1Signature::LENGTH];
-                    signature.copy_from_slice(&bytes[1..(1 + Secp256r1Signature::LENGTH)]);
-
-                    let mut public_key = [0; Secp256r1PublicKey::LENGTH];
-                    public_key.copy_from_slice(&bytes[(1 + Secp256r1Signature::LENGTH)..]);
-
-                    Ok(SimpleSignature::Secp256r1 {
-                        signature: Secp256r1Signature::new(signature),
-                        public_key: Secp256r1PublicKey::new(public_key),
-                    })
-                }
-                SignatureScheme::Multisig
-                | SignatureScheme::Bls12381
-                | SignatureScheme::PasskeyAuthenticator
-                | SignatureScheme::MoveAuthenticator => {
-                    Err(SignatureFromBytesError::new("invalid signature scheme"))
-                }
+                SignatureScheme::Ed25519
+                | SignatureScheme::Secp256k1
+                | SignatureScheme::Secp256r1 => bcs::from_bytes::<SimpleSignatureBody>(bytes)
+                    .map(Into::into)
+                    .map_err(|_| {
+                        SignatureFromBytesError::new(match flag {
+                            SignatureScheme::Ed25519 => "invalid ed25519 signature",
+                            SignatureScheme::Secp256k1 => "invalid secp25k1 signature",
+                            _ => "invalid secp25r1 signature",
+                        })
+                    }),
+                _ => Err(SignatureFromBytesError::new("invalid signature scheme")),
             }
         }
     }
@@ -514,92 +607,10 @@ mod serialization {
         where
             S: serde::Serializer,
         {
-            #[derive(serde::Serialize)]
-            #[serde(tag = "scheme")]
-            #[serde(rename_all = "lowercase")]
-            enum Sig<'a> {
-                Ed25519 {
-                    signature: &'a Ed25519Signature,
-                    public_key: &'a Ed25519PublicKey,
-                },
-                Secp256k1 {
-                    signature: &'a Secp256k1Signature,
-                    public_key: &'a Secp256k1PublicKey,
-                },
-                Secp256r1 {
-                    signature: &'a Secp256r1Signature,
-                    public_key: &'a Secp256r1PublicKey,
-                },
-            }
-
             if serializer.is_human_readable() {
-                let sig = match self {
-                    SimpleSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    } => Sig::Ed25519 {
-                        signature,
-                        public_key,
-                    },
-                    SimpleSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    } => Sig::Secp256k1 {
-                        signature,
-                        public_key,
-                    },
-                    SimpleSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    } => Sig::Secp256r1 {
-                        signature,
-                        public_key,
-                    },
-                };
-
-                sig.serialize(serializer)
+                ReadableSimpleSignature::from(self).serialize(serializer)
             } else {
-                match self {
-                    SimpleSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    } => {
-                        let mut buf = [0; 1 + Ed25519Signature::LENGTH + Ed25519PublicKey::LENGTH];
-                        buf[0] = SignatureScheme::Ed25519 as u8;
-                        buf[1..(1 + Ed25519Signature::LENGTH)].copy_from_slice(signature.as_ref());
-                        buf[(1 + Ed25519Signature::LENGTH)..].copy_from_slice(public_key.as_ref());
-
-                        serializer.serialize_bytes(&buf)
-                    }
-                    SimpleSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    } => {
-                        let mut buf =
-                            [0; 1 + Secp256k1Signature::LENGTH + Secp256k1PublicKey::LENGTH];
-                        buf[0] = SignatureScheme::Secp256k1 as u8;
-                        buf[1..(1 + Secp256k1Signature::LENGTH)]
-                            .copy_from_slice(signature.as_ref());
-                        buf[(1 + Secp256k1Signature::LENGTH)..]
-                            .copy_from_slice(public_key.as_ref());
-
-                        serializer.serialize_bytes(&buf)
-                    }
-                    SimpleSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    } => {
-                        let mut buf =
-                            [0; 1 + Secp256r1Signature::LENGTH + Secp256r1PublicKey::LENGTH];
-                        buf[0] = SignatureScheme::Secp256r1 as u8;
-                        buf[1..(1 + Secp256r1Signature::LENGTH)]
-                            .copy_from_slice(signature.as_ref());
-                        buf[(1 + Secp256r1Signature::LENGTH)..]
-                            .copy_from_slice(public_key.as_ref());
-
-                        serializer.serialize_bytes(&buf)
-                    }
-                }
+                serializer.serialize_bytes(&self.to_bytes())
             }
         }
     }
@@ -609,112 +620,104 @@ mod serialization {
         where
             D: serde::Deserializer<'de>,
         {
-            #[derive(serde::Deserialize)]
-            #[serde(tag = "scheme")]
-            #[serde(rename_all = "lowercase")]
-            enum Sig {
-                Ed25519 {
-                    signature: Ed25519Signature,
-                    public_key: Ed25519PublicKey,
-                },
-                Secp256k1 {
-                    signature: Secp256k1Signature,
-                    public_key: Secp256k1PublicKey,
-                },
-                Secp256r1 {
-                    signature: Secp256r1Signature,
-                    public_key: Secp256r1PublicKey,
-                },
-            }
-
             if deserializer.is_human_readable() {
-                let sig = Sig::deserialize(deserializer)?;
-                Ok(match sig {
-                    Sig::Ed25519 {
-                        signature,
-                        public_key,
-                    } => SimpleSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    },
-                    Sig::Secp256k1 {
-                        signature,
-                        public_key,
-                    } => SimpleSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    },
-                    Sig::Secp256r1 {
-                        signature,
-                        public_key,
-                    } => SimpleSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    },
-                })
+                ReadableSimpleSignature::deserialize(deserializer).map(Into::into)
             } else {
-                let bytes: std::borrow::Cow<'de, [u8]> =
-                    std::borrow::Cow::deserialize(deserializer)?;
-                Self::from_bytes(bytes).map_err(serde::de::Error::custom)
+                let bytes: Cow<'de, [u8]> = Bytes::deserialize_as(deserializer)?;
+                Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
             }
         }
     }
 
-    impl UserSignature {
-        pub fn to_bytes(&self) -> Vec<u8> {
-            match self {
-                UserSignature::Simple(s) => s.to_bytes(),
-                UserSignature::Multisig(m) => m.to_bytes(),
-                UserSignature::PasskeyAuthenticator(p) => p.to_bytes(),
-                UserSignature::MoveAuthenticator(m) => m.to_bytes(),
-            }
-        }
+    // -----------------------------------------------------------------------
+    // UserSignature
+    // -----------------------------------------------------------------------
 
-        pub fn to_base64(&self) -> String {
-            use base64ct::Encoding;
+    /// Decode-side wire shape for `UserSignature`: the flat
+    /// `scheme-flag || payload` body inside the outer length prefix.
+    ///
+    /// Variant order matches the eight scheme flags so the BCS variant tag is
+    /// the scheme byte. `Bls12381Reserved` and `ZkLoginDeprecated` hold the
+    /// `0x04`/`0x05` slots (keeping `Passkey` at `0x06`); the `TryFrom`
+    /// conversion rejects both because they are not valid user signature
+    /// schemes, and they are `bcs_schema(skip)`ped from the generated grammar.
+    ///
+    /// The multisig and passkey variants hold the flat body pivots rather
+    /// than the public types, whose own serde emits the historical
+    /// `bytes`-wrapped `flag || body` form.
+    #[derive(serde::Deserialize)]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    pub(crate) enum UserSignatureBody {
+        Ed25519 {
+            signature: Ed25519Signature,
+            public_key: Ed25519PublicKey,
+        },
+        Secp256k1 {
+            signature: Secp256k1Signature,
+            public_key: Secp256k1PublicKey,
+        },
+        Secp256r1 {
+            signature: Secp256r1Signature,
+            public_key: Secp256r1PublicKey,
+        },
+        Multisig(
+            #[cfg_attr(
+                feature = "bcs-schema",
+                bcs_schema(as_type = "multisig-aggregated-signature")
+            )]
+            crate::crypto::multisig::serialization::Multisig,
+        ),
+        #[cfg_attr(feature = "bcs-schema", bcs_schema(skip))]
+        Bls12381Reserved,
+        #[cfg_attr(feature = "bcs-schema", bcs_schema(skip))]
+        ZkLoginDeprecated,
+        Passkey(
+            #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "passkey-authenticator"))]
+            crate::crypto::passkey::serialization::Authenticator,
+        ),
+        Move(MoveAuthenticator),
+    }
 
-            base64ct::Base64::encode_string(&self.to_bytes())
-        }
+    impl TryFrom<UserSignatureBody> for UserSignature {
+        type Error = SignatureFromBytesError;
 
-        pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, SignatureFromBytesError> {
-            let bytes = bytes.as_ref();
-
-            let flag =
-                SignatureScheme::from_byte(*bytes.first().ok_or_else(|| {
-                    SignatureFromBytesError::new("missing signature scheme flag")
-                })?)
-                .map_err(SignatureFromBytesError::new)?;
-            match flag {
-                SignatureScheme::Ed25519
-                | SignatureScheme::Secp256k1
-                | SignatureScheme::Secp256r1 => {
-                    let simple = SimpleSignature::from_bytes(bytes)?;
-                    Ok(Self::Simple(simple))
+        fn try_from(body: UserSignatureBody) -> Result<Self, Self::Error> {
+            Ok(match body {
+                UserSignatureBody::Ed25519 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Ed25519 {
+                    signature,
+                    public_key,
+                }),
+                UserSignatureBody::Secp256k1 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                }),
+                UserSignatureBody::Secp256r1 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                }),
+                UserSignatureBody::Multisig(m) => Self::Multisig(m.try_into()?),
+                UserSignatureBody::Bls12381Reserved => {
+                    return Err(SignatureFromBytesError::new(
+                        "bls not supported for user signatures",
+                    ));
                 }
-                SignatureScheme::Multisig => {
-                    let multisig = MultisigAggregatedSignature::from_bytes(bytes)?;
-                    Ok(Self::Multisig(multisig))
+                UserSignatureBody::ZkLoginDeprecated => {
+                    return Err(SignatureFromBytesError::new(
+                        "zklogin is not supported for user signatures",
+                    ));
                 }
-                SignatureScheme::Bls12381 => Err(SignatureFromBytesError::new(
-                    "bls not supported for user signatures",
-                )),
-                SignatureScheme::PasskeyAuthenticator => {
-                    let passkey = PasskeyAuthenticator::from_bytes(bytes)?;
-                    Ok(Self::PasskeyAuthenticator(passkey))
-                }
-                SignatureScheme::MoveAuthenticator => {
-                    let move_auth = MoveAuthenticator::from_bytes(bytes)?;
-                    Ok(Self::MoveAuthenticator(move_auth))
-                }
-            }
-        }
-
-        pub fn from_base64(s: &str) -> Result<Self, bcs::Error> {
-            use base64ct::Encoding;
-            use serde::de::Error;
-
-            let bytes = base64ct::Base64::decode_vec(s).map_err(bcs::Error::custom)?;
-            Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
+                UserSignatureBody::Passkey(p) => Self::PasskeyAuthenticator(p.try_into()?),
+                UserSignatureBody::Move(m) => Self::MoveAuthenticator(m),
+            })
         }
     }
 
@@ -760,57 +763,127 @@ mod serialization {
         Move(MoveAuthenticator),
     }
 
+    impl<'a> From<&'a UserSignature> for ReadableUserSignatureRef<'a> {
+        fn from(sig: &'a UserSignature) -> Self {
+            match sig {
+                UserSignature::Simple(SimpleSignature::Ed25519 {
+                    signature,
+                    public_key,
+                }) => Self::Ed25519 {
+                    signature,
+                    public_key,
+                },
+                UserSignature::Simple(SimpleSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                }) => Self::Secp256k1 {
+                    signature,
+                    public_key,
+                },
+                UserSignature::Simple(SimpleSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                }) => Self::Secp256r1 {
+                    signature,
+                    public_key,
+                },
+                UserSignature::Multisig(m) => Self::Multisig(m),
+                UserSignature::PasskeyAuthenticator(p) => Self::Passkey(p),
+                UserSignature::MoveAuthenticator(m) => Self::Move(m),
+            }
+        }
+    }
+
+    impl From<ReadableUserSignature> for UserSignature {
+        fn from(r: ReadableUserSignature) -> Self {
+            match r {
+                ReadableUserSignature::Ed25519 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Ed25519 {
+                    signature,
+                    public_key,
+                }),
+                ReadableUserSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Secp256k1 {
+                    signature,
+                    public_key,
+                }),
+                ReadableUserSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                } => Self::Simple(SimpleSignature::Secp256r1 {
+                    signature,
+                    public_key,
+                }),
+                ReadableUserSignature::Multisig(m) => Self::Multisig(m),
+                ReadableUserSignature::Passkey(p) => Self::PasskeyAuthenticator(p),
+                ReadableUserSignature::Move(m) => Self::MoveAuthenticator(m),
+            }
+        }
+    }
+
+    impl UserSignature {
+        /// Encode this signature as `<scheme-flag> <payload>`.
+        ///
+        /// Note: this is the flat body shape — no outer length prefix.
+        pub fn to_bytes(&self) -> Vec<u8> {
+            match self {
+                UserSignature::Simple(s) => s.to_bytes(),
+                UserSignature::Multisig(m) => m.to_bytes(),
+                UserSignature::PasskeyAuthenticator(p) => p.to_bytes(),
+                UserSignature::MoveAuthenticator(m) => m.to_bytes(),
+            }
+        }
+
+        pub fn to_base64(&self) -> String {
+            use base64ct::Encoding;
+
+            base64ct::Base64::encode_string(&self.to_bytes())
+        }
+
+        /// Decode a `UserSignature` from its flat-body byte encoding.
+        pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, SignatureFromBytesError> {
+            let bytes = bytes.as_ref();
+            let flag =
+                SignatureScheme::from_byte(*bytes.first().ok_or_else(|| {
+                    SignatureFromBytesError::new("missing signature scheme flag")
+                })?)
+                .map_err(SignatureFromBytesError::new)?;
+            let body = bcs::from_bytes::<UserSignatureBody>(bytes).map_err(|_| {
+                SignatureFromBytesError::new(match flag {
+                    SignatureScheme::Ed25519 => "invalid ed25519 signature",
+                    SignatureScheme::Secp256k1 => "invalid secp25k1 signature",
+                    SignatureScheme::Secp256r1 => "invalid secp25r1 signature",
+                    SignatureScheme::Multisig => "invalid multisig",
+                    SignatureScheme::Bls12381 => "bls not supported for user signatures",
+                    SignatureScheme::PasskeyAuthenticator => "invalid passkey",
+                    SignatureScheme::MoveAuthenticator => "invalid move authenticator",
+                })
+            })?;
+            body.try_into()
+        }
+
+        pub fn from_base64(s: &str) -> Result<Self, bcs::Error> {
+            use base64ct::Encoding;
+            use serde::de::Error;
+
+            let bytes = base64ct::Base64::decode_vec(s).map_err(bcs::Error::custom)?;
+            Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
+        }
+    }
+
     impl serde::Serialize for UserSignature {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
         {
             if serializer.is_human_readable() {
-                let readable = match self {
-                    UserSignature::Simple(SimpleSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    }) => ReadableUserSignatureRef::Ed25519 {
-                        signature,
-                        public_key,
-                    },
-                    UserSignature::Simple(SimpleSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    }) => ReadableUserSignatureRef::Secp256k1 {
-                        signature,
-                        public_key,
-                    },
-                    UserSignature::Simple(SimpleSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    }) => ReadableUserSignatureRef::Secp256r1 {
-                        signature,
-                        public_key,
-                    },
-                    UserSignature::Multisig(multisig) => {
-                        ReadableUserSignatureRef::Multisig(multisig)
-                    }
-                    UserSignature::PasskeyAuthenticator(passkey) => {
-                        ReadableUserSignatureRef::Passkey(passkey)
-                    }
-                    UserSignature::MoveAuthenticator(move_auth) => {
-                        ReadableUserSignatureRef::Move(move_auth)
-                    }
-                };
-                readable.serialize(serializer)
+                ReadableUserSignatureRef::from(self).serialize(serializer)
             } else {
-                match self {
-                    UserSignature::Simple(simple) => simple.serialize(serializer),
-                    UserSignature::Multisig(multisig) => multisig.serialize(serializer),
-                    UserSignature::PasskeyAuthenticator(passkey) => passkey.serialize(serializer),
-                    // `MoveAuthenticator` derives `Serialize`, so delegating here would emit the
-                    // bare enum instead of the length-prefixed `flag || payload` byte blob every
-                    // other signature scheme uses (and that `from_bytes`/deserialize expect).
-                    UserSignature::MoveAuthenticator(move_auth) => {
-                        serializer.serialize_bytes(&move_auth.to_bytes())
-                    }
-                }
+                serializer.serialize_bytes(&self.to_bytes())
             }
         }
     }
@@ -821,39 +894,10 @@ mod serialization {
             D: serde::Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                let readable = ReadableUserSignature::deserialize(deserializer)?;
-                Ok(match readable {
-                    ReadableUserSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    } => Self::Simple(SimpleSignature::Ed25519 {
-                        signature,
-                        public_key,
-                    }),
-                    ReadableUserSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    } => Self::Simple(SimpleSignature::Secp256k1 {
-                        signature,
-                        public_key,
-                    }),
-                    ReadableUserSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    } => Self::Simple(SimpleSignature::Secp256r1 {
-                        signature,
-                        public_key,
-                    }),
-                    ReadableUserSignature::Multisig(multisig) => Self::Multisig(multisig),
-                    ReadableUserSignature::Passkey(passkey) => Self::PasskeyAuthenticator(passkey),
-                    ReadableUserSignature::Move(move_auth) => Self::MoveAuthenticator(move_auth),
-                })
+                ReadableUserSignature::deserialize(deserializer).map(Into::into)
             } else {
-                use serde_with::DeserializeAs;
-
-                let bytes: std::borrow::Cow<'de, [u8]> =
-                    serde_with::Bytes::deserialize_as(deserializer)?;
-                Self::from_bytes(bytes).map_err(serde::de::Error::custom)
+                let bytes: Cow<'de, [u8]> = Bytes::deserialize_as(deserializer)?;
+                Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
             }
         }
     }


### PR DESCRIPTION
Closes #1079

## Why

The signature types hand-rolled their BCS serialization with manual byte building (`buf.push(flag); buf.extend(sig); buf.extend(pk)`) and matching manual parsers (`bytes[0]` flag checks, hand-counted length offsets). That's error-prone and means the generated ABNF can only describe a signature as opaque `bytes`.

## What

Each signature type now round-trips through a private **wire-shape "Body" type** deriving `Deserialize` + `BcsSchema` (plus `Serialize` where that doesn't force a clone). The custom `Serialize`/`Deserialize` impls shrink to a thin dispatcher:

- **binary** → `serialize_bytes` of the flat `[scheme-flag][payload]` body; decode parses the body and converts back
- **human-readable** → delegate to a `Readable*` enum (preserves the existing `{"scheme": "ed25519", …}` JSON)

No more hand-written byte fiddling, flag parsing, or length accounting.

`MultisigAggregatedSignature` keeps a thin custom `Serialize`/`Deserialize` so its **standalone** BCS form stays the historical length-prefixed `[flag][body]` — a plain derive would have silently changed the public type's wire format. `UserSignatureBody` embeds a flat multisig pivot (and a flat passkey pivot) for the same reason, and its serialize path delegates per-variant rather than cloning the payload.

### Why the custom `Serialize` can't go away entirely

On the IOTA wire, an embedded signature is **length-prefixed bytes**: a ULEB128 length followed by `[scheme-flag][payload]`. A plain `#[derive(Serialize)]` enum produces `[tag][fields]` with no outer length, so the `serialize_bytes` wrapping has to live somewhere. Putting it *on the type* keeps a single canonical wire format and one ABNF rule per type.

## ABNF result

The schema is now structural instead of opaque. `user-signature = bytes` (the wire wrapping) gains a sibling `user-signature-body` enumerating the scheme variants, and embedding sites reference the typed name:

```abnf
user-signature = bytes

user-signature-body = %d00 ed25519-signature ed25519-public-key       ; Ed25519
                    / %d01 secp256k1-signature secp256k1-public-key   ; Secp256k1
                    / %d02 secp256r1-signature secp256r1-public-key   ; Secp256r1
                    / %d03 multisig-aggregated-signature              ; Multisig
                    / %d06 passkey-authenticator                      ; Passkey
                    / %d07 move-authenticator                         ; Move

signed-transaction = transaction              ; transaction
                     (size *user-signature)   ; signatures   <-- was (size *bytes)
```

Reserved scheme flags `0x04` (BLS) and `0x05` (deprecated zkLogin) are kept as placeholder variants — rejected on decode and omitted from the grammar via `#[bcs_schema(skip)]` (the variant-skip attribute landed in #1262). `simple-signature{,-body}`, `multisig-aggregated-signature`, `multisig-member-signature`, `multisig-committee`, `multisig-member`, `passkey-authenticator`, and `move-authenticator{,-v1}` all gain structural rules too.

## Notes

- **Public API unchanged.** `UserSignature` keeps its 5 variants; `SimpleSignature`, `MultisigMemberSignature`, etc. are untouched. The flat `*Body` types are private.
- **BCS wire format is byte-identical** — locked in by the `simple_fixtures` / `multisig_fixtures` / `passkey_fixtures` round-trip tests, plus a standalone-multisig framing test.
- **JSON shape unchanged** — all signature types preserve their existing internally-tagged `{"scheme": "…", …}` form via `Readable*` dispatcher enums.
- **`PasskeyAuthenticator`** keeps its challenge-derivation validation on the deserialize path via an `Authenticator` pivot.

## Test plan

- `cargo test -p iota-sdk-types --all-features` — all unit + fuzzing + doc tests pass
- `cargo build --workspace --all-features` — clean
- `cargo clippy` — clean with `-D warnings`
- ABNF regenerated via `BCS_SCHEMA=1 cargo check`; grammar-driven `bcs_schema_fuzzing` test passes

https://claude.ai/code/session_01Uavu5pByHv9y9ZjrLBamya