### PR TITLE
feat: `ObjectData` improvements

### DIFF
--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -309,7 +309,22 @@ macro_rules! def_is_as_into_opt {
 
         #[doc = "Converts this into a " $rename:snake " if it is a " $variant:snake " variant, or returns `None` otherwise."]
         #[inline]
+        pub fn [< as_ $rename _mut >](&mut self) -> &mut $inner {
+            self.[< as_ $rename _mut_opt >]().expect(&format!("not a {}", stringify!($variant)))
+        }
+
+        #[inline]
         pub fn [< as_ $rename _opt >](&self) -> Option<&$inner> {
+            #[allow(irrefutable_let_patterns)]
+            if let Self::$variant(inner) = self {
+                Some(inner)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
+        pub fn [< as_ $rename _mut_opt >](&mut self) -> Option<&mut $inner> {
             #[allow(irrefutable_let_patterns)]
             if let Self::$variant(inner) = self {
                 Some(inner)

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -307,12 +307,12 @@ macro_rules! def_is_as_into_opt {
             self.[< as_ $rename _opt >]().expect(&format!("not a {}", stringify!($variant)))
         }
 
-        #[doc = "Converts this into a " $rename:snake " if it is a " $variant:snake " variant, or returns `None` otherwise."]
         #[inline]
         pub fn [< as_ $rename _mut >](&mut self) -> &mut $inner {
             self.[< as_ $rename _mut_opt >]().expect(&format!("not a {}", stringify!($variant)))
         }
 
+        #[doc = "Converts this into a " $rename:snake " if it is a " $variant:snake " variant, or returns `None` otherwise."]
         #[inline]
         pub fn [< as_ $rename _opt >](&self) -> Option<&$inner> {
             #[allow(irrefutable_let_patterns)]

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -307,6 +307,7 @@ macro_rules! def_is_as_into_opt {
             self.[< as_ $rename _opt >]().expect(&format!("not a {}", stringify!($variant)))
         }
 
+        #[doc = "Converts this into a mut " $rename:snake " if it is a " $variant:snake " variant, or panics otherwise."]
         #[inline]
         pub fn [< as_ $rename _mut >](&mut self) -> &mut $inner {
             self.[< as_ $rename _mut_opt >]().expect(&format!("not a {}", stringify!($variant)))
@@ -323,6 +324,7 @@ macro_rules! def_is_as_into_opt {
             }
         }
 
+        #[doc = "Converts this into a mut " $rename:snake " if it is a " $variant:snake " variant, or returns `None` otherwise."]
         #[inline]
         pub fn [< as_ $rename _mut_opt >](&mut self) -> Option<&mut $inner> {
             #[allow(irrefutable_let_patterns)]

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -172,6 +172,27 @@ pub enum ObjectData {
 
 impl ObjectData {
     crate::def_is_as_into_opt!(Struct(MoveStruct), Package(MovePackage));
+
+    pub fn object_type(&self) -> Option<&MoveObjectType> {
+        match self {
+            Self::Struct(m) => Some(m.object_type()),
+            Self::Package(_) => None,
+        }
+    }
+
+    pub fn struct_tag(&self) -> Option<StructTag> {
+        match self {
+            Self::Struct(m) => Some(m.struct_tag().clone()),
+            Self::Package(_) => None,
+        }
+    }
+
+    pub fn id(&self) -> ObjectId {
+        match self {
+            Self::Struct(v) => v.id(),
+            Self::Package(m) => m.id(),
+        }
+    }
 }
 
 /// A [`StructTag`] with optimized BCS serialization for object types.


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/23-ProgrammableTransaction`. Rounds out `ObjectData` with the accessors the monorepo expects (object id, type, struct tag) and extends the `def_is_as_into_opt!` macro with mutable-borrow accessors so enums generated via the macro support in-place mutation of their inner values.

## Changes

### `ObjectData`

New methods on `ObjectData` in [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs):

- `id()` — returns the inner `ObjectId` regardless of variant (`Struct` delegates to `MoveStruct::id`, `Package` delegates to `MovePackage::id`).
- `object_type()` — returns `Some(&MoveObjectType)` for `Struct`, `None` for `Package`.
- `struct_tag()` — returns `Some(StructTag)` (cloned) for `Struct`, `None` for `Package`.

### `def_is_as_into_opt!` macro

Adds mutable-borrow accessors to the plain-`$inner` arm of the macro in [crates/iota-sdk-types/src/lib.rs](crates/iota-sdk-types/src/lib.rs):

- `as_<rename>_mut(&mut self) -> &mut $inner` — panicking variant.
- `as_<rename>_mut_opt(&mut self) -> Option<&mut $inner>` — fallible variant.

These mirror the existing `as_<rename>` / `as_<rename>_opt` pair and let callers mutate the inner value of an enum variant without re-matching. The `Box<$inner>` arm is intentionally left unchanged.
