### PR TITLE
feat: `GenesisObject` improvements

### DIFF
--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -545,7 +545,7 @@ fn id_opt(contents: &[u8]) -> Option<ObjectId> {
 /// ```text
 /// genesis-object = %d00 object-data owner   ; RawObject
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct GenesisObject {
     pub data: ObjectData,
@@ -584,6 +584,10 @@ impl GenesisObject {
 
     pub fn data(&self) -> &ObjectData {
         &self.data
+    }
+
+    pub fn id(&self) -> ObjectId {
+        self.data.id()
     }
 }
 
@@ -974,6 +978,7 @@ mod serialization {
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
+    #[serde(rename = "GenesisObject")]
     #[cfg_attr(
         feature = "bcs-schema",
         derive(iota_bcs_schema::BcsSchema),


### PR DESCRIPTION
## Summary

- Derive `Hash` on `GenesisObject` so it can be used in hash-based collections, matching the derives on related object types.
- Add a convenience `GenesisObject::id()` method that delegates to the inner `ObjectData::id()`.
- Add `#[serde(rename = "GenesisObject")]` on the internal serialization shadow struct so the serialized type name matches the public type.

## Test plan

- [ ] `cargo build -p iota-sdk-types`
- [ ] `cargo test -p iota-sdk-types`
- [ ] Verify BCS / serde output for `GenesisObject` is unchanged on the wire (rename only affects the type name reported by schema-aware formats).
