### PR TITLE
feat: `TransactionExpiration` improvements

### DIFF
--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -818,8 +818,8 @@ mod transaction_expiration {
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "TransactionExpiration")]
-    #[serde(rename_all = "lowercase")]
     enum ReadableTransactionExpiration {
+        None,
         /// Validators won't sign a transaction unless the expiration Epoch
         /// is greater than or equal to the current epoch
         Epoch(
@@ -828,6 +828,7 @@ mod transaction_expiration {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename = "TransactionExpiration")]
     pub enum BinaryTransactionExpiration {
         /// The transaction has no expiration
         None,
@@ -843,8 +844,8 @@ mod transaction_expiration {
         {
             if serializer.is_human_readable() {
                 match *self {
-                    Self::None => None,
-                    Self::Epoch(epoch) => Some(ReadableTransactionExpiration::Epoch(epoch)),
+                    Self::None => ReadableTransactionExpiration::None,
+                    Self::Epoch(epoch) => ReadableTransactionExpiration::Epoch(epoch),
                 }
                 .serialize(serializer)
             } else {
@@ -863,10 +864,10 @@ mod transaction_expiration {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                Option::<ReadableTransactionExpiration>::deserialize(deserializer).map(|readable| {
+                ReadableTransactionExpiration::deserialize(deserializer).map(|readable| {
                     match readable {
-                        None => Self::None,
-                        Some(ReadableTransactionExpiration::Epoch(epoch)) => Self::Epoch(epoch),
+                        ReadableTransactionExpiration::None => Self::None,
+                        ReadableTransactionExpiration::Epoch(epoch) => Self::Epoch(epoch),
                     }
                 })
             } else {


### PR DESCRIPTION
## Summary

Improvements to `TransactionExpiration`'s human-readable serialization to prepare for core replacement.

### Changes

- The binary serde shadow `BinaryTransactionExpiration` now carries `#[serde(rename = "TransactionExpiration")]` so the type name in non-BCS self-describing binary formats matches the public type name rather than the internal `Binary*` shadow name. Same pattern used in #1102 for the `ExecutionStatus`/`ExecutionError` shadows.
- Drop `#[serde(rename_all = "lowercase")]` on the readable shadow so variant names round-trip with their Rust casing (`Epoch` instead of `epoch`).
- Replace the `Option<ReadableTransactionExpiration>` readable representation (where `None` was mapped to `Self::None` and `Some(Epoch(_))` to `Self::Epoch(_)`) with an explicit two-variant enum that has its own `None` arm. This is what restores the `None` variant in the JSON output and is what the monorepo expects.

### Serialization change (breaking, human-readable only)

Human-readable JSON output for `TransactionExpiration` changes:

| Variant | Before | After |
| --- | --- | --- |
| `None` | `null` | `"None"` |
| `Epoch(123)` | `{"epoch": "123"}` | `{"Epoch": "123"}` |

Binary (BCS) serialization is unchanged.
