### PR TITLE
feat(iota-sdk-types)!: add MoveObjectType

### DIFF
--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -561,8 +561,9 @@ pub struct MoveStruct {
 
 impl From<iota_sdk::types::MoveStruct> for MoveStruct {
     fn from(value: iota_sdk::types::MoveStruct) -> Self {
+        let struct_tag: iota_sdk::types::StructTag = value.type_.into();
         Self {
-            struct_type: Arc::new(value.type_.into()),
+            struct_type: Arc::new(struct_tag.into()),
             version: Arc::new(value.version.into()),
             contents: value.contents,
         }
@@ -572,7 +573,7 @@ impl From<iota_sdk::types::MoveStruct> for MoveStruct {
 impl From<MoveStruct> for iota_sdk::types::MoveStruct {
     fn from(value: MoveStruct) -> Self {
         Self {
-            type_: value.struct_type.0.clone(),
+            type_: value.struct_type.0.clone().into(),
             version: **value.version,
             contents: value.contents,
         }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -159,7 +159,8 @@ pub use gas::GasCostSummary;
 pub use move_core::{Identifier, StructTag, TypeParseError, TypeTag};
 pub use move_package::{MovePackage, MovePackageData, TypeOrigin, UpgradeInfo, UpgradePolicy};
 pub use object::{
-    GenesisObject, MoveStruct, Object, ObjectData, ObjectReference, ObjectType, Owner,
+    GenesisObject, MoveObjectType, MoveStruct, Object, ObjectData, ObjectReference, ObjectType,
+    Owner,
 };
 pub use object_id::ObjectId;
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -216,6 +216,27 @@ impl StructTag {
         (self.address, self.module, self.name, self.type_params)
     }
 
+    /// Checks if this is a timelocked coin balance `TimeLock<Balance<T>>`
+    pub fn is_timelocked_balance(&self) -> bool {
+        self.is_time_lock()
+            && matches!(
+                self.type_params.as_slice(),
+                [TypeTag::Struct(inner)] if inner.is_balance()
+            )
+    }
+
+    /// Creates a new timelocked IOTA balance struct tag
+    /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
+    pub fn new_timelocked_gas_balance() -> Self {
+        Self::new_time_lock(Self::new_balance(Self::new_gas()))
+    }
+
+    /// Checks if this is a timelocked IOTA balance type
+    /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
+    pub fn is_timelocked_gas_balance(&self) -> bool {
+        *self == Self::new_timelocked_gas_balance()
+    }
+
     /// Returns the string representation of this struct tag using the
     /// canonical display, with or without a `0x` prefix.
     pub fn to_canonical_string(&self, with_prefix: bool) -> String {
@@ -396,6 +417,7 @@ impl StructTag {
     );
     add_struct_tag_ctor!(STD, string::String);
     add_struct_tag_ctor!(@with_module STD, ascii::String);
+    add_struct_tag_ctor!(FRAMEWORK, coin::RegulatedCoinMetadata, coin::DenyCapV1);
     add_struct_tag_ctor_from_struct_tag!(
         FRAMEWORK,
         coin::CoinMetadata,

--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -225,6 +225,16 @@ impl StructTag {
             )
     }
 
+    /// Checks if this is an IOTA balance type
+    /// (`0x2::balance::Balance<0x2::iota::IOTA>`)
+    pub fn is_gas_balance(&self) -> bool {
+        self.is_balance()
+            && matches!(
+                self.type_params.as_slice(),
+                [TypeTag::Struct(inner)] if inner.is_gas()
+            )
+    }
+
     /// Creates a new timelocked IOTA balance struct tag
     /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
     pub fn new_timelocked_gas_balance() -> Self {
@@ -234,7 +244,11 @@ impl StructTag {
     /// Checks if this is a timelocked IOTA balance type
     /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
     pub fn is_timelocked_gas_balance(&self) -> bool {
-        *self == Self::new_timelocked_gas_balance()
+        self.is_time_lock()
+            && matches!(
+                self.type_params.as_slice(),
+                [TypeTag::Struct(inner)] if inner.is_gas_balance()
+            )
     }
 
     /// Returns the string representation of this struct tag using the

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -176,7 +176,8 @@ impl ObjectData {
 /// A [`StructTag`] with optimized BCS serialization for object types.
 ///
 /// GasCoin, StakedIota, and Coin variants use compact enum encoding
-/// instead of the full StructTag representation.
+/// instead of the full StructTag representation. The Other variant
+/// carries the full StructTag inline.
 ///
 /// # BCS
 ///

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -173,6 +173,74 @@ impl ObjectData {
     crate::def_is_as_into_opt!(Struct(MoveStruct), Package(MovePackage));
 }
 
+/// A [`StructTag`] with optimized BCS serialization for object types.
+///
+/// GasCoin, StakedIota, and Coin variants use compact enum encoding
+/// instead of the full StructTag representation.
+///
+/// # BCS
+///
+/// ```text
+/// compressed-struct-tag = other-struct-type / gas-coin-type / staked-iota-type / coin-type
+/// other-struct-type     = %x00 struct-tag
+/// gas-coin-type         = %x01
+/// staked-iota-type      = %x02
+/// coin-type             = %x03 type-tag
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
+pub struct MoveObjectType(StructTag);
+
+impl MoveObjectType {
+    pub fn new(tag: StructTag) -> Self {
+        Self(tag)
+    }
+
+    pub fn into_inner(self) -> StructTag {
+        self.0
+    }
+}
+
+impl std::ops::Deref for MoveObjectType {
+    type Target = StructTag;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<StructTag> for MoveObjectType {
+    fn from(tag: StructTag) -> Self {
+        Self(tag)
+    }
+}
+
+impl From<MoveObjectType> for StructTag {
+    fn from(obj_type: MoveObjectType) -> Self {
+        obj_type.0
+    }
+}
+
+impl PartialEq<StructTag> for MoveObjectType {
+    fn eq(&self, other: &StructTag) -> bool {
+        &self.0 == other
+    }
+}
+
+impl std::fmt::Display for MoveObjectType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for MoveObjectType {
+    type Err = crate::TypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        StructTag::from_str(s).map(Self)
+    }
+}
+
 /// A move struct
 ///
 /// # BCS
@@ -196,13 +264,9 @@ impl ObjectData {
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MoveStruct {
-    /// The type of this object
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "::serde_with::As::<serialization::BinaryMoveStructType>")
-    )]
+    /// The type of this object. Uses optimized BCS serialization.
     #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "compressed-struct-tag"))]
-    pub type_: StructTag,
+    pub type_: MoveObjectType,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
@@ -311,7 +375,7 @@ impl Object {
     /// Return this object's type
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct(struct_.type_.clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.type_).clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -424,7 +488,7 @@ impl GenesisObject {
 
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct(struct_.type_.clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.type_).clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -511,12 +575,13 @@ mod serialization {
     /// specialized variants, e.g. `Other(GasCoin::type_())` instead of
     /// `GasCoin`
     #[derive(serde::Deserialize)]
+    #[serde(rename = "MoveObjectType")]
     #[cfg_attr(
         feature = "bcs-schema",
         derive(iota_bcs_schema::BcsSchema),
         bcs_schema(name = "compressed-struct-tag")
     )]
-    enum MoveStructType {
+    enum MoveObjectTypeWrapper {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(StructTag),
         /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
@@ -532,9 +597,10 @@ mod serialization {
         // to make sure the new type and Other(_) are interpreted consistently.
     }
 
-    /// See `MoveStructType`
+    /// See `MoveObjectType`
     #[derive(serde::Serialize)]
-    enum MoveStructTypeRef<'a> {
+    #[serde(rename = "MoveObjectType")]
+    enum MoveObjectTypeRef<'a> {
         /// A type that is not `0x2::coin::Coin<T>`
         Other(&'a StructTag),
         /// An IOTA coin (i.e., `0x2::coin::Coin<0x2::iota::IOTA>`)
@@ -550,18 +616,18 @@ mod serialization {
         // to make sure the new type and Other(_) are interpreted consistently.
     }
 
-    impl MoveStructType {
+    impl MoveObjectTypeWrapper {
         fn into_struct_tag(self) -> StructTag {
             match self {
-                MoveStructType::Other(tag) => tag,
-                MoveStructType::GasCoin => StructTag::new_gas_coin(),
-                MoveStructType::StakedIota => StructTag::new_staked_iota(),
-                MoveStructType::Coin(type_tag) => StructTag::new_coin(type_tag),
+                MoveObjectTypeWrapper::Other(tag) => tag,
+                MoveObjectTypeWrapper::GasCoin => StructTag::new_gas_coin(),
+                MoveObjectTypeWrapper::StakedIota => StructTag::new_staked_iota(),
+                MoveObjectTypeWrapper::Coin(type_tag) => StructTag::new_coin(type_tag),
             }
         }
     }
 
-    impl<'a> MoveStructTypeRef<'a> {
+    impl<'a> MoveObjectTypeRef<'a> {
         fn from_struct_tag(s: &'a StructTag) -> Self {
             if let Some(coin_type) = s.coin_type_opt() {
                 if let TypeTag::Struct(s_inner) = coin_type
@@ -586,25 +652,29 @@ mod serialization {
         }
     }
 
-    pub(super) struct BinaryMoveStructType;
-
-    impl SerializeAs<StructTag> for BinaryMoveStructType {
-        fn serialize_as<S>(source: &StructTag, serializer: S) -> Result<S::Ok, S::Error>
+    impl Serialize for MoveObjectType {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
-            let move_object_type = MoveStructTypeRef::from_struct_tag(source);
-            move_object_type.serialize(serializer)
+            if serializer.is_human_readable() {
+                self.0.serialize(serializer)
+            } else {
+                MoveObjectTypeRef::from_struct_tag(&self.0).serialize(serializer)
+            }
         }
     }
 
-    impl<'de> DeserializeAs<'de, StructTag> for BinaryMoveStructType {
-        fn deserialize_as<D>(deserializer: D) -> Result<StructTag, D::Error>
+    impl<'de> Deserialize<'de> for MoveObjectType {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
         {
-            let struct_type = MoveStructType::deserialize(deserializer)?;
-            Ok(struct_type.into_struct_tag())
+            if deserializer.is_human_readable() {
+                StructTag::deserialize(deserializer).map(Self)
+            } else {
+                MoveObjectTypeWrapper::deserialize(deserializer).map(|t| Self(t.into_struct_tag()))
+            }
         }
     }
 
@@ -764,7 +834,7 @@ mod serialization {
                         }
 
                         ObjectData::Struct(MoveStruct {
-                            type_,
+                            type_: type_.into(),
                             version,
                             contents,
                         })
@@ -907,7 +977,7 @@ mod serialization {
                         }
 
                         ObjectData::Struct(MoveStruct {
-                            type_,
+                            type_: type_.into(),
                             version,
                             contents,
                         })
@@ -966,12 +1036,12 @@ mod serialization {
         fn obj() {
             let o = Object {
                 data: ObjectData::Struct(MoveStruct {
-                    type_: StructTag::new(
+                    type_: MoveObjectType::new(StructTag::new(
                         Address::FRAMEWORK,
                         Identifier::new("bar").unwrap(),
                         Identifier::new("foo").unwrap(),
                         Vec::new(),
-                    ),
+                    )),
                     version: Version::from_u64(12),
                     contents: ObjectId::ZERO.into(),
                 }),


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/18-ConsensusCommitPrologueV1`. Introduces a `MoveObjectType` newtype that owns the compact BCS encoding for object types, and adds a few `StructTag` constructors/predicates for timelocked balances and coin-metadata types.

- **New `MoveObjectType` newtype** in [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs): wraps `StructTag` and carries the compact `Other / GasCoin / StakedIota / Coin` BCS encoding directly on the type. Provides `new`, `into_inner`, `Deref<Target = StructTag>`, `From`/`Into` between `StructTag` and `MoveObjectType`, `PartialEq<StructTag>`, `Display`, and `FromStr`. Re-exported from the crate root in [crates/iota-sdk-types/src/lib.rs](crates/iota-sdk-types/src/lib.rs).
- **`MoveStruct::type_` is now `MoveObjectType`** (was `StructTag` plus a `serde(with = BinaryMoveStructType)` adapter). The compact BCS form is intrinsic to the type, and serialization now branches on `is_human_readable()`: BCS uses the wrapped enum (unchanged), JSON serializes the underlying `StructTag` directly via its `Display`/`FromStr`. The `BinaryMoveStructType` `serde_with` adapter is removed.
- **JSON form simplified**: previously the `BinaryMoveStructType` adapter applied to both BCS and JSON, so JSON emitted the externally-tagged wrapper — `"GasCoin"`, `"StakedIota"`, `{"Coin": "<type-tag>"}`, or `{"Other": <struct-tag>}`. JSON now emits the canonical `StructTag` string in every case (e.g. `"0x2::coin::Coin<0x2::iota::IOTA>"` instead of `"GasCoin"`). BCS is unchanged. The JSON form is not used on any public API surface, so this is internal-only.
- **Internal serde rename** in [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs): the binary helper enums (`MoveStructType` → `MoveObjectTypeWrapper`, `MoveStructTypeRef` → `MoveObjectTypeRef`) carry `#[serde(rename = "MoveObjectType")]` so generated schemas keep the public type name.
- **`StructTag` additions** in [crates/iota-sdk-types/src/move_core/struct_tag.rs](crates/iota-sdk-types/src/move_core/struct_tag.rs): `new_timelocked_gas_balance`, `is_timelocked_gas_balance`, `is_timelocked_balance`, plus `RegulatedCoinMetadata` and `DenyCapV1` constructors.

BCS round-trips identically. Breaking at the Rust API level for any caller that constructs `MoveStruct { type_: <StructTag>, .. }` or pattern-matches the field — wrap with `.into()` / `MoveObjectType::new(..)`.
