### PR TITLE
feat(iota-sdk-types)!: add Input consts and methods

### DIFF
--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -328,7 +328,7 @@ impl Input {
     /// not contain structs or objects.
     #[uniffi::constructor]
     pub fn new_pure(value: Vec<u8>) -> Self {
-        Self(iota_sdk::types::Input::Pure { value })
+        Self(iota_sdk::types::Input::Pure(value))
     }
 
     /// A move object that is either immutable or address owned
@@ -344,11 +344,13 @@ impl Input {
         initial_shared_version: &Version,
         mutable: bool,
     ) -> Self {
-        Self(iota_sdk::types::Input::Shared {
-            object_id: object_id.0,
-            initial_shared_version: **initial_shared_version,
-            mutable,
-        })
+        Self(iota_sdk::types::Input::Shared(
+            iota_sdk::types::SharedObjectReference {
+                object_id: object_id.0,
+                initial_shared_version: **initial_shared_version,
+                mutable,
+            },
+        ))
     }
 
     #[uniffi::constructor]

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -12,8 +12,8 @@ use std::{
 use iota_graphql_client::Client;
 use iota_types::{
     Address, GasPayment, Identifier, MovePackageData, ObjectId, ObjectReference, Owner,
-    ProgrammableTransaction, StructTag, Transaction, TransactionEffects, TransactionExpiration,
-    TransactionV1, TypeTag,
+    ProgrammableTransaction, SharedObjectReference, StructTag, Transaction, TransactionEffects,
+    TransactionExpiration, TransactionV1, TypeTag,
 };
 use reqwest::Url;
 use serde::Serialize;
@@ -1035,13 +1035,11 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
                                     obj.digest(),
                                 ))
                             }
-                            Owner::Shared(v) => {
-                                iota_types::Input::Shared(iota_types::SharedObjectReference {
-                                    object_id,
-                                    initial_shared_version: *v,
-                                    mutable: false,
-                                })
-                            }
+                            Owner::Shared(v) => iota_types::Input::Shared(SharedObjectReference {
+                                object_id,
+                                initial_shared_version: *v,
+                                mutable: false,
+                            }),
                             _ => unimplemented!(
                                 "a new enum variant was added and needs to be handled"
                             ),
@@ -1061,7 +1059,7 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
 
                     let input = match obj.owner() {
                         Owner::Shared(version) => {
-                            iota_types::Input::Shared(iota_types::SharedObjectReference {
+                            iota_types::Input::Shared(SharedObjectReference {
                                 object_id,
                                 initial_shared_version: *version,
                                 mutable,

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -157,10 +157,7 @@ impl TransactionBuildData {
 
     /// Add a pure input using the BCS serialized bytes
     pub fn pure_bytes(&mut self, bytes: Vec<u8>) -> Argument {
-        self.set_input(
-            InputKind::Input(iota_types::Input::Pure { value: bytes }),
-            false,
-        )
+        self.set_input(InputKind::Input(iota_types::Input::Pure(bytes)), false)
     }
 
     /// Add a pure input
@@ -1038,11 +1035,13 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
                                     obj.digest(),
                                 ))
                             }
-                            Owner::Shared(v) => iota_types::Input::Shared {
-                                object_id,
-                                initial_shared_version: *v,
-                                mutable: false,
-                            },
+                            Owner::Shared(v) => {
+                                iota_types::Input::Shared(iota_types::SharedObjectReference {
+                                    object_id,
+                                    initial_shared_version: *v,
+                                    mutable: false,
+                                })
+                            }
                             _ => unimplemented!(
                                 "a new enum variant was added and needs to be handled"
                             ),
@@ -1061,11 +1060,13 @@ impl<C: ClientMethods, L> TransactionBuilder<C, L> {
                         .ok_or_else(|| Error::Input(format!("missing object {object_id}")))?;
 
                     let input = match obj.owner() {
-                        Owner::Shared(version) => iota_types::Input::Shared {
-                            object_id,
-                            initial_shared_version: *version,
-                            mutable,
-                        },
+                        Owner::Shared(version) => {
+                            iota_types::Input::Shared(iota_types::SharedObjectReference {
+                                object_id,
+                                initial_shared_version: *version,
+                                mutable,
+                            })
+                        }
                         _ => {
                             return Err(Error::Input(format!(
                                 "object {object_id} was passed as shared, but is not"

--- a/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
@@ -85,9 +85,11 @@ impl MoveAuthenticatorBuilder {
                     iota_types::Input::ImmutableOrOwned(obj.object_ref())
                 }
                 InputKind::Shared { object_id, mutable }
-                | InputKind::Input(iota_types::Input::Shared {
-                    object_id, mutable, ..
-                }) => {
+                | InputKind::Input(iota_types::Input::Shared(
+                    iota_types::SharedObjectReference {
+                        object_id, mutable, ..
+                    },
+                )) => {
                     let obj = client
                         .object(object_id, None)
                         .await
@@ -102,11 +104,11 @@ impl MoveAuthenticatorBuilder {
                         )));
                     };
 
-                    iota_types::Input::Shared {
+                    iota_types::Input::Shared(iota_types::SharedObjectReference {
                         object_id,
                         initial_shared_version: *version,
                         mutable,
-                    }
+                    })
                 }
                 InputKind::Receiving(_) | InputKind::Input(iota_types::Input::Receiving(_)) => {
                     return Err(Error::InvalidMoveAuthArg(

--- a/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
@@ -6,7 +6,8 @@
 //! Account Abstraction.
 
 use iota_types::{
-    MoveAuthenticator, MoveAuthenticatorV1, ObjectId, ObjectReference, Owner, TypeTag,
+    Input, MoveAuthenticator, MoveAuthenticatorV1, ObjectId, ObjectReference, Owner,
+    SharedObjectReference, TypeTag,
 };
 
 use crate::{
@@ -66,9 +67,8 @@ impl MoveAuthenticatorBuilder {
         for input in self.call_args {
             call_args.push(match input {
                 InputKind::ImmutableOrOwned(object_id)
-                | InputKind::Input(iota_types::Input::ImmutableOrOwned(ObjectReference {
-                    object_id,
-                    ..
+                | InputKind::Input(Input::ImmutableOrOwned(ObjectReference {
+                    object_id, ..
                 })) => {
                     let obj = client
                         .object(object_id, None)
@@ -82,14 +82,14 @@ impl MoveAuthenticatorBuilder {
                             "call arguments must not be owned".to_owned(),
                         ));
                     }
-                    iota_types::Input::ImmutableOrOwned(obj.object_ref())
+                    Input::ImmutableOrOwned(obj.object_ref())
                 }
                 InputKind::Shared { object_id, mutable }
-                | InputKind::Input(iota_types::Input::Shared(
-                    iota_types::SharedObjectReference {
-                        object_id, mutable, ..
-                    },
-                )) => {
+                | InputKind::Input(Input::Shared(SharedObjectReference {
+                    object_id,
+                    mutable,
+                    ..
+                })) => {
                     let obj = client
                         .object(object_id, None)
                         .await
@@ -104,13 +104,13 @@ impl MoveAuthenticatorBuilder {
                         )));
                     };
 
-                    iota_types::Input::Shared(iota_types::SharedObjectReference {
+                    Input::Shared(SharedObjectReference {
                         object_id,
                         initial_shared_version: *version,
                         mutable,
                     })
                 }
-                InputKind::Receiving(_) | InputKind::Input(iota_types::Input::Receiving(_)) => {
+                InputKind::Receiving(_) | InputKind::Input(Input::Receiving(_)) => {
                     return Err(Error::InvalidMoveAuthArg(
                         "call arguments must not be receiving".to_owned(),
                     ));

--- a/crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/ptb_arguments.rs
@@ -62,9 +62,7 @@ impl PTBArgument for ObjectReference {
 
 impl<T: MoveArg> PTBArgument for T {
     fn input(self) -> InputKind {
-        InputKind::Input(iota_types::Input::Pure {
-            value: self.pure_bytes().0,
-        })
+        InputKind::Input(iota_types::Input::Pure(self.pure_bytes().0))
     }
 }
 
@@ -226,11 +224,13 @@ impl PTBArgument for Shared<ObjectReference> {
 
 impl PTBArgument for &Shared<ObjectReference> {
     fn input(self) -> InputKind {
-        InputKind::Input(iota_types::Input::Shared {
-            object_id: self.0.object_id,
-            mutable: false,
-            initial_shared_version: self.0.version,
-        })
+        InputKind::Input(iota_types::Input::Shared(
+            iota_types::SharedObjectReference {
+                object_id: self.0.object_id,
+                mutable: false,
+                initial_shared_version: self.0.version,
+            },
+        ))
     }
 }
 
@@ -278,11 +278,13 @@ impl PTBArgument for SharedMut<ObjectReference> {
 
 impl PTBArgument for &SharedMut<ObjectReference> {
     fn input(self) -> InputKind {
-        InputKind::Input(iota_types::Input::Shared {
-            object_id: self.0.object_id,
-            mutable: true,
-            initial_shared_version: self.0.version,
-        })
+        InputKind::Input(iota_types::Input::Shared(
+            iota_types::SharedObjectReference {
+                object_id: self.0.object_id,
+                mutable: true,
+                initial_shared_version: self.0.version,
+            },
+        ))
     }
 }
 

--- a/crates/iota-sdk-transaction-builder/src/unresolved.rs
+++ b/crates/iota-sdk-transaction-builder/src/unresolved.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use iota_types::{Identifier, ObjectId, ObjectReference, TypeTag};
+use iota_types::{Identifier, ObjectId, ObjectReference, SharedObjectReference, TypeTag};
 
 /// An identifier indicating the unresolved index of an input.
 pub type InputId = usize;
@@ -25,9 +25,7 @@ impl Input {
             InputKind::Input(input) => match input {
                 iota_types::Input::Pure(..) => None,
                 iota_types::Input::ImmutableOrOwned(ObjectReference { object_id, .. })
-                | iota_types::Input::Shared(iota_types::SharedObjectReference {
-                    object_id, ..
-                })
+                | iota_types::Input::Shared(SharedObjectReference { object_id, .. })
                 | iota_types::Input::Receiving(ObjectReference { object_id, .. }) => {
                     Some(object_id)
                 }
@@ -54,7 +52,7 @@ impl InputKind {
         | Self::Input(
             iota_types::Input::ImmutableOrOwned(ObjectReference { object_id, .. })
             | iota_types::Input::Receiving(ObjectReference { object_id, .. })
-            | iota_types::Input::Shared(iota_types::SharedObjectReference { object_id, .. }),
+            | iota_types::Input::Shared(SharedObjectReference { object_id, .. }),
         ) = self
         {
             Some(*object_id)

--- a/crates/iota-sdk-transaction-builder/src/unresolved.rs
+++ b/crates/iota-sdk-transaction-builder/src/unresolved.rs
@@ -23,9 +23,11 @@ impl Input {
             | InputKind::Shared { object_id, .. }
             | InputKind::Receiving(object_id) => Some(object_id),
             InputKind::Input(input) => match input {
-                iota_types::Input::Pure { .. } => None,
+                iota_types::Input::Pure(..) => None,
                 iota_types::Input::ImmutableOrOwned(ObjectReference { object_id, .. })
-                | iota_types::Input::Shared { object_id, .. }
+                | iota_types::Input::Shared(iota_types::SharedObjectReference {
+                    object_id, ..
+                })
                 | iota_types::Input::Receiving(ObjectReference { object_id, .. }) => {
                     Some(object_id)
                 }
@@ -52,7 +54,7 @@ impl InputKind {
         | Self::Input(
             iota_types::Input::ImmutableOrOwned(ObjectReference { object_id, .. })
             | iota_types::Input::Receiving(ObjectReference { object_id, .. })
-            | iota_types::Input::Shared { object_id, .. },
+            | iota_types::Input::Shared(iota_types::SharedObjectReference { object_id, .. }),
         ) = self
         {
             Some(*object_id)

--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -1,7 +1,9 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Address, Input, ObjectId, ObjectReference, TypeTag, Version};
+use crate::{
+    Address, Input, ObjectId, ObjectReference, TypeTag, Version, transaction::SharedObjectReference,
+};
 
 /// MoveAuthenticator is a signature variant that enables a method of
 /// authentication through Move code. This type represents the data received
@@ -56,7 +58,7 @@ impl MoveAuthenticatorV1 {
         Self {
             call_args,
             type_args,
-            object_to_authenticate: Input::Shared(crate::transaction::SharedObjectReference {
+            object_to_authenticate: Input::Shared(SharedObjectReference {
                 object_id: object_to_authenticate,
                 initial_shared_version,
                 mutable: false,
@@ -69,9 +71,7 @@ impl MoveAuthenticatorV1 {
     pub fn address(&self) -> Address {
         match self.object_to_authenticate {
             Input::ImmutableOrOwned(ObjectReference { object_id, .. })
-            | Input::Shared(crate::transaction::SharedObjectReference { object_id, .. }) => {
-                object_id.into()
-            }
+            | Input::Shared(SharedObjectReference { object_id, .. }) => object_id.into(),
             _ => unreachable!(),
         }
     }

--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -56,11 +56,11 @@ impl MoveAuthenticatorV1 {
         Self {
             call_args,
             type_args,
-            object_to_authenticate: Input::Shared {
+            object_to_authenticate: Input::Shared(crate::transaction::SharedObjectReference {
                 object_id: object_to_authenticate,
                 initial_shared_version,
                 mutable: false,
-            },
+            }),
         }
     }
 
@@ -69,7 +69,9 @@ impl MoveAuthenticatorV1 {
     pub fn address(&self) -> Address {
         match self.object_to_authenticate {
             Input::ImmutableOrOwned(ObjectReference { object_id, .. })
-            | Input::Shared { object_id, .. } => object_id.into(),
+            | Input::Shared(crate::transaction::SharedObjectReference { object_id, .. }) => {
+                object_id.into()
+            }
             _ => unreachable!(),
         }
     }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -170,8 +170,9 @@ pub use transaction::{
     Command, ConsensusCommitPrologueV1, ConsensusDeterminedVersionAssignments,
     EndOfEpochTransactionKind, GasPayment, GenesisTransaction, Input, MakeMoveVector, MergeCoins,
     MoveCall, ProgrammableTransaction, Publish, RandomnessStateUpdate, SenderSignedTransaction,
-    SignedTransaction, SplitCoins, SystemPackage, Transaction, TransactionExpiration,
-    TransactionKind, TransactionV1, TransferObjects, Upgrade, VersionAssignment,
+    SharedObjectReference, SignedTransaction, SplitCoins, SystemPackage, Transaction,
+    TransactionExpiration, TransactionKind, TransactionV1, TransferObjects, Upgrade,
+    VersionAssignment,
 };
 pub use validator::{
     ValidatorAggregatedSignature, ValidatorCommittee, ValidatorCommitteeMember, ValidatorSignature,

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -644,29 +644,129 @@ pub enum Input {
     ///
     /// For normal operations this is required to be a move primitive type and
     /// not contain structs or objects.
-    Pure { value: Vec<u8> },
+    Pure(Vec<u8>),
     /// A move object that is either immutable or address owned
     ImmutableOrOwned(ObjectReference),
     /// A move object whose owner is "Shared"
-    Shared {
-        object_id: ObjectId,
-        initial_shared_version: Version,
-        /// Controls whether the caller asks for a mutable reference to the
-        /// shared object.
-        mutable: bool,
-    },
+    Shared(SharedObjectReference),
     /// A move object that is attempted to be received in this transaction.
     // TODO add discussion around what receiving is
     Receiving(ObjectReference),
 }
 
 impl Input {
-    crate::def_is!(Pure, Shared);
+    /// Shared `Input` for the IOTA system state object.
+    pub const IOTA_SYSTEM_MUTABLE: Self = Self::Shared(SharedObjectReference {
+        object_id: ObjectId::SYSTEM_STATE,
+        initial_shared_version: Version::INITIAL_SHARED_VERSION,
+        mutable: true,
+    });
+
+    /// Shared `Input` for the clock object.
+    pub const CLOCK_IMMUTABLE: Self = Self::Shared(SharedObjectReference {
+        object_id: ObjectId::CLOCK,
+        initial_shared_version: Version::INITIAL_SHARED_VERSION,
+        mutable: false,
+    });
+
+    /// Shared `Input` for the clock object.
+    pub const CLOCK_MUTABLE: Self = Self::Shared(SharedObjectReference {
+        object_id: ObjectId::CLOCK,
+        initial_shared_version: Version::INITIAL_SHARED_VERSION,
+        mutable: true,
+    });
+
+    /// Shared `Input` for the authenticator state object.
+    pub const AUTHENTICATOR_STATE_MUTABLE: Self = Self::Shared(SharedObjectReference {
+        object_id: ObjectId::AUTHENTICATOR_STATE,
+        initial_shared_version: Version::INITIAL_SHARED_VERSION,
+        mutable: true,
+    });
 
     crate::def_is_as_into_opt!(
+        Pure(Vec<u8>),
         ImmutableOrOwned(ObjectReference),
+        Shared(SharedObjectReference),
         Receiving(ObjectReference)
     );
+
+    /// Create a `Pure` input from a BCS-serializable value.
+    #[cfg(feature = "serde")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
+    pub fn pure<T: serde::Serialize>(value: &T) -> Self {
+        Self::Pure(bcs::to_bytes(value).expect("value should be serializable"))
+    }
+
+    /// Returns the object id referenced by this input, if any.
+    ///
+    /// Returns `None` for `Pure` inputs.
+    pub fn object_id_opt(&self) -> Option<&ObjectId> {
+        match self {
+            Self::Pure { .. } => None,
+            Self::ImmutableOrOwned(obj_ref) | Self::Receiving(obj_ref) => Some(&obj_ref.object_id),
+            Self::Shared(SharedObjectReference { object_id, .. }) => Some(object_id),
+        }
+    }
+
+    /// Returns `true` if this input references a mutable shared object.
+    pub fn is_mutable_shared(&self) -> bool {
+        matches!(
+            self,
+            Self::Shared(SharedObjectReference { mutable: true, .. })
+        )
+    }
+
+    /// Returns the [`ObjectReference`] if this is an `ImmutableOrOwned` or
+    /// `Receiving` input.
+    pub fn as_object_ref_opt(&self) -> Option<&ObjectReference> {
+        match self {
+            Self::ImmutableOrOwned(obj_ref) | Self::Receiving(obj_ref) => Some(obj_ref),
+            _ => None,
+        }
+    }
+
+    /// Returns the pure value bytes if this is a `Pure` input.
+    pub fn as_pure_value_opt(&self) -> Option<&[u8]> {
+        match self {
+            Self::Pure(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+/// A shared object input to a programmable transaction
+#[derive(Copy, Clone, Hash, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "camelCase")
+)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+pub struct SharedObjectReference {
+    pub object_id: ObjectId,
+    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+    pub initial_shared_version: Version,
+    /// Controls whether the caller asks for a mutable reference to the
+    /// shared object.
+    pub mutable: bool,
+}
+
+impl SharedObjectReference {
+    pub const IOTA_SYSTEM_STATE_OBJ_MUTABLE: Self = Self {
+        object_id: ObjectId::SYSTEM_STATE,
+        initial_shared_version: Version::INITIAL_SHARED_VERSION,
+        mutable: true,
+    };
+
+    /// Creates a new shared object reference from the object's id, initial
+    /// shared version, and mutability.
+    pub const fn new(object_id: ObjectId, initial_shared_version: Version, mutable: bool) -> Self {
+        Self {
+            object_id,
+            initial_shared_version,
+            mutable,
+        }
+    }
 }
 
 /// A single command in a programmable transaction.

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -350,22 +350,35 @@ mod version_assignments {
 
 mod input_argument {
     use super::*;
-    use crate::{Version, transaction::Input};
+    use crate::{
+        Version,
+        transaction::{Input, SharedObjectReference},
+    };
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct PureInput {
+        #[serde(with = "::serde_with::As::<crate::_serde::Base64Encoded>")]
+        value: Vec<u8>,
+    }
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "snake_case")]
     enum ReadableInput {
-        Pure {
-            #[serde(with = "::serde_with::As::<crate::_serde::Base64Encoded>")]
-            value: Vec<u8>,
-        },
+        /// A move value serialized as BCS.
+        ///
+        /// For normal operations this is required to be a move primitive type
+        /// and not contain structs or objects.
+        Pure(PureInput),
+        /// A move object that is either immutable or address owned
         ImmutableOrOwned(ObjectReference),
+        /// A move object whose owner is "Shared"
         Shared {
             object_id: ObjectId,
-            #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+            #[serde(with = "crate::_serde::ReadableDisplay")]
             initial_shared_version: Version,
             mutable: bool,
         },
+        /// A move object that is attempted to be received in this transaction.
         Receiving(ObjectReference),
     }
 
@@ -395,15 +408,15 @@ mod input_argument {
         {
             if serializer.is_human_readable() {
                 let readable = match self.clone() {
-                    Input::Pure { value } => ReadableInput::Pure { value },
+                    Input::Pure(value) => ReadableInput::Pure(PureInput { value }),
                     Input::ImmutableOrOwned(object_ref) => {
                         ReadableInput::ImmutableOrOwned(object_ref)
                     }
-                    Input::Shared {
+                    Input::Shared(SharedObjectReference {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    } => ReadableInput::Shared {
+                    }) => ReadableInput::Shared {
                         object_id,
                         initial_shared_version,
                         mutable,
@@ -413,15 +426,15 @@ mod input_argument {
                 readable.serialize(serializer)
             } else {
                 let binary = match self.clone() {
-                    Input::Pure { value } => CallArg::Pure(value),
+                    Input::Pure(value) => CallArg::Pure(value),
                     Input::ImmutableOrOwned(object_ref) => {
                         CallArg::Object(ObjectArg::ImmutableOrOwned(object_ref))
                     }
-                    Input::Shared {
+                    Input::Shared(SharedObjectReference {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    } => CallArg::Object(ObjectArg::Shared {
+                    }) => CallArg::Object(ObjectArg::Shared {
                         object_id,
                         initial_shared_version,
                         mutable,
@@ -442,7 +455,7 @@ mod input_argument {
         {
             if deserializer.is_human_readable() {
                 ReadableInput::deserialize(deserializer).map(|readable| match readable {
-                    ReadableInput::Pure { value } => Input::Pure { value },
+                    ReadableInput::Pure(PureInput { value }) => Input::Pure(value),
                     ReadableInput::ImmutableOrOwned(object_ref) => {
                         Input::ImmutableOrOwned(object_ref)
                     }
@@ -450,16 +463,16 @@ mod input_argument {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    } => Input::Shared {
+                    } => Input::Shared(SharedObjectReference {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    },
+                    }),
                     ReadableInput::Receiving(object_ref) => Input::Receiving(object_ref),
                 })
             } else {
                 CallArg::deserialize(deserializer).map(|binary| match binary {
-                    CallArg::Pure(value) => Input::Pure { value },
+                    CallArg::Pure(value) => Input::Pure(value),
                     CallArg::Object(ObjectArg::ImmutableOrOwned(object_ref)) => {
                         Input::ImmutableOrOwned(object_ref)
                     }
@@ -467,11 +480,11 @@ mod input_argument {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    }) => Input::Shared {
+                    }) => Input::Shared(SharedObjectReference {
                         object_id,
                         initial_shared_version,
                         mutable,
-                    },
+                    }),
                     CallArg::Object(ObjectArg::Receiving(object_ref)) => {
                         Input::Receiving(object_ref)
                     }
@@ -872,7 +885,7 @@ mod tests {
 
     use crate::{
         Digest, ObjectId, ObjectReference, Version,
-        transaction::{Argument, Input, Transaction},
+        transaction::{Argument, Input, SharedObjectReference, Transaction},
     };
 
     #[test]
@@ -901,9 +914,7 @@ mod tests {
     fn input_argument() {
         let test_cases = [
             (
-                Input::Pure {
-                    value: vec![1, 2, 3, 4],
-                },
+                Input::Pure(vec![1, 2, 3, 4]),
                 serde_json::json!({
                   "pure": {
                     "value": "AQIDBA=="
@@ -925,11 +936,11 @@ mod tests {
                 }),
             ),
             (
-                Input::Shared {
+                Input::Shared(SharedObjectReference {
                     object_id: ObjectId::ZERO,
                     initial_shared_version: Version::from_u64(1),
                     mutable: true,
-                },
+                }),
                 serde_json::json!({
                   "shared": {
                     "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/crates/iota-sdk-types/src/version.rs
+++ b/crates/iota-sdk-types/src/version.rs
@@ -58,6 +58,9 @@ impl Version {
     /// is assigned to, does not appear in a cancelled transaction.
     pub const MIN_VALID_INCL: Self = Self(u64::MIN);
 
+    /// The initial shared version for shared system objects.
+    pub const INITIAL_SHARED_VERSION: Self = Self(1);
+
     /// An exclusive upper limit on a valid version: versions
     /// strictly smaller than this limit are valid versions.
     ///


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/13-move-package`. Reshapes `Input` to use tuple variants and a dedicated `SharedObjectReference` struct, and adds constants and ergonomic helpers for the common system-object inputs (system state, clock, authenticator state).


- **`Input` variants → tuple form** in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs): `Input::Pure(Vec<u8>)` and `Input::Shared(SharedObjectReference)`. `SharedObjectReference` is a new `Copy` struct holding `object_id`, `initial_shared_version`, `mutable`.
- **Constants for common shared inputs:** `Input::IOTA_SYSTEM_MUTABLE`, `CLOCK_IMMUTABLE`, `CLOCK_MUTABLE`, `AUTHENTICATOR_STATE_MUTABLE`, plus `Version::INITIAL_SHARED_VERSION`.
- **New helpers on `Input`:** `pure<T: Serialize>(&T)` (BCS), `object_id_opt`, `is_mutable_shared`, `as_object_ref_opt`, `as_pure_value_opt`. `def_is_as_into_opt!` now covers all variants.
- **Wire format unchanged** (JSON and BCS). Internal callers in `iota-sdk-ffi`, `iota-sdk-transaction-builder`, and `iota-sdk-types::crypto::move_authenticator` are updated to the new shape.

**Breaking** for external Rust consumers that pattern-match `Input::Pure { value }` / `Input::Shared { .. }`; migration is mechanical. FFI binding signatures are unchanged.
