### PR TITLE
feat(types): Skip validation of identifiers in `MoveCall` for BCS

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -1228,6 +1228,10 @@ pub struct MoveCall {
     /// The package containing the module and function.
     pub package: ObjectId,
     /// The specific module in the package containing the function.
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "serialization::deserialize_ident_unchecked")
+    )]
     pub module: Identifier,
     /// The function to be called.
     pub function: Identifier,

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
 use super::Argument;
-use crate::{ObjectId, ObjectReference};
+use crate::{Identifier, ObjectId, ObjectReference};
 
 mod transaction_kind {
     use super::*;
@@ -876,6 +876,23 @@ mod transaction_expiration {
                 })
             }
         }
+    }
+}
+
+/// Deserialize an `Identifier` without validating that it is a valid Move
+/// identifier. This is used for deserializing the module in `MoveCall`
+/// commands, where BCS bytes could contain invalid identifiers but we still
+/// want to be able to deserialize them and let the move VM handle the
+/// validation.
+pub(super) fn deserialize_ident_unchecked<'de, D>(d: D) -> Result<Identifier, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    if d.is_human_readable() {
+        serde::Deserialize::deserialize(d)
+    } else {
+        let s: String = serde::Deserialize::deserialize(d)?;
+        Ok(Identifier::new_unchecked(s))
     }
 }
 


### PR DESCRIPTION
## Description

Skips validation of Identifiers in BCS bytes for MoveCall commands. This is necessary because these fields were not previously validated and is invalid in some failed transactions on the network.