### PR TITLE
feat: `Owner` improvements

### DIFF
--- a/bindings/csharp/src/IotaSdk/IotaSdk.cs
+++ b/bindings/csharp/src/IotaSdk/IotaSdk.cs
@@ -4027,6 +4027,8 @@ static class _UniFFILib {
     
     
     
+    
+    
 
     static _UniFFILib() {
         _UniFFILib.uniffiCheckContractApiVersion();
@@ -7361,6 +7363,10 @@ static class _UniFFILib {
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(IntPtr @version,ref UniffiRustCallStatus _uniffi_out_err
+    );
+
+    [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(IntPtr @ptr,ref UniffiRustCallStatus _uniffi_out_err
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
@@ -14504,6 +14510,10 @@ static class _UniFFILib {
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
+    public static extern ushort uniffi_iota_sdk_ffi_checksum_method_owner_address(
+    );
+
+    [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
     public static extern ushort uniffi_iota_sdk_ffi_checksum_method_owner_as_address(
     );
 
@@ -21563,6 +21573,12 @@ static class _UniFFILib {
             var checksum = _UniFFILib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct();
             if (checksum != 33698) {
                 throw new UniffiContractChecksumException($"IotaSdk: uniffi bindings expected function `uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct` checksum `33698`, library returned `{checksum}`");
+            }
+        }
+        {
+            var checksum = _UniFFILib.uniffi_iota_sdk_ffi_checksum_method_owner_address();
+            if (checksum != 46638) {
+                throw new UniffiContractChecksumException($"IotaSdk: uniffi bindings expected function `uniffi_iota_sdk_ffi_checksum_method_owner_address` checksum `46638`, library returned `{checksum}`");
             }
         }
         {
@@ -42846,6 +42862,11 @@ class FfiConverterTypeObjectType: FfiConverter<ObjectType, IntPtr> {
 /// </summary>
 public interface IOwner: IEquatable<Owner> {
     /// <summary>
+    /// Returns an address if this object is owned by an address or
+    /// object, and None if it is shared or immutable.
+    /// </summary>
+    Address? Address();
+    /// <summary>
     /// Convert this owner into an address owner if it is one, or panic
     /// otherwise
     /// </summary>
@@ -42994,6 +43015,18 @@ public class Owner : IOwner, IDisposable {
         }
     }
 
+    
+    /// <summary>
+    /// Returns an address if this object is owned by an address or
+    /// object, and None if it is shared or immutable.
+    /// </summary>
+    public Address? Address() {
+        return CallWithPointer(thisPtr => FfiConverterOptionalTypeAddress.INSTANCE.Lift(
+    _UniffiHelpers.RustCall( (ref UniffiRustCallStatus _status) =>
+    _UniFFILib.uniffi_iota_sdk_ffi_fn_method_owner_address(thisPtr,  ref _status)
+)));
+    }
+    
     
     /// <summary>
     /// Convert this owner into an address owner if it is one, or panic

--- a/bindings/csharp/src/IotaSdk/IotaSdk.cs
+++ b/bindings/csharp/src/IotaSdk/IotaSdk.cs
@@ -7366,7 +7366,7 @@ static class _UniFFILib {
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(IntPtr @ptr,ref UniffiRustCallStatus _uniffi_out_err
+    public static extern RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(IntPtr @ptr,ref UniffiRustCallStatus _uniffi_out_err
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
@@ -14510,7 +14510,7 @@ static class _UniFFILib {
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
-    public static extern ushort uniffi_iota_sdk_ffi_checksum_method_owner_address(
+    public static extern ushort uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object(
     );
 
     [DllImport("iota_sdk_ffi", CallingConvention = CallingConvention.Cdecl)]
@@ -21576,9 +21576,9 @@ static class _UniFFILib {
             }
         }
         {
-            var checksum = _UniFFILib.uniffi_iota_sdk_ffi_checksum_method_owner_address();
-            if (checksum != 46638) {
-                throw new UniffiContractChecksumException($"IotaSdk: uniffi bindings expected function `uniffi_iota_sdk_ffi_checksum_method_owner_address` checksum `46638`, library returned `{checksum}`");
+            var checksum = _UniFFILib.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object();
+            if (checksum != 23748) {
+                throw new UniffiContractChecksumException($"IotaSdk: uniffi bindings expected function `uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object` checksum `23748`, library returned `{checksum}`");
             }
         }
         {
@@ -42862,10 +42862,10 @@ class FfiConverterTypeObjectType: FfiConverter<ObjectType, IntPtr> {
 /// </summary>
 public interface IOwner: IEquatable<Owner> {
     /// <summary>
-    /// Returns an address if this object is owned by an address or
+    /// Returns an `Address` if this object is owned by an address or
     /// object, and None if it is shared or immutable.
     /// </summary>
-    Address? Address();
+    Address? AddressOrObject();
     /// <summary>
     /// Convert this owner into an address owner if it is one, or panic
     /// otherwise
@@ -43017,13 +43017,13 @@ public class Owner : IOwner, IDisposable {
 
     
     /// <summary>
-    /// Returns an address if this object is owned by an address or
+    /// Returns an `Address` if this object is owned by an address or
     /// object, and None if it is shared or immutable.
     /// </summary>
-    public Address? Address() {
+    public Address? AddressOrObject() {
         return CallWithPointer(thisPtr => FfiConverterOptionalTypeAddress.INSTANCE.Lift(
     _UniffiHelpers.RustCall( (ref UniffiRustCallStatus _status) =>
-    _UniFFILib.uniffi_iota_sdk_ffi_fn_method_owner_address(thisPtr,  ref _status)
+    _UniFFILib.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(thisPtr,  ref _status)
 )));
     }
     

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -6721,11 +6721,11 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-		return C.uniffi_iota_sdk_ffi_checksum_method_owner_address()
+		return C.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object()
 	})
-	if checksum != 46638 {
+	if checksum != 23748 {
 		// If this happens try cleaning and rebuilding your project
-		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_owner_address: UniFFI API checksum mismatch")
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object: UniFFI API checksum mismatch")
 	}
 	}
 	{
@@ -27736,9 +27736,9 @@ func (_ FfiDestroyerObjectType) Destroy(value *ObjectType) {
 // owner-immutable = %d03
 // ```
 type OwnerInterface interface {
-	// Returns an address if this object is owned by an address or
+	// Returns an `Address` if this object is owned by an address or
 	// object, and None if it is shared or immutable.
-	Address() **Address
+	AddressOrObject() **Address
 	// Convert this owner into an address owner if it is one, or panic
 	// otherwise
 	AsAddress() *Address
@@ -27809,14 +27809,14 @@ func OwnerNewShared(version *Version) *Owner {
 
 
 
-// Returns an address if this object is owned by an address or
+// Returns an `Address` if this object is owned by an address or
 // object, and None if it is shared or immutable.
-func (_self *Owner) Address() **Address {
+func (_self *Owner) AddressOrObject() **Address {
 	_pointer := _self.ffiObject.incrementPointer("*Owner")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterOptionalAddressINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer {
-		inner: C.uniffi_iota_sdk_ffi_fn_method_owner_address(
+		inner: C.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(
 		_pointer,_uniffiStatus),
 	}
 	}))

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -6721,6 +6721,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+		return C.uniffi_iota_sdk_ffi_checksum_method_owner_address()
+	})
+	if checksum != 46638 {
+		// If this happens try cleaning and rebuilding your project
+		panic("iota_sdk_ffi: uniffi_iota_sdk_ffi_checksum_method_owner_address: UniFFI API checksum mismatch")
+	}
+	}
+	{
+	checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 		return C.uniffi_iota_sdk_ffi_checksum_method_owner_as_address()
 	})
 	if checksum != 13454 {
@@ -27727,6 +27736,9 @@ func (_ FfiDestroyerObjectType) Destroy(value *ObjectType) {
 // owner-immutable = %d03
 // ```
 type OwnerInterface interface {
+	// Returns an address if this object is owned by an address or
+	// object, and None if it is shared or immutable.
+	Address() **Address
 	// Convert this owner into an address owner if it is one, or panic
 	// otherwise
 	AsAddress() *Address
@@ -27796,6 +27808,19 @@ func OwnerNewShared(version *Version) *Owner {
 }
 
 
+
+// Returns an address if this object is owned by an address or
+// object, and None if it is shared or immutable.
+func (_self *Owner) Address() **Address {
+	_pointer := _self.ffiObject.incrementPointer("*Owner")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterOptionalAddressINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer {
+		inner: C.uniffi_iota_sdk_ffi_fn_method_owner_address(
+		_pointer,_uniffiStatus),
+	}
+	}))
+}
 
 // Convert this owner into an address owner if it is one, or panic
 // otherwise

--- a/bindings/go/iota_sdk/iota_sdk.h
+++ b/bindings/go/iota_sdk/iota_sdk.h
@@ -4679,6 +4679,11 @@ void* uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(void* id, RustCallStat
 void* uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(void* version, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(void* ptr, RustCallStatus *out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
 void* uniffi_iota_sdk_ffi_fn_method_owner_as_address(void* ptr, RustCallStatus *out_status
@@ -14361,6 +14366,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address(void
     
 );
 #endif

--- a/bindings/go/iota_sdk/iota_sdk.h
+++ b/bindings/go/iota_sdk/iota_sdk.h
@@ -4679,9 +4679,9 @@ void* uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(void* id, RustCallStat
 void* uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(void* version, RustCallStatus *out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
-RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(void* ptr, RustCallStatus *out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS_OR_OBJECT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS_OR_OBJECT
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(void* ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
@@ -14369,9 +14369,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
-uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS_OR_OBJECT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS_OR_OBJECT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object(void
     
 );
 #endif

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -4005,6 +4005,8 @@ internal open class UniffiVTableCallbackInterfaceTransactionSignerFn(
 
 
 
+
+
 // For large crates we prevent `MethodTooLargeException` (see #2340)
 // N.B. the name of the extension is very misleading, since it is 
 // rather `InterfaceTooLargeException`, caused by too many methods 
@@ -5427,6 +5429,8 @@ fun uniffi_iota_sdk_ffi_checksum_method_objecttype_as_struct_opt(
 fun uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(
+): Short
+fun uniffi_iota_sdk_ffi_checksum_method_owner_address(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_owner_as_address(
 ): Short
@@ -8554,6 +8558,8 @@ fun uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(`id`: Pointer,uniffi_out
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(`version`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
+fun uniffi_iota_sdk_ffi_fn_method_owner_address(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_method_owner_as_address(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_method_owner_as_address_opt(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
@@ -12852,6 +12858,9 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454.toShort()) {
@@ -40329,6 +40338,12 @@ public object FfiConverterTypeObjectType: FfiConverter<ObjectType, Pointer> {
 public interface OwnerInterface {
     
     /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */
+    fun `address`(): Address?
+    
+    /**
      * Convert this owner into an address owner if it is one, or panic
      * otherwise
      */
@@ -40482,6 +40497,22 @@ open class Owner: Disposable, AutoCloseable, OwnerInterface
             UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_clone_owner(pointer!!, status)
         }
     }
+
+    
+    /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */override fun `address`(): Address? {
+            return FfiConverterOptionalTypeAddress.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_owner_address(
+        it, _status)
+}
+    }
+    )
+    }
+    
 
     
     /**

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -5430,7 +5430,7 @@ fun uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(
 ): Short
-fun uniffi_iota_sdk_ffi_checksum_method_owner_address(
+fun uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object(
 ): Short
 fun uniffi_iota_sdk_ffi_checksum_method_owner_as_address(
 ): Short
@@ -8558,7 +8558,7 @@ fun uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(`id`: Pointer,uniffi_out
 ): Pointer
 fun uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(`version`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
-fun uniffi_iota_sdk_ffi_fn_method_owner_address(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_iota_sdk_ffi_fn_method_owner_as_address(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
 ): Pointer
@@ -12860,7 +12860,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638.toShort()) {
+    if (lib.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object() != 23748.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454.toShort()) {
@@ -40338,10 +40338,10 @@ public object FfiConverterTypeObjectType: FfiConverter<ObjectType, Pointer> {
 public interface OwnerInterface {
     
     /**
-     * Returns an address if this object is owned by an address or
+     * Returns an `Address` if this object is owned by an address or
      * object, and None if it is shared or immutable.
      */
-    fun `address`(): Address?
+    fun `addressOrObject`(): Address?
     
     /**
      * Convert this owner into an address owner if it is one, or panic
@@ -40500,13 +40500,13 @@ open class Owner: Disposable, AutoCloseable, OwnerInterface
 
     
     /**
-     * Returns an address if this object is owned by an address or
+     * Returns an `Address` if this object is owned by an address or
      * object, and None if it is shared or immutable.
-     */override fun `address`(): Address? {
+     */override fun `addressOrObject`(): Address? {
             return FfiConverterOptionalTypeAddress.lift(
     callWithPointer {
     uniffiRustCall() { _status ->
-    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_owner_address(
+    UniffiLib.INSTANCE.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(
         it, _status)
 }
     }

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -1869,7 +1869,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638:
+    if lib.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object() != 23748:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -7719,11 +7719,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared.restype = ctypes.c_void_p
-_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
-_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address.restype = _UniffiRustBuffer
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_as_address.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -15356,9 +15356,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package.restype = c
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct.restype = ctypes.c_uint16
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address.argtypes = (
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object.argtypes = (
 )
-_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address.restype = ctypes.c_uint16
@@ -46289,9 +46289,9 @@ class OwnerProtocol(typing.Protocol):
     ```
     """
 
-    def address(self, ):
+    def address_or_object(self, ):
         """
-        Returns an address if this object is owned by an address or
+        Returns an `Address` if this object is owned by an address or
         object, and None if it is shared or immutable.
         """
 
@@ -46436,14 +46436,14 @@ class Owner():
 
 
 
-    def address(self, ) -> "typing.Optional[Address]":
+    def address_or_object(self, ) -> "typing.Optional[Address]":
         """
-        Returns an address if this object is owned by an address or
+        Returns an `Address` if this object is owned by an address or
         object, and None if it is shared or immutable.
         """
 
         return _UniffiConverterOptionalTypeAddress.lift(
-            _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address,self._uniffi_clone_pointer(),)
+            _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address_or_object,self._uniffi_clone_pointer(),)
         )
 
 

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -1869,6 +1869,8 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    if lib.uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638:
+        raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address_opt() != 12290:
@@ -7717,6 +7719,11 @@ _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared.restype = ctypes.c_void_p
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address.argtypes = (
+    ctypes.c_void_p,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_as_address.argtypes = (
     ctypes.c_void_p,
     ctypes.POINTER(_UniffiRustCallStatus),
@@ -15349,6 +15356,9 @@ _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package.restype = c
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct.restype = ctypes.c_uint16
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address.argtypes = (
+)
+_UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_address.restype = ctypes.c_uint16
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address.argtypes = (
 )
 _UniffiLib.uniffi_iota_sdk_ffi_checksum_method_owner_as_address.restype = ctypes.c_uint16
@@ -46279,6 +46289,13 @@ class OwnerProtocol(typing.Protocol):
     ```
     """
 
+    def address(self, ):
+        """
+        Returns an address if this object is owned by an address or
+        object, and None if it is shared or immutable.
+        """
+
+        raise NotImplementedError
     def as_address(self, ):
         """
         Convert this owner into an address owner if it is one, or panic
@@ -46416,6 +46433,20 @@ class Owner():
         pointer = _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared,
         _UniffiConverterTypeVersion.lower(version))
         return cls._make_instance_(pointer)
+
+
+
+    def address(self, ) -> "typing.Optional[Address]":
+        """
+        Returns an address if this object is owned by an address or
+        object, and None if it is shared or immutable.
+        """
+
+        return _UniffiConverterOptionalTypeAddress.lift(
+            _uniffi_rust_call(_UniffiLib.uniffi_iota_sdk_ffi_fn_method_owner_address,self._uniffi_clone_pointer(),)
+        )
+
+
 
 
 

--- a/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
+++ b/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
@@ -4544,9 +4544,9 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(void*_Nonnull 
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(void*_Nonnull version, RustCallStatus *_Nonnull out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
-RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS_OR_OBJECT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS_OR_OBJECT
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
@@ -14234,9 +14234,9 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
-#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
-uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS_OR_OBJECT
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS_OR_OBJECT
+uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object(void
     
 );
 #endif

--- a/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
+++ b/bindings/swift/Sources/CIotaSDK/CIotaSDK.h
@@ -4544,6 +4544,11 @@ void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_object(void*_Nonnull 
 void*_Nonnull uniffi_iota_sdk_ffi_fn_constructor_owner_new_shared(void*_Nonnull version, RustCallStatus *_Nonnull out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_ADDRESS
+RustBuffer uniffi_iota_sdk_ffi_fn_method_owner_address(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_FN_METHOD_OWNER_AS_ADDRESS
 void*_Nonnull uniffi_iota_sdk_ffi_fn_method_owner_as_address(void*_Nonnull ptr, RustCallStatus *_Nonnull out_status
@@ -14226,6 +14231,12 @@ uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_package(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 #define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OBJECTTYPE_IS_STRUCT
 uint16_t uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+#define UNIFFI_FFIDEF_UNIFFI_IOTA_SDK_FFI_CHECKSUM_METHOD_OWNER_ADDRESS
+uint16_t uniffi_iota_sdk_ffi_checksum_method_owner_address(void
     
 );
 #endif

--- a/bindings/swift/Sources/IotaSDK/IotaSDK.swift
+++ b/bindings/swift/Sources/IotaSDK/IotaSDK.swift
@@ -17130,6 +17130,12 @@ public func FfiConverterTypeObjectType_lower(_ value: ObjectType) -> UnsafeMutab
 public protocol OwnerProtocol: AnyObject, Sendable {
     
     /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */
+    func address()  -> Address?
+    
+    /**
      * Convert this owner into an address owner if it is one, or panic
      * otherwise
      */
@@ -17282,6 +17288,17 @@ public static func newShared(version: Version) -> Owner  {
 }
     
 
+    
+    /**
+     * Returns an address if this object is owned by an address or
+     * object, and None if it is shared or immutable.
+     */
+open func address() -> Address?  {
+    return try!  FfiConverterOptionTypeAddress.lift(try! rustCall() {
+    uniffi_iota_sdk_ffi_fn_method_owner_address(self.uniffiClonePointer(),$0
+    )
+})
+}
     
     /**
      * Convert this owner into an address owner if it is one, or panic
@@ -48364,6 +48381,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454) {

--- a/bindings/swift/Sources/IotaSDK/IotaSDK.swift
+++ b/bindings/swift/Sources/IotaSDK/IotaSDK.swift
@@ -17130,10 +17130,10 @@ public func FfiConverterTypeObjectType_lower(_ value: ObjectType) -> UnsafeMutab
 public protocol OwnerProtocol: AnyObject, Sendable {
     
     /**
-     * Returns an address if this object is owned by an address or
+     * Returns an `Address` if this object is owned by an address or
      * object, and None if it is shared or immutable.
      */
-    func address()  -> Address?
+    func addressOrObject()  -> Address?
     
     /**
      * Convert this owner into an address owner if it is one, or panic
@@ -17290,12 +17290,12 @@ public static func newShared(version: Version) -> Owner  {
 
     
     /**
-     * Returns an address if this object is owned by an address or
+     * Returns an `Address` if this object is owned by an address or
      * object, and None if it is shared or immutable.
      */
-open func address() -> Address?  {
+open func addressOrObject() -> Address?  {
     return try!  FfiConverterOptionTypeAddress.lift(try! rustCall() {
-    uniffi_iota_sdk_ffi_fn_method_owner_address(self.uniffiClonePointer(),$0
+    uniffi_iota_sdk_ffi_fn_method_owner_address_or_object(self.uniffiClonePointer(),$0
     )
 })
 }
@@ -48383,7 +48383,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_iota_sdk_ffi_checksum_method_objecttype_is_struct() != 33698) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_iota_sdk_ffi_checksum_method_owner_address() != 46638) {
+    if (uniffi_iota_sdk_ffi_checksum_method_owner_address_or_object() != 23748) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_iota_sdk_ffi_checksum_method_owner_as_address() != 13454) {

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -690,10 +690,14 @@ impl Owner {
             .map(Arc::new)
     }
 
-    /// Returns an address if this object is owned by an address or
+    /// Returns an `Address` if this object is owned by an address or
     /// object, and None if it is shared or immutable.
-    pub fn address(&self) -> Option<Arc<Address>> {
-        self.0.address().copied().map(Into::into).map(Arc::new)
+    pub fn address_or_object(&self) -> Option<Arc<Address>> {
+        self.0
+            .address_or_object()
+            .copied()
+            .map(Into::into)
+            .map(Arc::new)
     }
 }
 

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -689,6 +689,12 @@ impl Owner {
             .map(Into::into)
             .map(Arc::new)
     }
+
+    /// Returns an address if this object is owned by an address or
+    /// object, and None if it is shared or immutable.
+    pub fn address(&self) -> Option<Arc<Address>> {
+        self.0.address().copied().map(Into::into).map(Arc::new)
+    }
 }
 
 /// Type of an IOTA object

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -108,9 +108,9 @@ impl Owner {
 
     crate::def_is_as_into_opt!(Address, Object(ObjectId), Shared(Version));
 
-    /// Returns an address if this object is owned by an address or
+    /// Returns an `Address` if this object is owned by an address or
     /// object, and None if it is shared or immutable.
-    pub fn address(&self) -> Option<&Address> {
+    pub fn address_or_object(&self) -> Option<&Address> {
         Some(match self {
             Self::Address(address) => address,
             Self::Object(object_id) => object_id.as_address(),

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -86,11 +86,6 @@ impl ObjectReference {
 /// owner-immutable = %d03
 /// ```
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Serialize, serde::Deserialize),
-    serde(rename_all = "lowercase")
-)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[non_exhaustive]
@@ -102,7 +97,6 @@ pub enum Owner {
     /// Object is shared, can be used by any address, and is mutable.
     Shared(
         /// The version at which the object became shared
-        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
         Version,
     ),
     /// Object is immutable, and hence ownership doesn't matter.
@@ -113,6 +107,28 @@ impl Owner {
     crate::def_is!(Immutable);
 
     crate::def_is_as_into_opt!(Address, Object(ObjectId), Shared(Version));
+
+    /// Returns an address if this object is owned by an address or
+    /// object, and None if it is shared or immutable.
+    pub fn address(&self) -> Option<&Address> {
+        Some(match self {
+            Self::Address(address) => address,
+            Self::Object(object_id) => object_id.as_address(),
+            _ => return None,
+        })
+    }
+}
+
+impl PartialEq<Address> for Owner {
+    fn eq(&self, other: &Address) -> bool {
+        self.as_address_opt() == Some(other)
+    }
+}
+
+impl PartialEq<ObjectId> for Owner {
+    fn eq(&self, other: &ObjectId) -> bool {
+        self.as_object_opt() == Some(other)
+    }
 }
 
 impl std::fmt::Display for Owner {
@@ -531,6 +547,60 @@ mod serialization {
 
     use super::*;
     use crate::TypeTag;
+
+    #[derive(Debug, Copy, Clone, Deserialize, Serialize, PartialEq, Eq)]
+    #[serde(rename = "Owner")]
+    enum ReadableOwner {
+        /// Object is exclusively owned by a single address, and is mutable.
+        AddressOwner(Address),
+        /// Object is exclusively owned by a single object, and is mutable.
+        /// The object ID is converted to IotaAddress as IotaAddress is
+        /// universal.
+        ObjectOwner(Address),
+        /// Object is shared, can be used by any address, and is mutable.
+        Shared {
+            /// The version at which the object became shared
+            initial_shared_version: Version,
+        },
+        /// Object is immutable, and hence ownership doesn't matter.
+        Immutable,
+    }
+
+    impl Serialize for Owner {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let readable_owner = match self {
+                Owner::Address(address) => ReadableOwner::AddressOwner(*address),
+                Owner::Object(object_id) => ReadableOwner::ObjectOwner(*object_id.as_address()),
+                Owner::Shared(initial_shared_version) => ReadableOwner::Shared {
+                    initial_shared_version: *initial_shared_version,
+                },
+                Owner::Immutable => ReadableOwner::Immutable,
+            };
+            readable_owner.serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Owner {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let readable_owner = ReadableOwner::deserialize(deserializer)?;
+            Ok(match readable_owner {
+                ReadableOwner::AddressOwner(address) => Owner::Address(address),
+                ReadableOwner::ObjectOwner(address) => {
+                    Owner::Object(ObjectId::from_address(address))
+                }
+                ReadableOwner::Shared {
+                    initial_shared_version,
+                } => Owner::Shared(initial_shared_version),
+                ReadableOwner::Immutable => Owner::Immutable,
+            })
+        }
+    }
 
     /// Wrapper around StructTag with a space-efficient representation for
     /// common types like coins The StructTag for a gas coin is 84 bytes, so

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -6,6 +6,7 @@ use super::{
     Address, CheckpointTimestamp, Digest, EpochId, Event, GenesisObject, Identifier, ObjectId,
     ObjectReference, ProtocolVersion, RandomnessRound, TypeTag, UserSignature, Version,
 };
+use crate::crypto::RandomnessRound;
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -6,7 +6,6 @@ use super::{
     Address, CheckpointTimestamp, Digest, EpochId, Event, GenesisObject, Identifier, ObjectId,
     ObjectReference, ProtocolVersion, RandomnessRound, TypeTag, UserSignature, Version,
 };
-use crate::crypto::RandomnessRound;
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]


### PR DESCRIPTION
## Summary

Improve the `Owner` enum for the core implementation.

### Changes

- Add `Owner::address_or_object()` returning an `Option<&Address>` for `Address`- and `Object`-owned variants (and `None` for `Shared`/`Immutable`).
- Implement `PartialEq<Address>` and `PartialEq<ObjectId>` for `Owner` so callers can compare an owner to an address/object id directly.
- Replace the derived `Serialize`/`Deserialize` with a custom impl backed by a `ReadableOwner` shape that matches the wire format used by the core implementation:
  - `AddressOwner(Address)` / `ObjectOwner(Address)` (object id is serialized as an address since `IotaAddress` is universal).
  - `Shared { initial_shared_version: Version }` (named field instead of a tuple, drops the `ReadableDisplay` wrapper on the version).
  - `Immutable`.