### PR TITLE
feat: MovePackage changes (#973)

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: BCS schema
         if: (!github.event.pull_request.draft || contains(github.event.pull_request.body, '[run-ci]'))
-        run: BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema
+        run: make bcs-schema
 
       - run: make is-dirty
 

--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,7 @@ release-examples: ## Run all release examples
 	@$(MAKE) csharp-release-example
 	@$(MAKE) swift-release-example
 
+.PHONY: bcs-schema
 bcs-schema: ## Regenerate bcs-schema.abnf
 	@printf "Regenerating bcs-schema.abnf...\n"
 	@BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash || exit $$?

--- a/Makefile
+++ b/Makefile
@@ -378,6 +378,10 @@ release-examples: ## Run all release examples
 	@$(MAKE) csharp-release-example
 	@$(MAKE) swift-release-example
 
+bcs-schema: ## Regenerate bcs-schema.abnf
+	@printf "Regenerating bcs-schema.abnf...\n"
+	@BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash || exit $$?
+
 .PHONY: help
 help: ## Show this help
 	@printf "Available targets:\n"

--- a/bindings/csharp/src/IotaSdk/IotaSdk.cs
+++ b/bindings/csharp/src/IotaSdk/IotaSdk.cs
@@ -58633,7 +58633,9 @@ class FfiConverterTypeTransactionsFilter: FfiConverterRustBuffer<TransactionsFil
 
 
 /// <summary>
-/// Identifies a struct and the module it was defined in
+/// Stores the origin of a data type where it first appeared in the version
+/// chain. A data type is identified by the name of the module and the name of
+/// the struct/enum in combination.
 ///
 /// # BCS
 ///
@@ -58643,15 +58645,33 @@ class FfiConverterTypeTransactionsFilter: FfiConverterRustBuffer<TransactionsFil
 /// type-origin = identifier identifier object-id
 /// ```
 /// </summary>
+/// <param name="module_name">
+/// The name of the module the data type resides in.
+/// </param>
+/// <param name="datatype_name">
+/// identifier.
+/// </param>
+/// <param name="package">
+/// ID of the package, where the given type first appeared.
+/// </param>
 public record TypeOrigin (
+    /// <summary>
+    /// The name of the module the data type resides in.
+    /// </summary>
     Identifier @moduleName, 
-    Identifier @structName, 
+    /// <summary>
+    /// identifier.
+    /// </summary>
+    Identifier @datatypeName, 
+    /// <summary>
+    /// ID of the package, where the given type first appeared.
+    /// </summary>
     ObjectId @package
 ) : IDisposable {
     public void Dispose() {
     FFIObjectUtil.DisposeAll(
             this.@moduleName,
-            this.@structName,
+            this.@datatypeName,
             this.@package);
     }
 }
@@ -58662,7 +58682,7 @@ class FfiConverterTypeTypeOrigin: FfiConverterRustBuffer<TypeOrigin> {
     public override TypeOrigin Read(BigEndianStream stream) {
         return new TypeOrigin(
             @moduleName: FfiConverterTypeIdentifier.INSTANCE.Read(stream),
-            @structName: FfiConverterTypeIdentifier.INSTANCE.Read(stream),
+            @datatypeName: FfiConverterTypeIdentifier.INSTANCE.Read(stream),
             @package: FfiConverterTypeObjectId.INSTANCE.Read(stream)
         );
     }
@@ -58670,13 +58690,13 @@ class FfiConverterTypeTypeOrigin: FfiConverterRustBuffer<TypeOrigin> {
     public override int AllocationSize(TypeOrigin value) {
         return 0
             + FfiConverterTypeIdentifier.INSTANCE.AllocationSize(value.@moduleName)
-            + FfiConverterTypeIdentifier.INSTANCE.AllocationSize(value.@structName)
+            + FfiConverterTypeIdentifier.INSTANCE.AllocationSize(value.@datatypeName)
             + FfiConverterTypeObjectId.INSTANCE.AllocationSize(value.@package);
     }
 
     public override void Write(TypeOrigin value, BigEndianStream stream) {
             FfiConverterTypeIdentifier.INSTANCE.Write(value.@moduleName, stream);
-            FfiConverterTypeIdentifier.INSTANCE.Write(value.@structName, stream);
+            FfiConverterTypeIdentifier.INSTANCE.Write(value.@datatypeName, stream);
             FfiConverterTypeObjectId.INSTANCE.Write(value.@package, stream);
     }
 }
@@ -58741,14 +58761,14 @@ class FfiConverterTypeUnchangedSharedObject: FfiConverterRustBuffer<UnchangedSha
 /// ```
 /// </summary>
 /// <param name="upgraded_id">
-/// Id of the upgraded packages
+/// ID of the upgraded package
 /// </param>
 /// <param name="upgraded_version">
 /// Version of the upgraded package
 /// </param>
 public record UpgradeInfo (
     /// <summary>
-    /// Id of the upgraded packages
+    /// ID of the upgraded package
     /// </summary>
     ObjectId @upgradedId, 
     /// <summary>

--- a/bindings/csharp/src/IotaSdk/IotaSdk.cs
+++ b/bindings/csharp/src/IotaSdk/IotaSdk.cs
@@ -58649,6 +58649,7 @@ class FfiConverterTypeTransactionsFilter: FfiConverterRustBuffer<TransactionsFil
 /// The name of the module the data type resides in.
 /// </param>
 /// <param name="datatype_name">
+/// The name of the data type. Either refers to an enum or a struct
 /// identifier.
 /// </param>
 /// <param name="package">
@@ -58660,6 +58661,7 @@ public record TypeOrigin (
     /// </summary>
     Identifier @moduleName, 
     /// <summary>
+    /// The name of the data type. Either refers to an enum or a struct
     /// identifier.
     /// </summary>
     Identifier @datatypeName, 

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -41241,7 +41241,9 @@ func (_ FfiDestroyerTransactionsFilter) Destroy(value TransactionsFilter) {
 	value.Destroy()
 }
 
-// Identifies a struct and the module it was defined in
+// Stores the origin of a data type where it first appeared in the version
+// chain. A data type is identified by the name of the module and the name of
+// the struct/enum in combination.
 //
 // # BCS
 //

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -41251,14 +41251,17 @@ func (_ FfiDestroyerTransactionsFilter) Destroy(value TransactionsFilter) {
 // type-origin = identifier identifier object-id
 // ```
 type TypeOrigin struct {
+	// The name of the module the data type resides in.
 	ModuleName *Identifier
-	StructName *Identifier
+	// identifier.
+	DatatypeName *Identifier
+	// ID of the package, where the given type first appeared.
 	Package *ObjectId
 }
 
 func (r *TypeOrigin) Destroy() {
 		FfiDestroyerIdentifier{}.Destroy(r.ModuleName);
-		FfiDestroyerIdentifier{}.Destroy(r.StructName);
+		FfiDestroyerIdentifier{}.Destroy(r.DatatypeName);
 		FfiDestroyerObjectId{}.Destroy(r.Package);
 }
 
@@ -41288,7 +41291,7 @@ func (c FfiConverterTypeOrigin) LowerExternal(value TypeOrigin) ExternalCRustBuf
 
 func (c FfiConverterTypeOrigin) Write(writer io.Writer, value TypeOrigin) {
 		FfiConverterIdentifierINSTANCE.Write(writer, value.ModuleName);
-		FfiConverterIdentifierINSTANCE.Write(writer, value.StructName);
+		FfiConverterIdentifierINSTANCE.Write(writer, value.DatatypeName);
 		FfiConverterObjectIdINSTANCE.Write(writer, value.Package);
 }
 
@@ -41361,7 +41364,7 @@ func (_ FfiDestroyerUnchangedSharedObject) Destroy(value UnchangedSharedObject) 
 // upgrade-info = object-id u64
 // ```
 type UpgradeInfo struct {
-	// Id of the upgraded packages
+	// ID of the upgraded package
 	UpgradedId *ObjectId
 	// Version of the upgraded package
 	UpgradedVersion *Version

--- a/bindings/go/iota_sdk/iota_sdk.go
+++ b/bindings/go/iota_sdk/iota_sdk.go
@@ -41255,6 +41255,7 @@ func (_ FfiDestroyerTransactionsFilter) Destroy(value TransactionsFilter) {
 type TypeOrigin struct {
 	// The name of the module the data type resides in.
 	ModuleName *Identifier
+	// The name of the data type. Either refers to an enum or a struct
 	// identifier.
 	DatatypeName *Identifier
 	// ID of the package, where the given type first appeared.

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -62171,6 +62171,7 @@ data class TypeOrigin (
      */
     var `moduleName`: Identifier, 
     /**
+     * The name of the data type. Either refers to an enum or a struct
      * identifier.
      */
     var `datatypeName`: Identifier, 

--- a/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
+++ b/bindings/kotlin/lib/iota_sdk/iota_sdk.kt
@@ -62153,7 +62153,9 @@ public object FfiConverterTypeTransactionsFilter: FfiConverterRustBuffer<Transac
 
 
 /**
- * Identifies a struct and the module it was defined in
+ * Stores the origin of a data type where it first appeared in the version
+ * chain. A data type is identified by the name of the module and the name of
+ * the struct/enum in combination.
  *
  * # BCS
  *
@@ -62164,8 +62166,17 @@ public object FfiConverterTypeTransactionsFilter: FfiConverterRustBuffer<Transac
  * ```
  */
 data class TypeOrigin (
+    /**
+     * The name of the module the data type resides in.
+     */
     var `moduleName`: Identifier, 
-    var `structName`: Identifier, 
+    /**
+     * identifier.
+     */
+    var `datatypeName`: Identifier, 
+    /**
+     * ID of the package, where the given type first appeared.
+     */
     var `package`: ObjectId
 ) : Disposable {
     
@@ -62174,7 +62185,7 @@ data class TypeOrigin (
         
     Disposable.destroy(
         this.`moduleName`,
-        this.`structName`,
+        this.`datatypeName`,
         this.`package`
     )
     }
@@ -62196,13 +62207,13 @@ public object FfiConverterTypeTypeOrigin: FfiConverterRustBuffer<TypeOrigin> {
 
     override fun allocationSize(value: TypeOrigin) = (
             FfiConverterTypeIdentifier.allocationSize(value.`moduleName`) +
-            FfiConverterTypeIdentifier.allocationSize(value.`structName`) +
+            FfiConverterTypeIdentifier.allocationSize(value.`datatypeName`) +
             FfiConverterTypeObjectId.allocationSize(value.`package`)
     )
 
     override fun write(value: TypeOrigin, buf: ByteBuffer) {
             FfiConverterTypeIdentifier.write(value.`moduleName`, buf)
-            FfiConverterTypeIdentifier.write(value.`structName`, buf)
+            FfiConverterTypeIdentifier.write(value.`datatypeName`, buf)
             FfiConverterTypeObjectId.write(value.`package`, buf)
     }
 }
@@ -62274,7 +62285,7 @@ public object FfiConverterTypeUnchangedSharedObject: FfiConverterRustBuffer<Unch
  */
 data class UpgradeInfo (
     /**
-     * Id of the upgraded packages
+     * ID of the upgraded package
      */
     var `upgradedId`: ObjectId, 
     /**

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -22025,6 +22025,7 @@ class TypeOrigin:
 
     datatype_name: "Identifier"
     """
+    The name of the data type. Either refers to an enum or a struct
     identifier.
     """
 

--- a/bindings/python/lib/iota_sdk.py
+++ b/bindings/python/lib/iota_sdk.py
@@ -22005,7 +22005,9 @@ class _UniffiConverterTypeTransactionsFilter(_UniffiConverterRustBuffer):
 
 class TypeOrigin:
     """
-    Identifies a struct and the module it was defined in
+    Stores the origin of a data type where it first appeared in the version
+    chain. A data type is identified by the name of the module and the name of
+    the struct/enum in combination.
 
     # BCS
 
@@ -22017,20 +22019,32 @@ class TypeOrigin:
     """
 
     module_name: "Identifier"
-    struct_name: "Identifier"
+    """
+    The name of the module the data type resides in.
+    """
+
+    datatype_name: "Identifier"
+    """
+    identifier.
+    """
+
     package: "ObjectId"
-    def __init__(self, *, module_name: "Identifier", struct_name: "Identifier", package: "ObjectId"):
+    """
+    ID of the package, where the given type first appeared.
+    """
+
+    def __init__(self, *, module_name: "Identifier", datatype_name: "Identifier", package: "ObjectId"):
         self.module_name = module_name
-        self.struct_name = struct_name
+        self.datatype_name = datatype_name
         self.package = package
 
     def __str__(self):
-        return "TypeOrigin(module_name={}, struct_name={}, package={})".format(self.module_name, self.struct_name, self.package)
+        return "TypeOrigin(module_name={}, datatype_name={}, package={})".format(self.module_name, self.datatype_name, self.package)
 
     def __eq__(self, other):
         if self.module_name != other.module_name:
             return False
-        if self.struct_name != other.struct_name:
+        if self.datatype_name != other.datatype_name:
             return False
         if self.package != other.package:
             return False
@@ -22041,20 +22055,20 @@ class _UniffiConverterTypeTypeOrigin(_UniffiConverterRustBuffer):
     def read(buf):
         return TypeOrigin(
             module_name=_UniffiConverterTypeIdentifier.read(buf),
-            struct_name=_UniffiConverterTypeIdentifier.read(buf),
+            datatype_name=_UniffiConverterTypeIdentifier.read(buf),
             package=_UniffiConverterTypeObjectId.read(buf),
         )
 
     @staticmethod
     def check_lower(value):
         _UniffiConverterTypeIdentifier.check_lower(value.module_name)
-        _UniffiConverterTypeIdentifier.check_lower(value.struct_name)
+        _UniffiConverterTypeIdentifier.check_lower(value.datatype_name)
         _UniffiConverterTypeObjectId.check_lower(value.package)
 
     @staticmethod
     def write(value, buf):
         _UniffiConverterTypeIdentifier.write(value.module_name, buf)
-        _UniffiConverterTypeIdentifier.write(value.struct_name, buf)
+        _UniffiConverterTypeIdentifier.write(value.datatype_name, buf)
         _UniffiConverterTypeObjectId.write(value.package, buf)
 
 
@@ -22121,7 +22135,7 @@ class UpgradeInfo:
 
     upgraded_id: "ObjectId"
     """
-    Id of the upgraded packages
+    ID of the upgraded package
     """
 
     upgraded_version: "Version"

--- a/bindings/swift/Sources/IotaSDK/IotaSDK.swift
+++ b/bindings/swift/Sources/IotaSDK/IotaSDK.swift
@@ -34350,7 +34350,9 @@ public func FfiConverterTypeTransactionsFilter_lower(_ value: TransactionsFilter
 
 
 /**
- * Identifies a struct and the module it was defined in
+ * Stores the origin of a data type where it first appeared in the version
+ * chain. A data type is identified by the name of the module and the name of
+ * the struct/enum in combination.
  *
  * # BCS
  *
@@ -34361,15 +34363,33 @@ public func FfiConverterTypeTransactionsFilter_lower(_ value: TransactionsFilter
  * ```
  */
 public struct TypeOrigin {
+    /**
+     * The name of the module the data type resides in.
+     */
     public var moduleName: Identifier
-    public var structName: Identifier
+    /**
+     * identifier.
+     */
+    public var datatypeName: Identifier
+    /**
+     * ID of the package, where the given type first appeared.
+     */
     public var package: ObjectId
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(moduleName: Identifier, structName: Identifier, package: ObjectId) {
+    public init(
+        /**
+         * The name of the module the data type resides in.
+         */moduleName: Identifier, 
+        /**
+         * identifier.
+         */datatypeName: Identifier, 
+        /**
+         * ID of the package, where the given type first appeared.
+         */package: ObjectId) {
         self.moduleName = moduleName
-        self.structName = structName
+        self.datatypeName = datatypeName
         self.package = package
     }
 }
@@ -34388,14 +34408,14 @@ public struct FfiConverterTypeTypeOrigin: FfiConverterRustBuffer {
         return
             try TypeOrigin(
                 moduleName: FfiConverterTypeIdentifier.read(from: &buf), 
-                structName: FfiConverterTypeIdentifier.read(from: &buf), 
+                datatypeName: FfiConverterTypeIdentifier.read(from: &buf), 
                 package: FfiConverterTypeObjectId.read(from: &buf)
         )
     }
 
     public static func write(_ value: TypeOrigin, into buf: inout [UInt8]) {
         FfiConverterTypeIdentifier.write(value.moduleName, into: &buf)
-        FfiConverterTypeIdentifier.write(value.structName, into: &buf)
+        FfiConverterTypeIdentifier.write(value.datatypeName, into: &buf)
         FfiConverterTypeObjectId.write(value.package, into: &buf)
     }
 }
@@ -34492,7 +34512,7 @@ public func FfiConverterTypeUnchangedSharedObject_lower(_ value: UnchangedShared
  */
 public struct UpgradeInfo {
     /**
-     * Id of the upgraded packages
+     * ID of the upgraded package
      */
     public var upgradedId: ObjectId
     /**
@@ -34504,7 +34524,7 @@ public struct UpgradeInfo {
     // declare one manually.
     public init(
         /**
-         * Id of the upgraded packages
+         * ID of the upgraded package
          */upgradedId: ObjectId, 
         /**
          * Version of the upgraded package

--- a/bindings/swift/Sources/IotaSDK/IotaSDK.swift
+++ b/bindings/swift/Sources/IotaSDK/IotaSDK.swift
@@ -34368,6 +34368,7 @@ public struct TypeOrigin {
      */
     public var moduleName: Identifier
     /**
+     * The name of the data type. Either refers to an enum or a struct
      * identifier.
      */
     public var datatypeName: Identifier
@@ -34383,6 +34384,7 @@ public struct TypeOrigin {
          * The name of the module the data type resides in.
          */moduleName: Identifier, 
         /**
+         * The name of the data type. Either refers to an enum or a struct
          * identifier.
          */datatypeName: Identifier, 
         /**

--- a/crates/iota-sdk-bcs-schema/README.md
+++ b/crates/iota-sdk-bcs-schema/README.md
@@ -62,7 +62,7 @@ The macro only writes to disk when the `BCS_SCHEMA` env var is set, so normal de
 
 ```sh
 # Regenerate
-BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema
+BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash
 
 # Normal build — no regeneration, no recompile overhead
 cargo check --all-features

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -392,7 +392,7 @@ impl ObjectData {
 pub struct TypeOrigin {
     /// The name of the module the data type resides in.
     pub module_name: Arc<Identifier>,
-    // The name of the data type. Either refers to an enum or a struct
+    /// The name of the data type. Either refers to an enum or a struct
     /// identifier.
     pub datatype_name: Arc<Identifier>,
     /// ID of the package, where the given type first appeared.

--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -377,7 +377,9 @@ impl ObjectData {
     }
 }
 
-/// Identifies a struct and the module it was defined in
+/// Stores the origin of a data type where it first appeared in the version
+/// chain. A data type is identified by the name of the module and the name of
+/// the struct/enum in combination.
 ///
 /// # BCS
 ///
@@ -388,8 +390,12 @@ impl ObjectData {
 /// ```
 #[derive(uniffi::Record)]
 pub struct TypeOrigin {
+    /// The name of the module the data type resides in.
     pub module_name: Arc<Identifier>,
-    pub struct_name: Arc<Identifier>,
+    // The name of the data type. Either refers to an enum or a struct
+    /// identifier.
+    pub datatype_name: Arc<Identifier>,
+    /// ID of the package, where the given type first appeared.
     pub package: Arc<ObjectId>,
 }
 
@@ -397,7 +403,7 @@ impl From<iota_sdk::types::TypeOrigin> for TypeOrigin {
     fn from(value: iota_sdk::types::TypeOrigin) -> Self {
         Self {
             module_name: Arc::new(value.module_name.into()),
-            struct_name: Arc::new(value.struct_name.into()),
+            datatype_name: Arc::new(value.datatype_name.into()),
             package: Arc::new(value.package.into()),
         }
     }
@@ -407,7 +413,7 @@ impl From<TypeOrigin> for iota_sdk::types::TypeOrigin {
     fn from(value: TypeOrigin) -> Self {
         Self {
             module_name: value.module_name.0.clone(),
-            struct_name: value.struct_name.0.clone(),
+            datatype_name: value.datatype_name.0.clone(),
             package: **value.package,
         }
     }
@@ -424,7 +430,7 @@ impl From<TypeOrigin> for iota_sdk::types::TypeOrigin {
 /// ```
 #[derive(uniffi::Record)]
 pub struct UpgradeInfo {
-    /// Id of the upgraded packages
+    /// ID of the upgraded package
     pub upgraded_id: Arc<ObjectId>,
     /// Version of the upgraded package
     pub upgraded_version: Arc<Version>,

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -389,7 +389,7 @@ type-argument-error = %d00   ; TypeNotFound
                     / %d01   ; ConstraintNotSatisfied
 
 type-origin = identifier   ; module-name
-              identifier   ; struct-name
+              identifier   ; datatype-name
               object-id    ; package
 
 type-tag = %d00              ; Bool

--- a/crates/iota-sdk-types/build.rs
+++ b/crates/iota-sdk-types/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 fn main() {
     // Regenerate bcs-schema.abnf only when explicitly requested via:
     //
-    //   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema
+    //   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash
     //
     // The env var (not just the feature) triggers the forced recompilation so
     // that `--all-features` builds remain incremental during normal development.

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -157,10 +157,9 @@ pub use execution_status::{
 pub use framework::Coin;
 pub use gas::GasCostSummary;
 pub use move_core::{Identifier, StructTag, TypeParseError, TypeTag};
-pub use move_package::{MovePackageData, UpgradePolicy};
+pub use move_package::{MovePackage, MovePackageData, TypeOrigin, UpgradeInfo, UpgradePolicy};
 pub use object::{
-    GenesisObject, MovePackage, MoveStruct, Object, ObjectData, ObjectReference, ObjectType, Owner,
-    TypeOrigin, UpgradeInfo,
+    GenesisObject, MoveStruct, Object, ObjectData, ObjectReference, ObjectType, Owner,
 };
 pub use object_id::ObjectId;
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/move_core/identifier.rs
+++ b/crates/iota-sdk-types/src/move_core/identifier.rs
@@ -234,6 +234,24 @@ impl PartialEq<str> for Identifier {
     }
 }
 
+impl PartialEq<&str> for Identifier {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialEq<Identifier> for str {
+    fn eq(&self, other: &Identifier) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl PartialEq<String> for Identifier {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
 impl std::ops::Deref for Identifier {
     type Target = str;
 

--- a/crates/iota-sdk-types/src/move_core/parse.rs
+++ b/crates/iota-sdk-types/src/move_core/parse.rs
@@ -18,10 +18,10 @@ pub const MAX_TYPE_TAG_NESTING: usize = 16;
 /// ALLOWED_IDENTIFIERS = r"(?:[a-zA-Z][a-zA-Z0-9_]*)|(?:_[a-zA-Z0-9_]+)";
 pub(crate) fn parse_identifier(input: &mut &str) -> ModalResult<Identifier, TypeParseError> {
     alt((
-        (one_of(|c: char| c.is_alpha()), valid_remainder(0)),
-        ('_', valid_remainder(1)),
+        "<SELF>",
+        (one_of(|c: char| c.is_alpha()), valid_remainder(0)).take(),
+        ('_', valid_remainder(1)).take(),
     ))
-    .take()
     .parse_next(input)
     .and_then(|s| {
         if s.len() > MAX_IDENTIFIER_LENGTH {
@@ -282,6 +282,28 @@ mod tests {
                 parsed.unwrap_err()
             );
         }
+    }
+
+    #[test]
+    fn test_parse_self_identifier() {
+        let parsed = "<SELF>".parse::<Identifier>();
+        assert!(parsed.is_ok(), "Failed to parse <SELF> as identifier");
+        assert_eq!(parsed.unwrap().as_str(), "<SELF>");
+
+        // <SELF> should work in struct tags
+        let parsed = "0x1::<SELF>::Foo".parse::<StructTag>();
+        assert!(
+            parsed.is_ok(),
+            "Failed to parse struct tag with <SELF> module: {}",
+            parsed.unwrap_err()
+        );
+
+        let parsed = "0x1::Foo::<SELF>".parse::<StructTag>();
+        assert!(
+            parsed.is_ok(),
+            "Failed to parse struct tag with <SELF> name: {}",
+            parsed.unwrap_err()
+        );
     }
 
     #[test]

--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -69,29 +69,12 @@ pub struct MovePackageData {
 impl MovePackageData {
     #[cfg(feature = "hash")]
     pub fn new(modules: Vec<Vec<u8>>, dependencies: Vec<ObjectId>) -> Self {
-        let mut components = dependencies
-            .iter()
-            .map(|o| o.into_bytes())
-            .chain(modules.iter().map(|module| {
-                let mut hasher = Hasher::new();
-                hasher.update(module);
-                hasher.finalize().into_inner()
-            }))
-            .collect::<Vec<_>>();
-
-        // Sort so the order of the modules and the order of the dependencies
-        // does not matter.
-        components.sort();
-
-        let mut hasher = Hasher::new();
-        for c in components {
-            hasher.update(c);
-        }
+        let digest = MovePackage::compute_digest_for_modules_and_deps(&modules, &dependencies);
 
         Self {
             modules,
             dependencies,
-            digest: Digest::from(hasher.finalize().into_inner()),
+            digest,
         }
     }
 }

--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -3,9 +3,10 @@
 
 use std::collections::BTreeMap;
 
+#[cfg(feature = "hash")]
+use crate::hash::Hasher;
 use crate::{
     Digest, ExecutionError, Identifier, ObjectId,
-    hash::Hasher,
     version::{Version, VersionError},
 };
 
@@ -68,7 +69,6 @@ pub struct MovePackageData {
 impl MovePackageData {
     #[cfg(feature = "hash")]
     pub fn new(modules: Vec<Vec<u8>>, dependencies: Vec<ObjectId>) -> Self {
-        use crate::hash::Hasher;
         let mut components = dependencies
             .iter()
             .map(|o| o.into_bytes())
@@ -246,6 +246,7 @@ impl MovePackage {
     /// It is important that this function is shared across both the calculation
     /// of the digest for the package, and the calculation of the digest
     /// on-chain.
+    #[cfg(feature = "hash")]
     pub fn compute_digest_for_modules_and_deps<'a>(
         modules: impl IntoIterator<Item = &'a Vec<u8>>,
         object_ids: impl IntoIterator<Item = &'a ObjectId>,

--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -1,7 +1,13 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Digest, ObjectId};
+use std::collections::BTreeMap;
+
+use crate::{
+    Digest, ExecutionError, Identifier, ObjectId,
+    hash::Hasher,
+    version::{Version, VersionError},
+};
 
 /// Rust representation of upgrade policy constants in `iota::package`.
 #[repr(u8)]
@@ -87,6 +93,257 @@ impl MovePackageData {
             dependencies,
             digest: Digest::from(hasher.finalize().into_inner()),
         }
+    }
+}
+
+/// Upgraded package info for [MovePackage]'s linkage_table.
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// upgrade-info = object-id version
+/// ```
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+pub struct UpgradeInfo {
+    /// ID of the upgraded package
+    pub upgraded_id: ObjectId,
+    /// Version of the upgraded package
+    pub upgraded_version: Version,
+}
+
+/// Stores the origin of a data type where it first appeared in the version
+/// chain. A data type is identified by the name of the module and the name of
+/// the struct/enum in combination.
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// type-origin = identifier identifier object-id
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+pub struct TypeOrigin {
+    /// The name of the module the data type resides in.
+    pub module_name: Identifier,
+    /// The name of the data type. Either refers to an enum or a struct
+    /// identifier.
+    // `struct_name` alias to support backwards compatibility with the old name
+    #[serde(alias = "struct_name")]
+    pub datatype_name: Identifier,
+    /// ID of the package, where the given type first appeared.
+    pub package: ObjectId,
+}
+
+/// A move package
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// move-package = object-id                          ; id
+///                version                            ; version
+///                (vector (identifier bytes))        ; modules
+///                (vector type-origin)               ; type-origin-table
+///                (vector (object-id upgrade-info))  ; linkage-table
+/// ```
+#[derive(Eq, PartialEq, Debug, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+pub struct MovePackage {
+    /// The ID of this package
+    pub id: ObjectId,
+    /// Most move packages are uniquely identified by their ID (i.e. there is
+    /// only one version per ID), but the version is still stored because
+    /// one package may be an upgrade of another (at a different ID), in
+    /// which case its version will be one greater than the version of the
+    /// upgraded package.
+    ///
+    /// Framework packages are an exception to this rule -- all versions of the
+    /// framework packages exist at the same ID, at increasing versions.
+    ///
+    /// In all cases, packages are referred to by move calls using just their
+    /// ID, and they are always loaded at their latest version.
+    pub version: Version,
+    /// Set of modules defined by this package
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "::serde_with::As::<BTreeMap<::serde_with::Same, ::serde_with::Bytes>>")
+    )]
+    #[cfg_attr(
+        feature = "proptest",
+        strategy(
+            proptest::collection::btree_map(proptest::arbitrary::any::<Identifier>(), proptest::collection::vec(proptest::arbitrary::any::<u8>(), 0..=1024), 0..=5)
+        )
+    )]
+    pub modules: BTreeMap<Identifier, Vec<u8>>,
+    /// Maps structs and enums in a given module to a package version where it
+    /// was first defined, stored as a vector for simple serialization and
+    /// deserialization.
+    pub type_origin_table: Vec<TypeOrigin>,
+    /// For each dependency, maps original package ID to the info about the
+    /// (upgraded) dependency version that this package is using.
+    #[cfg_attr(
+        feature = "proptest",
+        strategy(
+            proptest::collection::btree_map(proptest::arbitrary::any::<ObjectId>(), proptest::arbitrary::any::<UpgradeInfo>(), 0..=5)
+        )
+    )]
+    pub linkage_table: BTreeMap<ObjectId, UpgradeInfo>,
+}
+
+impl MovePackage {
+    /// Create a package with all required data (including serialized modules,
+    /// type origin and linkage tables) already supplied.
+    ///
+    /// It does not perform any type of validation. Ensure that the supplied
+    /// parts are semantically valid.
+    pub fn new(
+        id: ObjectId,
+        version: Version,
+        modules: BTreeMap<Identifier, Vec<u8>>,
+        max_move_package_size: u64,
+        type_origin_table: Vec<TypeOrigin>,
+        linkage_table: BTreeMap<ObjectId, UpgradeInfo>,
+    ) -> Result<Self, ExecutionError> {
+        let pkg = Self {
+            id,
+            version,
+            modules,
+            type_origin_table,
+            linkage_table,
+        };
+        let object_size = pkg.size() as u64;
+        if object_size > max_move_package_size {
+            return Err(ExecutionError::PackageTooBig {
+                object_size,
+                max_object_size: max_move_package_size,
+            });
+        }
+        Ok(pkg)
+    }
+
+    /// Calculate the digest of the [MovePackage].
+    pub fn digest(&self) -> Digest {
+        Self::compute_digest_for_modules_and_deps(
+            self.modules.values(),
+            self.linkage_table
+                .values()
+                .map(|UpgradeInfo { upgraded_id, .. }| upgraded_id),
+        )
+    }
+
+    /// It is important that this function is shared across both the calculation
+    /// of the digest for the package, and the calculation of the digest
+    /// on-chain.
+    pub fn compute_digest_for_modules_and_deps<'a>(
+        modules: impl IntoIterator<Item = &'a Vec<u8>>,
+        object_ids: impl IntoIterator<Item = &'a ObjectId>,
+    ) -> Digest {
+        let mut components = object_ids
+            .into_iter()
+            .map(|o| o.into_bytes())
+            .chain(
+                modules
+                    .into_iter()
+                    .map(|module| Hasher::digest(module).into_inner()),
+            )
+            .collect::<Vec<_>>();
+
+        // NB: sorting so the order of the modules and the order of the dependencies
+        // does not matter.
+        components.sort();
+
+        let mut digest = Hasher::new();
+        for c in components {
+            digest.update(c);
+        }
+        digest.finalize()
+    }
+
+    /// Retrieve the module from this package with the given [Identifier].
+    pub fn get_module(&self, name: &Identifier) -> Option<&Vec<u8>> {
+        self.modules.get(name)
+    }
+
+    /// Return the size of the package in bytes
+    pub fn size(&self) -> usize {
+        let module_map_size = self
+            .modules
+            .iter()
+            .map(|(name, module)| name.len() + module.len())
+            .sum::<usize>();
+        let type_origin_table_size = self
+            .type_origin_table
+            .iter()
+            .map(
+                |TypeOrigin {
+                     module_name,
+                     datatype_name,
+                     ..
+                 }| module_name.len() + datatype_name.len() + ObjectId::LENGTH,
+            )
+            .sum::<usize>();
+
+        let linkage_table_size = self.linkage_table.len()
+            * (ObjectId::LENGTH + (ObjectId::LENGTH + std::mem::size_of::<Version>()));
+
+        std::mem::size_of::<Version>()
+            + module_map_size
+            + type_origin_table_size
+            + linkage_table_size
+    }
+
+    /// `Package ID`/`Storage ID` of this package.
+    pub fn id(&self) -> ObjectId {
+        self.id
+    }
+
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    pub fn increment_version(&mut self) -> Result<(), VersionError> {
+        self.version.increment()
+    }
+
+    pub fn decrement_version(&mut self) -> Result<(), VersionError> {
+        self.version.decrement()
+    }
+
+    pub fn serialized_module_map(&self) -> &BTreeMap<Identifier, Vec<u8>> {
+        &self.modules
+    }
+
+    pub fn type_origin_table(&self) -> &Vec<TypeOrigin> {
+        &self.type_origin_table
+    }
+
+    pub fn type_origin_map(&self) -> BTreeMap<(Identifier, Identifier), ObjectId> {
+        self.type_origin_table
+            .iter()
+            .map(
+                |TypeOrigin {
+                     module_name,
+                     datatype_name,
+                     package,
+                 }| { ((module_name.clone(), datatype_name.clone()), *package) },
+            )
+            .collect()
+    }
+
+    pub fn linkage_table(&self) -> &BTreeMap<ObjectId, UpgradeInfo> {
+        &self.linkage_table
     }
 }
 

--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -234,6 +234,7 @@ impl MovePackage {
     }
 
     /// Calculate the digest of the [MovePackage].
+    #[cfg(feature = "hash")]
     pub fn digest(&self) -> Digest {
         Self::compute_digest_for_modules_and_deps(
             self.modules.values(),

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -4,8 +4,9 @@
 
 use std::collections::BTreeMap;
 
-use super::{Address, Digest, Identifier, ObjectId, StructTag};
-use crate::Version;
+use super::{
+    Address, Digest, Identifier, MovePackage, ObjectId, StructTag, TypeOrigin, UpgradeInfo, Version,
+};
 
 /// Reference to an object
 ///
@@ -170,105 +171,6 @@ pub enum ObjectData {
 
 impl ObjectData {
     crate::def_is_as_into_opt!(Struct(MoveStruct), Package(MovePackage));
-}
-
-/// A move package
-///
-/// # BCS
-///
-/// The BCS serialized form for this type is defined by the following ABNF:
-///
-/// ```text
-/// move-package = object-id                          ; id
-///                u64                                ; version
-///                (vector (identifier bytes))        ; modules
-///                (vector type-origin)               ; type-origin-table
-///                (vector (object-id upgrade-info))  ; linkage-table
-/// ```
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
-pub struct MovePackage {
-    /// Address or Id of this package
-    pub id: ObjectId,
-    /// Most move packages are uniquely identified by their ID (i.e. there is
-    /// only one version per ID), but the version is still stored because
-    /// one package may be an upgrade of another (at a different ID), in
-    /// which case its version will be one greater than the version of the
-    /// upgraded package.
-    ///
-    /// Framework packages are an exception to this rule -- all versions of the
-    /// framework packages exist at the same ID, at increasing versions.
-    ///
-    /// In all cases, packages are referred to by move calls using just their
-    /// ID, and they are always loaded at their latest version.
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    pub version: Version,
-    /// Set of modules defined by this package
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "::serde_with::As::<BTreeMap<::serde_with::Same, ::serde_with::Bytes>>")
-    )]
-    #[cfg_attr(
-        feature = "proptest",
-        strategy(
-            proptest::collection::btree_map(proptest::arbitrary::any::<Identifier>(), proptest::collection::vec(proptest::arbitrary::any::<u8>(), 0..=1024), 0..=5)
-        )
-    )]
-    pub modules: BTreeMap<Identifier, Vec<u8>>,
-    /// Maps struct/module to a package version where it was first defined,
-    /// stored as a vector for simple serialization and deserialization.
-    pub type_origin_table: Vec<TypeOrigin>,
-    /// For each dependency, maps original package ID to the info about the
-    /// (upgraded) dependency version that this package is using
-    #[cfg_attr(
-        feature = "proptest",
-        strategy(
-            proptest::collection::btree_map(proptest::arbitrary::any::<ObjectId>(), proptest::arbitrary::any::<UpgradeInfo>(), 0..=5)
-        )
-    )]
-    pub linkage_table: BTreeMap<ObjectId, UpgradeInfo>,
-}
-
-/// Identifies a struct and the module it was defined in
-///
-/// # BCS
-///
-/// The BCS serialized form for this type is defined by the following ABNF:
-///
-/// ```text
-/// type-origin = identifier identifier object-id
-/// ```
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
-pub struct TypeOrigin {
-    pub module_name: Identifier,
-    pub struct_name: Identifier,
-    pub package: ObjectId,
-}
-
-/// Upgraded package info for the linkage table
-///
-/// # BCS
-///
-/// The BCS serialized form for this type is defined by the following ABNF:
-///
-/// ```text
-/// upgrade-info = object-id u64
-/// ```
-#[derive(Eq, PartialEq, Debug, Clone, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
-#[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
-pub struct UpgradeInfo {
-    /// Id of the upgraded packages
-    pub upgraded_id: ObjectId,
-    /// Version of the upgraded package
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    pub upgraded_version: Version,
 }
 
 /// A move struct

--- a/crates/iota-sdk-types/src/version.rs
+++ b/crates/iota-sdk-types/src/version.rs
@@ -106,6 +106,8 @@ impl Version {
     const MIN_CONGESTED_FOR_GAS_PRICE_FEEDBACK: Self =
         Self(Self::MAX_VALID_EXCL.0 + Self::CONGESTED_BASE_OFFSET_FOR_GAS_PRICE_FEEDBACK.0);
 
+    pub const OBJECT_START: Self = Self(1);
+
     /// Create a new Version from a u64 value
     pub const fn from_u64(value: u64) -> Self {
         Self(value)

--- a/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
+++ b/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
@@ -7,7 +7,7 @@
 //! This proves the grammar is a sound description of what BCS can decode
 //! (grammar → BCS). Run with:
 //!
-//!   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema hash
+//!   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash
 //!   cargo test -p iota-sdk-types --features bcs-schema --test
 //! bcs_schema_fuzzing
 

--- a/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
+++ b/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
@@ -7,7 +7,7 @@
 //! This proves the grammar is a sound description of what BCS can decode
 //! (grammar → BCS). Run with:
 //!
-//!   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema
+//!   BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema hash
 //!   cargo test -p iota-sdk-types --features bcs-schema --test
 //! bcs_schema_fuzzing
 
@@ -390,7 +390,7 @@ impl TestHarness {
         let content = std::fs::read_to_string(schema_path).unwrap_or_else(|_| {
             panic!(
                 "failed to read {schema_path} — regenerate it with:\n  \
-             BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema"
+             BCS_SCHEMA=1 cargo check -p iota-sdk-types --features bcs-schema,hash"
             )
         });
         let grammar = parse_grammar(&content);


### PR DESCRIPTION
## Summary

Brings `MovePackage` and its companion types in line with what the monorepo needs to drop its own copy and consume `iota-sdk-types` instead. Adds the constructors, accessors, and digest helpers that the monorepo relies on, fixes the `TypeOrigin` field name to match the upstream type system (which now covers enums as well as structs), and relaxes the parser/identifier types just enough to round-trip the special `<SELF>` identifier used in module self-references.

## Changes

### `MovePackage` / `TypeOrigin` / `UpgradeInfo`

- Moved `MovePackage`, `TypeOrigin`, and `UpgradeInfo` out of [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs) and into the dedicated [crates/iota-sdk-types/src/move_package.rs](crates/iota-sdk-types/src/move_package.rs) module. Re-exports from the crate root are unchanged for downstream consumers.
- Renamed `TypeOrigin::struct_name` → `TypeOrigin::datatype_name` to reflect that it now identifies either a struct *or* an enum. A `#[serde(alias = "struct_name")]` is kept on the new field so existing serialized payloads continue to deserialize. Doc comments updated to match.
- New `MovePackage::new(id, version, modules, max_move_package_size, type_origin_table, linkage_table) -> Result<Self, ExecutionError>` constructor that enforces the package size limit and returns `ExecutionError::PackageTooBig` if exceeded.
- New methods on `MovePackage`:
  - `digest()` — computes the canonical package digest from modules + linkage-table dependencies.
  - `compute_digest_for_modules_and_deps(modules, object_ids)` — the underlying helper, exposed as an associated function so the same digest logic can be shared with on-chain computation.
  - `get_module(name)` — fetches a serialized module by [`Identifier`](crates/iota-sdk-types/src/move_core/identifier.rs).
  - `size()` — returns the in-memory size in bytes (matching the monorepo's accounting for the package size limit check).
  - `id()`, `version()`, `increment_version()`, `decrement_version()`.
  - `serialized_module_map()`, `type_origin_table()`, `linkage_table()` — borrowing accessors over the underlying maps/vecs.
  - `type_origin_map()` — returns the `type_origin_table` flattened into a `BTreeMap<(Identifier, Identifier), ObjectId>` keyed by `(module_name, datatype_name)`.

### Serialization change (breaking, human-readable form only)

- Dropped the `ReadableDisplay` serde wrapper on the `version` fields of `MovePackage` and `UpgradeInfo`. BCS encoding is unchanged; in human-readable formats (e.g. JSON) `version` is now emitted as the underlying number rather than a quoted decimal string.

### `Version`

- New `Version::OBJECT_START` constant (= 1) — the version that a freshly-created object starts at, used as a default in places that need to mint a brand-new package.

### `Identifier`

- Added three `PartialEq` impls — `PartialEq<&str> for Identifier`, `PartialEq<String> for Identifier`, and `PartialEq<Identifier> for str` — so identifiers can be compared directly against string literals and `String`s in either direction without an explicit `.as_str()`.

### Move type parser

- The identifier parser now accepts the literal `<SELF>` as a valid identifier in addition to the regular `[a-zA-Z][a-zA-Z0-9_]*` / `_[a-zA-Z0-9_]+` shapes. This is the special name used by the bytecode for self-references, and was previously rejected by `parse_identifier`. Covered by a new `test_parse_self_identifier` unit test that exercises both `0x1::<SELF>::Foo` and `0x1::Foo::<SELF>` as valid `StructTag`s.

### FFI

- [crates/iota-sdk-ffi/src/types/object.rs](crates/iota-sdk-ffi/src/types/object.rs): `TypeOrigin.struct_name` → `TypeOrigin.datatype_name` to match the type-system change, with the conversions in both directions and the doc comments updated. The Go, Kotlin, and Python bindings are regenerated to match.

## Test plan

- [ ] `cargo test -p iota-sdk-types`
- [ ] `cargo test -p iota-sdk-types --all-features`
- [ ] `cargo check --workspace`
- [ ] Regenerate / smoke-test the Go, Kotlin, and Python bindings against the new `datatype_name` field name on `TypeOrigin`.
