### PR TITLE
feat(iota-sdk-types): derive AddAssign and SubAssign for GasCostSummary

### DIFF
--- a/crates/iota-sdk-types/src/gas.rs
+++ b/crates/iota-sdk-types/src/gas.rs
@@ -39,7 +39,7 @@
 ///                    u64   ; storage-rebate
 ///                    u64   ; non-refundable-storage-fee
 /// ```
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, derive_more::AddAssign, derive_more::SubAssign)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -100,6 +100,26 @@ impl GasCostSummary {
     /// A positive number means used gas; negative number means refund.
     pub fn net_gas_usage(&self) -> i64 {
         self.gas_used() as i64 - self.storage_rebate as i64
+    }
+}
+
+impl std::ops::AddAssign<&Self> for GasCostSummary {
+    fn add_assign(&mut self, other: &Self) {
+        self.computation_cost += other.computation_cost;
+        self.computation_cost_burned += other.computation_cost_burned;
+        self.storage_cost += other.storage_cost;
+        self.storage_rebate += other.storage_rebate;
+        self.non_refundable_storage_fee += other.non_refundable_storage_fee;
+    }
+}
+
+impl std::ops::SubAssign<&Self> for GasCostSummary {
+    fn sub_assign(&mut self, other: &Self) {
+        self.computation_cost -= other.computation_cost;
+        self.computation_cost_burned -= other.computation_cost_burned;
+        self.storage_cost -= other.storage_cost;
+        self.storage_rebate -= other.storage_rebate;
+        self.non_refundable_storage_fee -= other.non_refundable_storage_fee;
     }
 }
 


### PR DESCRIPTION
## Summary

Continues the SDK replacement series. Adds in-place arithmetic to `GasCostSummary` so callers can accumulate or subtract gas costs without manually destructuring all five fields. Mirrors the ergonomics already provided by `Add`/`Sub` and avoids the allocation of building a fresh summary just to overwrite the existing one.

- **`AddAssign` / `SubAssign` on `GasCostSummary`** in [crates/iota-sdk-types/src/gas.rs](crates/iota-sdk-types/src/gas.rs):
  - **Owned RHS** via `derive_more::AddAssign` and `derive_more::SubAssign` on the struct derive — field-wise `+=` / `-=` across `computation_cost`, `computation_cost_burned`, `storage_cost`, `storage_rebate`, and `non_refundable_storage_fee`.
  - **Borrowed RHS** via hand-written `impl AddAssign<&Self>` and `impl SubAssign<&Self>` so accumulation loops can keep ownership of the summand (`total += &item.gas_cost_summary` instead of `total += item.gas_cost_summary.clone()`). `derive_more` does not emit the borrowed variants, so they are spelled out explicitly.
