### PR TITLE
feat: ObjectReference changes for monorepo (#522)

### DIFF
--- a/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
+++ b/crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs
@@ -420,7 +420,7 @@ impl iota_sdk::transaction_builder::PTBArgument for &PTBArgument {
     ) -> iota_sdk::transaction_builder::unresolved::Argument {
         match self {
             PTBArgument::ObjectId(object_id) => object_id.arg(ptb),
-            PTBArgument::ObjectRef(obj_ref) => obj_ref.clone().arg(ptb),
+            PTBArgument::ObjectRef(obj_ref) => obj_ref.arg(ptb),
             PTBArgument::Move(arg) => arg.arg(ptb),
             PTBArgument::Assigned(assigned) => assigned.arg(ptb),
             PTBArgument::Shared(shared) => shared.arg(ptb),
@@ -433,7 +433,7 @@ impl iota_sdk::transaction_builder::PTBArgument for &PTBArgument {
     fn input(self) -> iota_sdk::transaction_builder::unresolved::InputKind {
         match self {
             PTBArgument::ObjectId(object_id) => object_id.input(),
-            PTBArgument::ObjectRef(obj_ref) => obj_ref.clone().input(),
+            PTBArgument::ObjectRef(obj_ref) => obj_ref.input(),
             PTBArgument::Move(arg) => arg.input(),
             PTBArgument::Assigned(assigned) => assigned.input(),
             PTBArgument::Shared(shared) => shared.input(),

--- a/crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs
@@ -327,7 +327,7 @@ impl PTBArgument for Receiving<ObjectReference> {
 
 impl PTBArgument for &Receiving<ObjectReference> {
     fn input(self) -> InputKind {
-        InputKind::Input(iota_types::Input::Receiving(self.0.clone()))
+        InputKind::Input(iota_types::Input::Receiving(self.0))
     }
 }
 

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -19,14 +19,12 @@ use crate::Version;
 /// object-reference = object-id u64 digest
 /// ```
 #[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct ObjectReference {
     /// The object id of this object.
     pub object_id: ObjectId,
     /// The version of this object.
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub version: Version,
     /// The digest of this object.
     pub digest: Digest,
@@ -35,7 +33,7 @@ pub struct ObjectReference {
 impl ObjectReference {
     /// Creates a new object reference from the object's id, version, and
     /// digest.
-    pub fn new(object_id: ObjectId, version: Version, digest: Digest) -> Self {
+    pub const fn new(object_id: ObjectId, version: Version, digest: Digest) -> Self {
         Self {
             object_id,
             version,
@@ -955,6 +953,35 @@ mod serialization {
         }
     }
 
+    // Custom serialization to be backwards compatible with the JSON RPC
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct TupleObjectReference(ObjectId, Version, Digest);
+
+    impl Serialize for ObjectReference {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            TupleObjectReference(self.object_id, self.version, self.digest).serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for ObjectReference {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let TupleObjectReference(object_id, version, digest) =
+                TupleObjectReference::deserialize(deserializer)?;
+
+            Ok(ObjectReference {
+                object_id,
+                version,
+                digest,
+            })
+        }
+    }
+
     #[cfg(test)]
     mod tests {
         #[cfg(target_arch = "wasm32")]
@@ -996,6 +1023,38 @@ mod serialization {
                 })
                 .unwrap()
             );
+        }
+
+        #[test]
+        fn object_reference_tuple_format() {
+            let json = r#"["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]"#;
+            let obj_ref: ObjectReference = serde_json::from_str(json).unwrap();
+            assert_eq!(obj_ref.object_id, ObjectId::ZERO);
+            assert_eq!(obj_ref.version, Version::from_u64(0));
+            assert_eq!(obj_ref.digest, Digest::ZERO);
+
+            // Roundtrip
+            let serialized = serde_json::to_string(&obj_ref).unwrap();
+            let roundtrip: ObjectReference = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(obj_ref, roundtrip);
+        }
+
+        #[test]
+        fn object_reference_in_map() {
+            use std::collections::BTreeMap;
+
+            let json = r#"{"4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]],"8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR":[["0x0000000000000000000000000000000000000000000000000000000000000000",0,"11111111111111111111111111111111"]]}"#;
+
+            let from_json: BTreeMap<String, Vec<ObjectReference>> =
+                serde_json::from_str(json).unwrap();
+
+            assert_eq!(from_json.len(), 2);
+            for refs in from_json.values() {
+                assert_eq!(refs.len(), 1);
+                assert_eq!(refs[0].object_id, ObjectId::ZERO);
+                assert_eq!(refs[0].version, Version::from_u64(0));
+                assert_eq!(refs[0].digest, Digest::ZERO);
+            }
         }
 
         #[test]

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -18,7 +18,7 @@ use crate::Version;
 /// ```text
 /// object-reference = object-id u64 digest
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Ord, PartialOrd, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -353,7 +353,7 @@ mod input_argument {
     use crate::{Version, transaction::Input};
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(tag = "type", rename_all = "snake_case")]
+    #[serde(rename_all = "snake_case")]
     enum ReadableInput {
         Pure {
             #[serde(with = "::serde_with::As::<crate::_serde::Base64Encoded>")]
@@ -910,8 +910,9 @@ mod tests {
                     value: vec![1, 2, 3, 4],
                 },
                 serde_json::json!({
-                  "type": "pure",
-                  "value": "AQIDBA=="
+                  "pure": {
+                    "value": "AQIDBA=="
+                  }
                 }),
             ),
             (
@@ -921,10 +922,11 @@ mod tests {
                     Digest::ZERO,
                 )),
                 serde_json::json!({
-                  "type": "immutable_or_owned",
-                  "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                  "version": "1",
-                  "digest": "11111111111111111111111111111111"
+                  "immutable_or_owned": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    1,
+                    "11111111111111111111111111111111"
+                  ]
                 }),
             ),
             (
@@ -934,10 +936,11 @@ mod tests {
                     mutable: true,
                 },
                 serde_json::json!({
-                  "type": "shared",
-                  "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                  "initial_shared_version": "1",
-                  "mutable": true
+                  "shared": {
+                    "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "initial_shared_version": "1",
+                    "mutable": true
+                  }
                 }),
             ),
             (
@@ -947,10 +950,11 @@ mod tests {
                     Digest::ZERO,
                 )),
                 serde_json::json!({
-                  "type": "receiving",
-                  "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                  "version": "1",
-                  "digest": "11111111111111111111111111111111"
+                  "receiving": [
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    1,
+                    "11111111111111111111111111111111"
+                  ]
                 }),
             ),
         ];


### PR DESCRIPTION
# feat: ObjectReference changes for monorepo

## Summary

- Derive `Copy`, `Ord`, and `PartialOrd` on `ObjectReference` (in addition to the existing `Clone`, `Debug`, `Eq`, `PartialEq`, `Hash`).
- Drop the now-unnecessary `.clone()` calls on `ObjectReference` in the PTB argument code paths in `iota-sdk-ffi` and `iota-sdk-transaction-builder`.

## Motivation

Aligns `ObjectReference` with the trait set used by the monorepo, making it cheaper to pass around (`Copy`) and usable in ordered collections (`Ord` / `PartialOrd`).

## Changes

- [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs): extend the derive list on `ObjectReference` with `Copy`, `Ord`, `PartialOrd`.
- [crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs](crates/iota-sdk-ffi/src/transaction_builder/ptb_arg.rs): remove `.clone()` on the `PTBArgument::ObjectRef` arms of `arg()` and `input()`.
- [crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs](crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs): remove `.clone()` in the `&Receiving<ObjectReference>` impl of `PTBArgument::input`.

## Test plan

- [ ] `cargo check --workspace`
- [ ] `cargo clippy --workspace --all-targets`
- [ ] `cargo test -p iota-sdk-types`
