### PR TITLE
feat(iota-sdk-types): derive Hash on Transaction / TransactionV1

### DIFF
--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -26,13 +26,12 @@ pub(crate) use serialization::SignedTransactionWithIntentMessage;
 ///
 /// transaction-v1 = transaction-kind address gas-payment transaction-expiration
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[non_exhaustive]
 pub enum Transaction {
-    #[cfg_attr(feature = "serde", serde(rename = "1"))]
     V1(TransactionV1),
     // When new variants are introduced, it is important that we check version support
     // in the validity_check function based on the protocol config.
@@ -48,7 +47,7 @@ impl From<TransactionV1> for Transaction {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/27-TransactionKind`.

- **Derive `Hash` on `Transaction` and `TransactionV1`** in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs). Required by the monorepo replacement, where `iota-types::transaction::TransactionData` derives `Hash`.
- **Drop the JSON-only variant rename on `Transaction::V1`** in [crates/iota-sdk-types/src/transaction/mod.rs](crates/iota-sdk-types/src/transaction/mod.rs): the `#[serde(rename = "1")]` is removed, so JSON now emits `{"V1": …}` instead of `{"1": …}`. BCS is unchanged.
- **Pin the public schema name for `UnchangedSharedKind`** in [crates/iota-sdk-types/src/effects/v1.rs](crates/iota-sdk-types/src/effects/v1.rs): the binary helper `BinaryUnchangedSharedKind` gains `#[serde(rename = "UnchangedSharedKind")]` so generated schemas keep the public type name.
