### PR TITLE
feat: MoveStruct improvements

### DIFF
--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -561,7 +561,7 @@ pub struct MoveStruct {
 
 impl From<iota_sdk::types::MoveStruct> for MoveStruct {
     fn from(value: iota_sdk::types::MoveStruct) -> Self {
-        let struct_tag: iota_sdk::types::StructTag = value.type_.into();
+        let struct_tag: iota_sdk::types::StructTag = value.object_type.into();
         Self {
             struct_type: Arc::new(struct_tag.into()),
             version: Arc::new(value.version.into()),
@@ -573,7 +573,7 @@ impl From<iota_sdk::types::MoveStruct> for MoveStruct {
 impl From<MoveStruct> for iota_sdk::types::MoveStruct {
     fn from(value: MoveStruct) -> Self {
         Self {
-            type_: value.struct_type.0.clone().into(),
+            object_type: value.struct_type.0.clone().into(),
             version: **value.version,
             contents: value.contents,
         }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -273,7 +273,7 @@ move-package = object-id                          ; id
                (size *type-origin)                ; type-origin-table
                (size *(object-id upgrade-info))   ; linkage-table
 
-move-struct = compressed-struct-tag   ; type-
+move-struct = compressed-struct-tag   ; object-type
               version                 ; version
               bytes                   ; contents
 

--- a/crates/iota-sdk-types/src/framework.rs
+++ b/crates/iota-sdk-types/src/framework.rs
@@ -30,7 +30,7 @@ impl Coin {
         match &object.data {
             super::ObjectData::Struct(move_struct) => {
                 let coin_type = move_struct
-                    .type_
+                    .object_type
                     .coin_type_opt()
                     .ok_or(CoinFromObjectError::NotACoin)?;
 

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "serde")]
 use std::collections::BTreeMap;
 
-use super::{Address, Digest, MovePackage, ObjectId, StructTag, Version};
+use super::{Address, Digest, MovePackage, ObjectId, StructTag, TypeTag, Version};
 #[cfg(feature = "serde")]
 use super::{Identifier, TypeOrigin, UpgradeInfo};
 
@@ -262,13 +262,14 @@ impl std::str::FromStr for MoveObjectType {
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 // TODO hand-roll a Deserialize impl to enforce that an objectid is present
+// https://github.com/iotaledger/iota-rust-sdk/issues/1043
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MoveStruct {
     /// The type of this object. Uses optimized BCS serialization.
     #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "compressed-struct-tag"))]
-    pub type_: MoveObjectType,
+    pub object_type: MoveObjectType,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
@@ -281,6 +282,67 @@ pub struct MoveStruct {
     )]
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(32..=1024).lift()))]
     pub contents: Vec<u8>,
+}
+
+impl MoveStruct {
+    /// Returns the type of this Move object.
+    pub fn object_type(&self) -> &MoveObjectType {
+        &self.object_type
+    }
+
+    /// Returns the object type as a [`StructTag`] reference.
+    pub fn struct_tag(&self) -> &StructTag {
+        &self.object_type
+    }
+
+    /// Returns `true` if the object's type matches the given [`StructTag`].
+    pub fn is_struct_tag(&self, s: &StructTag) -> bool {
+        &self.object_type == s
+    }
+
+    /// Returns the object's ID, extracted from the BCS-encoded contents.
+    pub fn id(&self) -> ObjectId {
+        Self::id_opt(&self.contents).unwrap()
+    }
+
+    /// Tries to extract an [`ObjectId`] from the leading bytes of `contents`.
+    pub fn id_opt(contents: &[u8]) -> Option<ObjectId> {
+        if contents.len() < ObjectId::LENGTH {
+            return None;
+        }
+        ObjectId::from_bytes(&contents[0..ObjectId::LENGTH]).ok()
+    }
+
+    /// Returns the version (lamport timestamp) of this object.
+    pub fn version(&self) -> Version {
+        self.version
+    }
+
+    /// Returns the raw BCS-encoded contents of this object.
+    pub fn contents(&self) -> &[u8] {
+        &self.contents
+    }
+
+    /// Consumes the object and returns the raw BCS-encoded contents.
+    pub fn into_contents(self) -> Vec<u8> {
+        self.contents
+    }
+
+    /// Returns the object type as a [`TypeTag`].
+    pub fn type_tag(&self) -> TypeTag {
+        TypeTag::Struct(Box::new(self.struct_tag().clone()))
+    }
+
+    /// Consumes the object and returns its type, version, and raw contents.
+    pub fn into_parts(self) -> (MoveObjectType, Version, Vec<u8>) {
+        (self.object_type, self.version, self.contents)
+    }
+
+    /// Deserializes the BCS-encoded contents into a Rust type.
+    #[cfg(feature = "serde")]
+    pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Option<T> {
+        bcs::from_bytes(self.contents()).ok()
+    }
 }
 
 /// Type of an IOTA object
@@ -377,7 +439,7 @@ impl Object {
     /// Return this object's type
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.type_).clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.object_type).clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -490,7 +552,7 @@ impl GenesisObject {
 
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.type_).clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.object_type).clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -827,7 +889,7 @@ mod serialization {
                         linkage_table,
                     }),
                     (
-                        ObjectType::Struct(type_),
+                        ObjectType::Struct(tag),
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
                         // check id matches in contents
@@ -836,7 +898,7 @@ mod serialization {
                         }
 
                         ObjectData::Struct(MoveStruct {
-                            type_: type_.into(),
+                            object_type: tag.into(),
                             version,
                             contents,
                         })
@@ -970,7 +1032,7 @@ mod serialization {
                         linkage_table,
                     }),
                     (
-                        ObjectType::Struct(type_),
+                        ObjectType::Struct(tag),
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
                         // check id matches in contents
@@ -979,7 +1041,7 @@ mod serialization {
                         }
 
                         ObjectData::Struct(MoveStruct {
-                            type_: type_.into(),
+                            object_type: tag.into(),
                             version,
                             contents,
                         })
@@ -1038,7 +1100,7 @@ mod serialization {
         fn obj() {
             let o = Object {
                 data: ObjectData::Struct(MoveStruct {
-                    type_: MoveObjectType::new(StructTag::new(
+                    object_type: MoveObjectType::new(StructTag::new(
                         Address::FRAMEWORK,
                         Identifier::new("bar").unwrap(),
                         Identifier::new("foo").unwrap(),

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -93,12 +93,13 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
                 let object = client.object(object_id, None).await?;
 
                 if let Some(object) = object {
-                    if object.as_struct().type_.name()
+                    if object.as_struct().object_type.name()
                         == &Identifier::from_static("PackageMetadataV1")
                     {
                         package_metadata_id.replace(object_id);
                     }
-                    if object.as_struct().type_.name() == &Identifier::from_static("Account") {
+                    if object.as_struct().object_type.name() == &Identifier::from_static("Account")
+                    {
                         account_id.replace(object_id);
                     }
                 }

--- a/crates/iota-sdk/examples/package_inspect.rs
+++ b/crates/iota-sdk/examples/package_inspect.rs
@@ -12,9 +12,7 @@ use iota_sdk::{
         pagination::{Direction, PaginationFilter},
         query_types::{MoveAbility, ObjectFilter, TransactionsFilter},
     },
-    types::{
-        Address, Input, MoveCall, MovePackage, ObjectId, StructTag, Transaction, UpgradePolicy,
-    },
+    types::{Address, Input, MoveCall, MovePackage, ObjectId, Transaction, UpgradePolicy},
 };
 
 #[tokio::main]
@@ -333,7 +331,7 @@ async fn resolve_upgrade_cap_id(client: &Client, package_id: ObjectId) -> Result
 
             if object
                 .as_struct_opt()
-                .is_some_and(|move_struct| move_struct.object_type == StructTag::new_upgrade_cap())
+                .is_some_and(|move_struct| move_struct.object_type.is_upgrade_cap())
             {
                 return Ok(Some(changed_object.object_id));
             }

--- a/crates/iota-sdk/examples/package_inspect.rs
+++ b/crates/iota-sdk/examples/package_inspect.rs
@@ -333,7 +333,7 @@ async fn resolve_upgrade_cap_id(client: &Client, package_id: ObjectId) -> Result
 
             if object
                 .as_struct_opt()
-                .is_some_and(|move_struct| move_struct.type_ == StructTag::new_upgrade_cap())
+                .is_some_and(|move_struct| move_struct.object_type == StructTag::new_upgrade_cap())
             {
                 return Ok(Some(changed_object.object_id));
             }

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -28,7 +28,7 @@ use iota_sdk::{
     crypto::{IotaSigner, ed25519::Ed25519PrivateKey},
     graphql_client::{Client, WaitForTx, faucet::FaucetClient},
     transaction_builder::{TransactionBuilder, assigned},
-    types::{Address, MovePackageData, ObjectId, ObjectOut, StructTag, UpgradePolicy},
+    types::{Address, MovePackageData, ObjectId, ObjectOut, UpgradePolicy},
 };
 use rand::rngs::OsRng;
 
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
                 let Some(obj) = client.object(object_id, None).await? else {
                     bail!("Missing object {object_id}");
                 };
-                if obj.as_struct().object_type == StructTag::new_upgrade_cap() {
+                if obj.as_struct().object_type.is_upgrade_cap() {
                     println!("UpgradeCap: {object_id}");
                     println!("UpgradeCapOwner: {}", owner.into_address());
                     upgrade_cap.replace(object_id);

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
                 let Some(obj) = client.object(object_id, None).await? else {
                     bail!("Missing object {object_id}");
                 };
-                if obj.as_struct().type_ == StructTag::new_upgrade_cap() {
+                if obj.as_struct().object_type == StructTag::new_upgrade_cap() {
                     println!("UpgradeCap: {object_id}");
                     println!("UpgradeCapOwner: {}", owner.into_address());
                     upgrade_cap.replace(object_id);


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/21-Command`. Renames `MoveStruct::type_` to `object_type` to drop the trailing-underscore keyword workaround, and rounds out the `MoveStruct` API with the accessors and helpers the monorepo expects (id extraction, type/version/contents getters, BCS round-tripping).

## Changes

### `MoveStruct`

- **Field rename** in [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs): `MoveStruct.type_` → `MoveStruct.object_type`. The new name matches the upstream type and removes the `type_` reserved-word workaround. All in-tree callers updated.
- **New methods** on `MoveStruct`:
  - `object_type()` / `struct_tag()` / `type_tag()` — borrowing accessors that return `&MoveObjectType`, `&StructTag`, and an owned `TypeTag` respectively.
  - `is_struct_tag(&StructTag)` — type-equality predicate.
  - `id()` / `id_opt(&[u8])` — extract the leading [`ObjectId`](crates/iota-sdk-types/src/object.rs) from the BCS contents (`id_opt` is the fallible associated function used by `id`).
  - `version()`, `contents()`, `into_contents()`, `into_parts()` — standard getter / consuming-getter set.
  - `to_rust::<T>()` — `serde`-feature-gated helper that BCS-decodes the contents into a caller-supplied type.
- **Issue link added** next to the existing `TODO` about hand-rolling a `Deserialize` impl that enforces the leading object id, pointing at [iotaledger/iota-rust-sdk#1043](https://github.com/iotaledger/iota-rust-sdk/issues/1043).

### Call-site updates

Mechanical `type_` → `object_type` renames in the in-tree consumers:

- [crates/iota-sdk-types/src/framework.rs](crates/iota-sdk-types/src/framework.rs) — `Coin::try_from_object`.
- [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs) — `Object::object_type`, `GenesisObject::object_type`, the readable/binary deserialization paths, and the `obj()` test fixture.
- [crates/iota-sdk-ffi/src/types/object.rs](crates/iota-sdk-ffi/src/types/object.rs) — `From` conversions in both directions between the FFI and core `MoveStruct`.
- [crates/iota-sdk/examples/abstract_account.rs](crates/iota-sdk/examples/abstract_account.rs), [crates/iota-sdk/examples/publish_upgrade.rs](crates/iota-sdk/examples/publish_upgrade.rs) — example code updated to the new field name.

## Breaking changes

- **Rust API**: `MoveStruct.type_` is renamed to `MoveStruct.object_type`. External consumers that constructed or pattern-matched the struct must rename the field; the migration is mechanical.
- **Wire format**: unchanged. BCS and JSON serialization of `MoveStruct` are unaffected — the field rename does not propagate to the serialized form.
- **FFI**: the generated `MoveStruct` binding still exposes `struct_type` / `version` / `contents`; only the internal `From` conversions change.

## Test plan

- [ ] `cargo test -p iota-sdk-types`
- [ ] `cargo test -p iota-sdk-types --all-features`
- [ ] `cargo check --workspace`
- [ ] Regenerate / smoke-test the Go, Kotlin, and Python bindings (FFI surface unchanged, but the `From` impls now reference the new field name).
