### PR TITLE
feat(types)!: remove `BalanceChange` type

### DIFF
--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -2,7 +2,7 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Address, Identifier, ObjectId, StructTag, TypeTag};
+use super::{Address, Identifier, ObjectId, StructTag};
 
 /// Events emitted during the successful execution of a transaction
 ///
@@ -51,20 +51,4 @@ pub struct Event {
         serde(with = "crate::_serde::ReadableBase64Encoded")
     )]
     pub contents: Vec<u8>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-pub struct BalanceChange {
-    /// Owner of the balance change
-    pub address: Address,
-    /// Type of the Coin
-    pub coin_type: TypeTag,
-    /// The amount indicate the balance value changes.
-    ///
-    /// A negative amount means spending coin value and positive means receiving
-    /// coin value.
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    pub amount: i128,
 }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -149,7 +149,7 @@ pub use effects::{
     ChangedObject, IdOperation, ObjectIn, ObjectOut, TransactionEffects, TransactionEffectsV1,
     UnchangedSharedKind, UnchangedSharedObject,
 };
-pub use events::{BalanceChange, Event, TransactionEvents};
+pub use events::{Event, TransactionEvents};
 pub use execution_status::{
     CommandArgumentError, ExecutionError, ExecutionStatus, MoveLocation, PackageUpgradeError,
     TypeArgumentError,

--- a/crates/iota-sdk-types/src/serialization_proptests.rs
+++ b/crates/iota-sdk-types/src/serialization_proptests.rs
@@ -84,7 +84,6 @@ serialization_test!(TransactionEffects);
 serialization_test!(TransactionEffectsV1);
 serialization_test!(UnchangedSharedKind);
 serialization_test!(UnchangedSharedObject);
-serialization_test!(BalanceChange);
 serialization_test!(Event);
 serialization_test!(TransactionEvents);
 serialization_test!(CommandArgumentError);


### PR DESCRIPTION
## Summary

Removes the `BalanceChange` type from `iota-sdk-types`, along with the now-unused `I128` type that was only kept around to support it.

## Changes

- Remove the `BalanceChange` struct from `crates/iota-sdk-types/src/events.rs` and its re-export from `lib.rs`
- Remove the corresponding `serialization_test!(BalanceChange)` proptest entry
- Drop the now-unused `TypeTag` import in `events.rs`
- Remove the `I128` type which was only used by `BalanceChange`

## Why

`BalanceChange` was unused and not part of the on-chain/protocol surface that `iota-sdk-types` is meant to expose. Removing it (and its dependency `I128`) trims dead surface area from the SDK types crate.

## Breaking change

This is a breaking change (`feat(types)!`): downstream consumers importing `iota_sdk_types::BalanceChange` will need to remove those usages. Balance-change information, if needed, should be derived from transaction effects instead.

## Test plan

- [x] `cargo build -p iota-sdk-types`
- [x] `cargo test -p iota-sdk-types`
- [x] Confirm no remaining references to `BalanceChange` or the removed `I128` type in dependent crates
