### PR TITLE
feat: `RandomnessStateUpdate` improvements

### DIFF
--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -1410,7 +1410,7 @@ impl From<RandomnessStateUpdate> for iota_sdk::types::RandomnessStateUpdate {
     fn from(value: RandomnessStateUpdate) -> Self {
         Self {
             epoch: value.epoch,
-            randomness_round: value.randomness_round,
+            randomness_round: value.randomness_round.into(),
             random_bytes: value.random_bytes,
             randomness_obj_initial_shared_version: **value.randomness_obj_initial_shared_version,
         }
@@ -1421,7 +1421,7 @@ impl From<iota_sdk::types::RandomnessStateUpdate> for RandomnessStateUpdate {
     fn from(value: iota_sdk::types::RandomnessStateUpdate) -> Self {
         Self {
             epoch: value.epoch,
-            randomness_round: value.randomness_round,
+            randomness_round: value.randomness_round.value(),
             random_bytes: value.random_bytes,
             randomness_obj_initial_shared_version: Arc::new(
                 value.randomness_obj_initial_shared_version.into(),

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -320,10 +320,10 @@ programmable-transaction = (size *input)     ; inputs
 publish = (size *bytes)       ; modules
           (size *object-id)   ; dependencies
 
-randomness-state-update = u64       ; epoch
-                          u64       ; randomness-round
-                          bytes     ; random-bytes
-                          version   ; randomness-obj-initial-shared-version
+randomness-state-update = u64                ; epoch
+                          randomness-round   ; randomness-round
+                          bytes              ; random-bytes
+                          version            ; randomness-obj-initial-shared-version
 
 signed-checkpoint-summary = checkpoint-summary               ; checkpoint
                             validator-aggregated-signature   ; signature

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -320,6 +320,8 @@ programmable-transaction = (size *input)     ; inputs
 publish = (size *bytes)       ; modules
           (size *object-id)   ; dependencies
 
+randomness-round = u64
+
 randomness-state-update = u64                ; epoch
                           randomness-round   ; randomness-round
                           bytes              ; random-bytes

--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -8,6 +8,7 @@ mod intent;
 mod move_authenticator;
 mod multisig;
 mod passkey;
+mod randomness_round;
 mod secp256k1;
 mod secp256r1;
 mod signature;
@@ -24,6 +25,7 @@ pub use multisig::{
     MultisigMemberSignature,
 };
 pub use passkey::{PasskeyAuthenticator, PasskeyPublicKey};
+pub use randomness_round::RandomnessRound;
 pub use secp256k1::{Secp256k1PublicKey, Secp256k1Signature};
 pub use secp256r1::{Secp256r1PublicKey, Secp256r1Signature};
 pub use signature::{InvalidSignatureScheme, SignatureScheme, SimpleSignature, UserSignature};

--- a/crates/iota-sdk-types/src/crypto/randomness_round.rs
+++ b/crates/iota-sdk-types/src/crypto/randomness_round.rs
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Round number of generated randomness.
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// randomness-round = u64
+/// ```
 #[derive(
     Clone,
     Copy,

--- a/crates/iota-sdk-types/src/crypto/randomness_round.rs
+++ b/crates/iota-sdk-types/src/crypto/randomness_round.rs
@@ -48,6 +48,7 @@ impl RandomnessRound {
     }
 
     /// Returns the message to be signed for a randomness round.
+    #[cfg(feature = "serde")]
     pub fn signature_message(&self) -> Vec<u8> {
         "random_beacon round "
             .as_bytes()

--- a/crates/iota-sdk-types/src/crypto/randomness_round.rs
+++ b/crates/iota-sdk-types/src/crypto/randomness_round.rs
@@ -24,6 +24,7 @@
     serde(transparent)
 )]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[repr(transparent)]
 pub struct RandomnessRound(
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))] u64,

--- a/crates/iota-sdk-types/src/crypto/randomness_round.rs
+++ b/crates/iota-sdk-types/src/crypto/randomness_round.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Round number of generated randomness.
+#[derive(
+    Clone,
+    Copy,
+    Hash,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    derive_more::From,
+    derive_more::Display,
+    derive_more::Add,
+    derive_more::AddAssign,
+    derive_more::Sub,
+    derive_more::SubAssign,
+)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(transparent)
+)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[repr(transparent)]
+pub struct RandomnessRound(
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))] u64,
+);
+
+impl RandomnessRound {
+    pub fn new(round: u64) -> Self {
+        Self(round)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+
+    pub fn checked_add(self, rhs: u64) -> Option<Self> {
+        self.0.checked_add(rhs).map(Self)
+    }
+
+    pub fn checked_sub(self, rhs: u64) -> Option<Self> {
+        self.0.checked_sub(rhs).map(Self)
+    }
+
+    /// Returns the message to be signed for a randomness round.
+    pub fn signature_message(&self) -> Vec<u8> {
+        "random_beacon round "
+            .as_bytes()
+            .iter()
+            .cloned()
+            .chain(bcs::to_bytes(&self.0).expect("serialization should not fail"))
+            .collect()
+    }
+}
+
+impl std::ops::Add<u64> for RandomnessRound {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl std::ops::Sub<u64> for RandomnessRound {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl std::ops::AddAssign<u64> for RandomnessRound {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs;
+    }
+}
+
+impl std::ops::SubAssign<u64> for RandomnessRound {
+    fn sub_assign(&mut self, rhs: u64) {
+        self.0 -= rhs;
+    }
+}

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -141,8 +141,8 @@ pub use crypto::{
     IntentVersion, InvalidSignatureScheme, MoveAuthenticator, MoveAuthenticatorV1,
     MultisigAggregatedSignature, MultisigCommittee, MultisigMember, MultisigMemberPublicKey,
     MultisigMemberSignature, PasskeyAuthenticator, PasskeyPublicKey, PersonalMessage, PublicKeyExt,
-    Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey, Secp256r1Signature,
-    SignatureScheme, SimpleSignature, UserSignature,
+    RandomnessRound, Secp256k1PublicKey, Secp256k1Signature, Secp256r1PublicKey,
+    Secp256r1Signature, SignatureScheme, SimpleSignature, UserSignature,
 };
 pub use digest::{Digest, DigestParseError, SigningDigest};
 pub use effects::{

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -4,9 +4,8 @@
 
 use super::{
     Address, CheckpointTimestamp, Digest, EpochId, Event, GenesisObject, Identifier, ObjectId,
-    ObjectReference, ProtocolVersion, TypeTag, UserSignature, Version,
+    ObjectReference, ProtocolVersion, RandomnessRound, TypeTag, UserSignature, Version,
 };
-use crate::crypto::RandomnessRound;
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -6,6 +6,7 @@ use super::{
     Address, CheckpointTimestamp, Digest, EpochId, Event, GenesisObject, Identifier, ObjectId,
     ObjectReference, ProtocolVersion, TypeTag, UserSignature, Version,
 };
+use crate::crypto::RandomnessRound;
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
@@ -145,7 +146,7 @@ pub struct GasPayment {
 /// ```text
 /// randomness-state-update = u64 u64 bytes u64
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -154,8 +155,7 @@ pub struct RandomnessStateUpdate {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub epoch: u64,
     /// Randomness round of the update
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    pub randomness_round: u64,
+    pub randomness_round: RandomnessRound,
     /// Updated random bytes
     #[cfg_attr(
         feature = "serde",

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -143,7 +143,7 @@ pub struct GasPayment {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// randomness-state-update = u64 u64 bytes u64
+/// randomness-state-update = u64 randomness-round bytes version
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
## Summary

- Introduce a `RandomnessRound` wrapper type around `u64` in `iota-sdk-types`, with `From`/`Display`/`Add`/`Sub` derives, checked arithmetic, and a `signature_message` helper for the random beacon.
- Replace the raw `u64` `randomness_round` field on `RandomnessStateUpdate` with `RandomnessRound`, and derive `Hash` on `RandomnessStateUpdate`.
- Update the BCS schema ABNF and the `iota-sdk-ffi` conversions to round-trip through `RandomnessRound::value()` / `From<u64>`.