### PR TITLE
feat: `ConsensusCommitPrologueV1` improvements

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -426,7 +426,6 @@ pub struct CancelledTransaction {
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct VersionAssignment {
     pub object_id: ObjectId,
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub version: Version,
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -370,7 +370,7 @@ impl EndOfEpochTransactionKind {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[non_exhaustive]
@@ -402,8 +402,7 @@ impl ConsensusDeterminedVersionAssignments {
 /// ```text
 /// cancelled-transaction = digest (vector version-assignment)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct CancelledTransaction {
@@ -416,19 +415,26 @@ pub struct CancelledTransaction {
 ///
 /// # BCS
 ///
-/// The BCS serialized form for this type is defined by the following ABNF:
+/// The BCS serialized form for this type is defined by the
+/// following ABNF:
 ///
 /// ```text
 /// version-assignment = object-id u64
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct VersionAssignment {
     pub object_id: ObjectId,
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub version: Version,
+}
+
+impl VersionAssignment {
+    /// Creates a [`VersionAssignment`].
+    pub fn new(object_id: ObjectId, version: Version) -> Self {
+        Self { object_id, version }
+    }
 }
 
 /// V1 of the consensus commit prologue system transaction
@@ -441,7 +447,7 @@ pub struct VersionAssignment {
 /// consensus-commit-prologue-v1 = u64 u64 (option u64) u64 digest
 ///                                consensus-determined-version-assignments
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -117,7 +117,7 @@ impl TransactionExpiration {
 ///               u64                       ; price
 ///               u64                       ; budget
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -261,36 +261,34 @@ mod end_of_epoch {
 
 mod version_assignments {
     use super::*;
-    use crate::transaction::{CancelledTransaction, ConsensusDeterminedVersionAssignments};
+    use crate::transaction::{
+        CancelledTransaction, ConsensusDeterminedVersionAssignments, VersionAssignment,
+    };
 
     #[derive(serde::Serialize)]
-    #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions {
-            cancelled_transactions: &'a Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
+    /// Uses an enum to allow for future expansion of the
+    /// ConsensusDeterminedVersionAssignments.
     #[derive(serde::Deserialize)]
-    #[serde(tag = "kind", rename_all = "snake_case")]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum ReadableConsensusDeterminedVersionAssignments {
-        CancelledTransactions {
-            cancelled_transactions: Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(Vec<CancelledTransaction>),
     }
 
     #[derive(serde::Serialize)]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions {
-            cancelled_transactions: &'a Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
     #[derive(serde::Deserialize)]
+    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
     enum BinaryConsensusDeterminedVersionAssignments {
-        CancelledTransactions {
-            cancelled_transactions: Vec<CancelledTransaction>,
-        },
+        CancelledTransactions(Vec<CancelledTransaction>),
     }
 
     impl Serialize for ConsensusDeterminedVersionAssignments {
@@ -302,18 +300,18 @@ mod version_assignments {
                 let readable = match self {
                     Self::CancelledTransactions {
                         cancelled_transactions,
-                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions {
+                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
                         cancelled_transactions,
-                    },
+                    ),
                 };
                 readable.serialize(serializer)
             } else {
                 let binary = match self {
                     Self::CancelledTransactions {
                         cancelled_transactions,
-                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions {
+                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
                         cancelled_transactions,
-                    },
+                    ),
                 };
                 binary.serialize(serializer)
             }
@@ -328,9 +326,9 @@ mod version_assignments {
             if deserializer.is_human_readable() {
                 ReadableConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
                     |readable| match readable {
-                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions {
+                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions(
                             cancelled_transactions,
-                        } => Self::CancelledTransactions {
+                        ) => Self::CancelledTransactions {
                             cancelled_transactions,
                         },
                     },
@@ -338,13 +336,108 @@ mod version_assignments {
             } else {
                 BinaryConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
                     |binary| match binary {
-                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions {
+                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions(
                             cancelled_transactions,
-                        } => Self::CancelledTransactions {
+                        ) => Self::CancelledTransactions {
                             cancelled_transactions,
                         },
                     },
                 )
+            }
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    #[serde(rename = "VersionAssignment")]
+    struct BinaryVersionAssignmentRef<'a>(&'a ObjectId, &'a crate::Version);
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename = "VersionAssignment")]
+    struct BinaryVersionAssignment(ObjectId, crate::Version);
+
+    impl Serialize for VersionAssignment {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if serializer.is_human_readable() {
+                use serde::ser::SerializeTuple;
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(&self.object_id)?;
+                tuple.serialize_element(&self.version)?;
+                tuple.end()
+            } else {
+                let binary = BinaryVersionAssignmentRef(&self.object_id, &self.version);
+                binary.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for VersionAssignment {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            if deserializer.is_human_readable() {
+                let (object_id, version): (ObjectId, u64) = Deserialize::deserialize(deserializer)?;
+                Ok(VersionAssignment {
+                    object_id,
+                    version: version.into(),
+                })
+            } else {
+                BinaryVersionAssignment::deserialize(deserializer).map(|b| VersionAssignment {
+                    object_id: b.0,
+                    version: b.1,
+                })
+            }
+        }
+    }
+
+    #[derive(serde::Serialize)]
+    #[serde(rename = "CancelledTransaction")]
+    struct BinaryCancelledTransactionRef<'a>(&'a crate::Digest, &'a Vec<VersionAssignment>);
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename = "CancelledTransaction")]
+    struct BinaryCancelledTransaction(crate::Digest, Vec<VersionAssignment>);
+
+    impl Serialize for CancelledTransaction {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            if serializer.is_human_readable() {
+                use serde::ser::SerializeTuple;
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(&self.digest)?;
+                tuple.serialize_element(&self.version_assignments)?;
+                tuple.end()
+            } else {
+                let binary = BinaryCancelledTransactionRef(&self.digest, &self.version_assignments);
+                binary.serialize(serializer)
+            }
+        }
+    }
+
+    impl<'de> Deserialize<'de> for CancelledTransaction {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            if deserializer.is_human_readable() {
+                let (digest, version_assignments): (crate::Digest, Vec<VersionAssignment>) =
+                    Deserialize::deserialize(deserializer)?;
+                Ok(CancelledTransaction {
+                    digest,
+                    version_assignments,
+                })
+            } else {
+                BinaryCancelledTransaction::deserialize(deserializer).map(|b| {
+                    CancelledTransaction {
+                        digest: b.0,
+                        version_assignments: b.1,
+                    }
+                })
             }
         }
     }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -818,8 +818,8 @@ mod transaction_expiration {
 
     #[derive(serde::Serialize, serde::Deserialize)]
     #[serde(rename = "TransactionExpiration")]
-    #[serde(rename_all = "lowercase")]
     enum ReadableTransactionExpiration {
+        None,
         /// Validators won't sign a transaction unless the expiration Epoch
         /// is greater than or equal to the current epoch
         Epoch(
@@ -828,6 +828,7 @@ mod transaction_expiration {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename = "TransactionExpiration")]
     pub enum BinaryTransactionExpiration {
         /// The transaction has no expiration
         None,
@@ -843,8 +844,8 @@ mod transaction_expiration {
         {
             if serializer.is_human_readable() {
                 match *self {
-                    Self::None => None,
-                    Self::Epoch(epoch) => Some(ReadableTransactionExpiration::Epoch(epoch)),
+                    Self::None => ReadableTransactionExpiration::None,
+                    Self::Epoch(epoch) => ReadableTransactionExpiration::Epoch(epoch),
                 }
                 .serialize(serializer)
             } else {
@@ -863,10 +864,10 @@ mod transaction_expiration {
             D: Deserializer<'de>,
         {
             if deserializer.is_human_readable() {
-                Option::<ReadableTransactionExpiration>::deserialize(deserializer).map(|readable| {
+                ReadableTransactionExpiration::deserialize(deserializer).map(|readable| {
                     match readable {
-                        None => Self::None,
-                        Some(ReadableTransactionExpiration::Epoch(epoch)) => Self::Epoch(epoch),
+                        ReadableTransactionExpiration::None => Self::None,
+                        ReadableTransactionExpiration::Epoch(epoch) => Self::Epoch(epoch),
                     }
                 })
             } else {


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/17-GasPayment`. Updates `ConsensusCommitPrologueV1` and its related types to match upstream's serialization layout, derives `Hash` to bring them in line with the other transaction types, and adds a small constructor.

- **`Hash`** derived on `ConsensusCommitPrologueV1`, `ConsensusDeterminedVersionAssignments`, `CancelledTransaction`, and `VersionAssignment` in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs).
- **`VersionAssignment::new`** constructor added in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs).
- **Custom `Serialize`/`Deserialize`** impls for `VersionAssignment` and `CancelledTransaction` (replacing the previously derived ones), and `ConsensusDeterminedVersionAssignments` switched from struct-style to tuple-style enum variants for both human-readable and binary representations, in [crates/iota-sdk-types/src/transaction/serialization.rs](crates/iota-sdk-types/src/transaction/serialization.rs).
