### PR TITLE
chore: remove `AUTHENTICATOR_STATE_MUTABLE` constant from `Input`

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -799,13 +799,6 @@ impl Input {
         mutable: true,
     });
 
-    /// Shared `Input` for the authenticator state object.
-    pub const AUTHENTICATOR_STATE_MUTABLE: Self = Self::Shared(SharedObjectReference {
-        object_id: ObjectId::AUTHENTICATOR_STATE,
-        initial_shared_version: Version::INITIAL_SHARED_VERSION,
-        mutable: true,
-    });
-
     crate::def_is_as_into_opt!(
         Pure(Vec<u8>),
         ImmutableOrOwned(ObjectReference),


### PR DESCRIPTION
`AUTHENTICATOR_STATE_MUTABLE` incorrectly hardcoded `Version::INITIAL_SHARED_VERSION` as the authenticator state object's initial shared version, but this version is not fixed — it must be provided at runtime.

## Changes

- **`crates/iota-sdk-types/src/transaction/mod.rs`**: Removed the `AUTHENTICATOR_STATE_MUTABLE` constant from the `Input` impl block.

The correct usage, as already demonstrated by `AuthenticatorStateExpire`, is to construct the `SharedObjectReference` with the runtime-supplied `authenticator_obj_initial_shared_version` field rather than relying on a hardcoded constant:

```rust
// Correct — uses runtime version
Self::AuthenticatorStateExpire(expire) => Either::Left(
    vec![SharedObjectReference {
        object_id: ObjectId::AUTHENTICATOR_STATE,
        initial_shared_version: expire.authenticator_obj_initial_shared_version,
        mutable: true,
    }]
    .into_iter(),
),

// Removed — initial shared version is not fixed
pub const AUTHENTICATOR_STATE_MUTABLE: Self = Self::Shared(SharedObjectReference {
    object_id: ObjectId::AUTHENTICATOR_STATE,
    initial_shared_version: Version::INITIAL_SHARED_VERSION, // incorrect assumption
    mutable: true,
});
```
