### PR TITLE
feat: improvements to Argument (#967)

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -933,7 +933,7 @@ impl std::fmt::Display for Argument {
             Argument::Gas => write!(f, "Gas"),
             Argument::Input(i) => write!(f, "Input({i})"),
             Argument::Result(i) => write!(f, "Result({i})"),
-            Argument::NestedResult(i, j) => write!(f, "NestedResult({i},{j})"),
+            Argument::NestedResult(i, j) => write!(f, "NestedResult({i}, {j})"),
         }
     }
 }

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -907,7 +907,7 @@ pub struct Upgrade {
 /// argument-result         = %d02 u16
 /// argument-nested-result  = %d03 u16 u16
 /// ```
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[non_exhaustive]
@@ -925,6 +925,17 @@ pub enum Argument {
     /// return values.
     // (command index, subresult index)
     NestedResult(u16, u16),
+}
+
+impl std::fmt::Display for Argument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Argument::Gas => write!(f, "Gas"),
+            Argument::Input(i) => write!(f, "Input({i})"),
+            Argument::Result(i) => write!(f, "Result({i})"),
+            Argument::NestedResult(i, j) => write!(f, "NestedResult({i},{j})"),
+        }
+    }
 }
 
 impl Argument {

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -485,25 +485,20 @@ mod argument {
     use super::*;
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename = "Argument", untagged, rename_all = "lowercase")]
+    #[serde(rename = "Argument")]
     enum ReadableArgument {
         /// # Gas
-        Gas(Gas),
-        /// # Input
-        Input { input: u16 },
-        /// # Result
-        Result { result: u16 },
-        /// # NestedResult
-        NestedResult { result: (u16, u16) },
-    }
-
-    #[derive(serde::Serialize, serde::Deserialize)]
-    #[serde(rename_all = "lowercase")]
-    enum Gas {
         Gas,
+        /// # Input
+        Input(u16),
+        /// # Result
+        Result(u16),
+        /// # NestedResult
+        NestedResult(u16, u16),
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename = "Argument")]
     enum BinaryArgument {
         Gas,
         Input(u16),
@@ -518,12 +513,12 @@ mod argument {
         {
             if serializer.is_human_readable() {
                 let readable = match *self {
-                    Argument::Gas => ReadableArgument::Gas(Gas::Gas),
-                    Argument::Input(input) => ReadableArgument::Input { input },
-                    Argument::Result(result) => ReadableArgument::Result { result },
-                    Argument::NestedResult(result, subresult) => ReadableArgument::NestedResult {
-                        result: (result, subresult),
-                    },
+                    Argument::Gas => ReadableArgument::Gas,
+                    Argument::Input(input) => ReadableArgument::Input(input),
+                    Argument::Result(result) => ReadableArgument::Result(result),
+                    Argument::NestedResult(result, subresult) => {
+                        ReadableArgument::NestedResult(result, subresult)
+                    }
                 };
                 readable.serialize(serializer)
             } else {
@@ -547,12 +542,12 @@ mod argument {
         {
             if deserializer.is_human_readable() {
                 ReadableArgument::deserialize(deserializer).map(|readable| match readable {
-                    ReadableArgument::Gas(_) => Argument::Gas,
-                    ReadableArgument::Input { input } => Argument::Input(input),
-                    ReadableArgument::Result { result } => Argument::Result(result),
-                    ReadableArgument::NestedResult {
-                        result: (result, subresult),
-                    } => Argument::NestedResult(result, subresult),
+                    ReadableArgument::Gas => Argument::Gas,
+                    ReadableArgument::Input(input) => Argument::Input(input),
+                    ReadableArgument::Result(result) => Argument::Result(result),
+                    ReadableArgument::NestedResult(result, subresult) => {
+                        Argument::NestedResult(result, subresult)
+                    }
                 })
             } else {
                 BinaryArgument::deserialize(deserializer).map(|binary| match binary {
@@ -883,12 +878,12 @@ mod tests {
     #[test]
     fn argument() {
         let test_cases = [
-            (Argument::Gas, serde_json::json!("gas")),
-            (Argument::Input(1), serde_json::json!({"input": 1})),
-            (Argument::Result(2), serde_json::json!({"result": 2})),
+            (Argument::Gas, serde_json::json!("Gas")),
+            (Argument::Input(1), serde_json::json!({"Input": 1})),
+            (Argument::Result(2), serde_json::json!({"Result": 2})),
             (
                 Argument::NestedResult(3, 4),
-                serde_json::json!({"result": [3, 4]}),
+                serde_json::json!({"NestedResult": [3, 4]}),
             ),
         ];
 


### PR DESCRIPTION
## Summary

- Derive `Hash` on [`Argument`](crates/iota-sdk-types/src/transaction/mod.rs) and add a `Display` impl rendering variants as `Gas`, `Input(i)`, `Result(i)`, `NestedResult(i,j)`.
- Simplify human-readable serialization: drop the `untagged` + lowercase scheme (which required a workaround `Gas` enum and a `{ result: (u16, u16) }` struct variant) in favor of an externally-tagged form that mirrors `Argument` directly.

## Serialization change (breaking)

Human-readable JSON output for `Argument` changes:

| Variant | Before | After |
| --- | --- | --- |
| `Gas` | `"gas"` | `"Gas"` |
| `Input(1)` | `{"input": 1}` | `{"Input": 1}` |
| `Result(2)` | `{"result": 2}` | `{"Result": 2}` |
| `NestedResult(3, 4)` | `{"result": [3, 4]}` | `{"NestedResult": [3, 4]}` |

Binary (BCS) serialization is unchanged.

## Test plan

- [ ] `cargo test -p iota-sdk-types transaction::serialization::tests::argument`
- [ ] Verify downstream consumers of the human-readable JSON form are updated for the new variant names
