### PR TITLE
chore: utils module containing write_sep (#1053)

### DIFF
--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -126,6 +126,7 @@ pub mod object;
 pub mod object_id;
 pub mod transaction;
 pub mod u256;
+pub mod utils;
 pub mod validator;
 pub mod version;
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -6,6 +6,7 @@ use super::{
     Address, CheckpointTimestamp, Digest, EpochId, Event, GenesisObject, Identifier, ObjectId,
     ObjectReference, ProtocolVersion, RandomnessRound, TypeTag, UserSignature, Version,
 };
+use crate::utils::write_sep;
 
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
@@ -1022,32 +1023,6 @@ impl Command {
             ticket,
         })
     }
-}
-
-/// Writes `items` to `f`, separated by `sep` and optionally wrapped in
-/// `delimiters` (e.g. `("[", "]")`). If the iterator is empty, nothing is
-/// written — not even the delimiters.
-pub fn write_sep<T: core::fmt::Display>(
-    f: &mut core::fmt::Formatter<'_>,
-    items: impl IntoIterator<Item = T>,
-    delimiters: Option<(&str, &str)>,
-    sep: &str,
-) -> std::fmt::Result {
-    let mut xs = items.into_iter();
-    let Some(x) = xs.next() else {
-        return Ok(());
-    };
-    if let Some((l, _)) = delimiters {
-        write!(f, "{l}")?;
-    }
-    write!(f, "{x}")?;
-    for x in xs {
-        write!(f, "{sep}{x}")?;
-    }
-    if let Some((_, r)) = delimiters {
-        write!(f, "{r}")?;
-    }
-    Ok(())
 }
 
 impl core::fmt::Display for MoveCall {

--- a/crates/iota-sdk-types/src/utils.rs
+++ b/crates/iota-sdk-types/src/utils.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+/// Write an iterator of items to a formatter, joined by a separator.
+///
+/// If `delimiters` is provided, the output is wrapped in the given left and
+/// right delimiter strings. An empty iterator produces no output at all (not
+/// even delimiters).
+///
+/// # Examples
+///
+/// ```
+/// use std::fmt;
+///
+/// struct Nums(Vec<i32>);
+///
+/// impl fmt::Display for Nums {
+///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+///         iota_sdk_types::utils::write_sep(f, &self.0, Some(("[", "]")), ", ")
+///     }
+/// }
+///
+/// assert_eq!(Nums(vec![1, 2, 3]).to_string(), "[1, 2, 3]");
+/// assert_eq!(Nums(vec![]).to_string(), "");
+/// ```
+pub fn write_sep<T: core::fmt::Display>(
+    f: &mut core::fmt::Formatter<'_>,
+    items: impl IntoIterator<Item = T>,
+    delimiters: Option<(&str, &str)>,
+    separator: &str,
+) -> std::fmt::Result {
+    let mut xs = items.into_iter();
+    let Some(x) = xs.next() else {
+        return Ok(());
+    };
+    if let Some((l, _)) = delimiters {
+        write!(f, "{l}")?;
+    }
+    write!(f, "{x}")?;
+    for x in xs {
+        write!(f, "{separator}{x}")?;
+    }
+    if let Some((_, r)) = delimiters {
+        write!(f, "{r}")?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Move the free function `write_sep` out of [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs) into a new top-level [crates/iota-sdk-types/src/utils.rs](crates/iota-sdk-types/src/utils.rs) module so it's reachable from anywhere in the crate (and downstream) without pulling in `transaction`.

## Changes

- New public module `utils` declared in [crates/iota-sdk-types/src/lib.rs](crates/iota-sdk-types/src/lib.rs).
- `write_sep` relocated to [crates/iota-sdk-types/src/utils.rs](crates/iota-sdk-types/src/utils.rs), with a doc comment and a runnable example covering the `Some(delimiters)` and empty-iterator cases.
- Renamed the parameter `sep` → `separator` for clarity at the call site.
- `transaction::mod` now imports it via `use crate::utils::write_sep;` — no behavior change at call sites.

## Test plan

- [ ] `cargo build -p iota-sdk-types`
- [ ] `cargo test -p iota-sdk-types` (including the new doctest in `utils`)