### PR TITLE
feat(iota-sdk-types): derive Hash for ProgrammableTransaction

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -729,7 +729,7 @@ pub struct GenesisTransaction {
 /// ```text
 /// ptb = (vector input) (vector command)
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/22-MoveObject`. Derives `Hash` on `ProgrammableTransaction` so it can be used as a key in hash-based collections, matching the sibling transaction types.

- **`ProgrammableTransaction` now derives `Hash`** in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs): adds `Hash` to the existing `Clone, Debug, PartialEq, Eq` derive. 
