### PR TITLE
feat: `GasPayment` improvements

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -117,7 +117,7 @@ impl TransactionExpiration {
 ///               u64                       ; price
 ///               u64                       ; budget
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -818,8 +818,8 @@ mod transaction_expiration {
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "TransactionExpiration")]
-    #[serde(rename_all = "lowercase")]
     enum ReadableTransactionExpiration {
+        None,
         /// Validators won't sign a transaction unless the expiration Epoch
         /// is greater than or equal to the current epoch
         Epoch(
@@ -828,6 +828,7 @@ mod transaction_expiration {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename = "TransactionExpiration")]
     pub enum BinaryTransactionExpiration {
         /// The transaction has no expiration
         None,
@@ -843,8 +844,8 @@ mod transaction_expiration {
         {
             if serializer.is_human_readable() {
                 match *self {
-                    Self::None => None,
-                    Self::Epoch(epoch) => Some(ReadableTransactionExpiration::Epoch(epoch)),
+                    Self::None => ReadableTransactionExpiration::None,
+                    Self::Epoch(epoch) => ReadableTransactionExpiration::Epoch(epoch),
                 }
                 .serialize(serializer)
             } else {
@@ -863,10 +864,10 @@ mod transaction_expiration {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                Option::<ReadableTransactionExpiration>::deserialize(deserializer).map(|readable| {
+                ReadableTransactionExpiration::deserialize(deserializer).map(|readable| {
                     match readable {
-                        None => Self::None,
-                        Some(ReadableTransactionExpiration::Epoch(epoch)) => Self::Epoch(epoch),
+                        ReadableTransactionExpiration::None => Self::None,
+                        ReadableTransactionExpiration::Epoch(epoch) => Self::Epoch(epoch),
                     }
                 })
             } else {


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/16-transaction-expiration`. Derives `Hash` on `GasPayment` to bring it in line with the other transaction types and let it participate in hashed collections.

- **`Hash`** derived on `GasPayment` in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs).
