### PR TITLE
feat(iota-sdk-types): EndOfEpochTransactionKind changes (#980)

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/api/package.rs
+++ b/crates/iota-sdk-ffi/src/graphql/api/package.rs
@@ -137,7 +137,7 @@ impl GraphQLClient {
     /// Return the normalized Move module data for the provided module.
     // TODO: do we want to self paginate everything and return all the data, or keep pagination
     // options?
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     #[uniffi::method(default(
         version = None,
         pagination_filter_enums = None,

--- a/crates/iota-sdk-ffi/src/types/checkpoint.rs
+++ b/crates/iota-sdk-ffi/src/types/checkpoint.rs
@@ -58,7 +58,7 @@ pub struct CheckpointSummary(pub iota_sdk::types::CheckpointSummary);
 #[uniffi::export]
 impl CheckpointSummary {
     #[uniffi::constructor]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         epoch: EpochId,
         sequence_number: CheckpointSequenceNumber,

--- a/crates/iota-sdk-graphql-client/src/api/package.rs
+++ b/crates/iota-sdk-graphql-client/src/api/package.rs
@@ -192,7 +192,7 @@ impl Client {
     /// Return the normalized Move module data for the provided module.
     // TODO: do we want to self paginate everything and return all the data, or keep pagination
     // options?
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn normalized_move_module(
         &self,
         package: Address,

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -247,7 +247,7 @@ impl EndOfEpochTransactionKind {
     crate::def_is_as_into_opt!(ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,);
 
     /// Creates a [`ChangeEpoch`] end-of-epoch transaction kind.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_change_epoch(
         next_epoch: EpochId,
         protocol_version: ProtocolVersion,
@@ -271,7 +271,7 @@ impl EndOfEpochTransactionKind {
     }
 
     /// Creates a [`ChangeEpochV2`] end-of-epoch transaction kind.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_change_epoch_v2(
         next_epoch: EpochId,
         protocol_version: ProtocolVersion,
@@ -297,7 +297,7 @@ impl EndOfEpochTransactionKind {
     }
 
     /// Creates a [`ChangeEpochV3`] end-of-epoch transaction kind.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_change_epoch_v3(
         next_epoch: EpochId,
         protocol_version: ProtocolVersion,
@@ -325,7 +325,7 @@ impl EndOfEpochTransactionKind {
     }
 
     /// Creates a [`ChangeEpochV4`] end-of-epoch transaction kind.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new_change_epoch_v4(
         next_epoch: EpochId,
         protocol_version: ProtocolVersion,

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -228,7 +228,7 @@ impl TransactionKind {
 ///                               =/ %d02 change-epoch-v3  ; ChangeEpochV3
 ///                               =/ %d03 change-epoch-v4  ; ChangeEpochV4
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[non_exhaustive]
@@ -244,7 +244,130 @@ pub enum EndOfEpochTransactionKind {
 }
 
 impl EndOfEpochTransactionKind {
-    crate::def_is_as_into_opt!(ChangeEpoch, ChangeEpochV2);
+    crate::def_is_as_into_opt!(ChangeEpoch, ChangeEpochV2, ChangeEpochV3, ChangeEpochV4,);
+
+    /// Creates a [`ChangeEpoch`] end-of-epoch transaction kind.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_change_epoch(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<SystemPackage>,
+    ) -> Self {
+        Self::ChangeEpoch(ChangeEpoch {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+        })
+    }
+
+    /// Creates a [`ChangeEpochV2`] end-of-epoch transaction kind.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_change_epoch_v2(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<SystemPackage>,
+    ) -> Self {
+        Self::ChangeEpochV2(ChangeEpochV2 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+        })
+    }
+
+    /// Creates a [`ChangeEpochV3`] end-of-epoch transaction kind.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_change_epoch_v3(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<SystemPackage>,
+        eligible_active_validators: Vec<u64>,
+    ) -> Self {
+        Self::ChangeEpochV3(ChangeEpochV3 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+        })
+    }
+
+    /// Creates a [`ChangeEpochV4`] end-of-epoch transaction kind.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_change_epoch_v4(
+        next_epoch: EpochId,
+        protocol_version: ProtocolVersion,
+        storage_charge: u64,
+        computation_charge: u64,
+        computation_charge_burned: u64,
+        storage_rebate: u64,
+        non_refundable_storage_fee: u64,
+        epoch_start_timestamp_ms: u64,
+        system_packages: Vec<SystemPackage>,
+        eligible_active_validators: Vec<u64>,
+        scores: Vec<u64>,
+        adjust_rewards_by_score: bool,
+    ) -> Self {
+        Self::ChangeEpochV4(ChangeEpochV4 {
+            epoch: next_epoch,
+            protocol_version,
+            storage_charge,
+            computation_charge,
+            computation_charge_burned,
+            storage_rebate,
+            non_refundable_storage_fee,
+            epoch_start_timestamp_ms,
+            system_packages,
+            eligible_active_validators,
+            scores,
+            adjust_rewards_by_score,
+        })
+    }
+
+    /// Returns an iterator over the shared input objects required by this
+    /// transaction kind.
+    pub fn shared_input_objects(&self) -> impl Iterator<Item = SharedObjectReference> + '_ {
+        match self {
+            Self::ChangeEpoch(_)
+            | Self::ChangeEpochV2(_)
+            | Self::ChangeEpochV3(_)
+            | Self::ChangeEpochV4(_) => {
+                vec![SharedObjectReference::IOTA_SYSTEM_STATE_OBJ_MUTABLE].into_iter()
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -362,7 +485,7 @@ pub struct ConsensusCommitPrologueV1 {
 ///                u64  ; epoch start timestamp
 ///                (vector system-package)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -417,7 +540,7 @@ pub struct ChangeEpoch {
 ///                   u64  ; epoch start timestamp
 ///                   (vector system-package)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -458,7 +581,7 @@ pub struct ChangeEpochV2 {
     pub system_packages: Vec<SystemPackage>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -502,7 +625,7 @@ pub struct ChangeEpochV3 {
     pub eligible_active_validators: Vec<u64>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -551,7 +674,7 @@ pub struct ChangeEpochV4 {
     pub adjust_rewards_by_score: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -177,6 +177,7 @@ mod end_of_epoch {
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "EndOfEpochTransactionKind")]
     enum BinaryEndOfEpochTransactionKindRef<'a> {
         ChangeEpoch(&'a ChangeEpoch),
         ChangeEpochV2(&'a ChangeEpochV2),

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -185,6 +185,7 @@ mod end_of_epoch {
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "EndOfEpochTransactionKind")]
     enum BinaryEndOfEpochTransactionKind {
         ChangeEpoch(ChangeEpoch),
         ChangeEpochV2(ChangeEpochV2),


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/14-input`. Fills out the `EndOfEpochTransactionKind` API with constructors for every `ChangeEpoch` version, adds a `shared_input_objects()` accessor, and derives `Hash` on the change-epoch payloads.

- **Constructors for every variant** in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs): `EndOfEpochTransactionKind::new_change_epoch{,_v2,_v3,_v4}`, so callers can build any version without naming the inner `ChangeEpoch*` struct.
- **`def_is_as_into_opt!` extended** to all four variants (previously only `ChangeEpoch`/`ChangeEpochV2`), giving the standard `is_*` / `as_*_opt` / `into_*_opt` set across the enum.
- **`shared_input_objects()`** iterator on `EndOfEpochTransactionKind` yielding the shared inputs used by each variant — currently `SharedObjectReference::IOTA_SYSTEM_STATE_OBJ_MUTABLE` for all four `ChangeEpoch*` kinds.
- **`Hash`** derived on `EndOfEpochTransactionKind`, `ChangeEpoch`, `ChangeEpochV2`, `ChangeEpochV3`, `ChangeEpochV4`.
- **BCS schema name fix** in [crates/iota-sdk-types/src/transaction/serialization.rs](crates/iota-sdk-types/src/transaction/serialization.rs): the binary deserialization helper is `#[serde(rename = "EndOfEpochTransactionKind")]` so generated schemas keep the public type name.
