### PR TITLE
feat(iota-sdk-types)!: make MoveStruct contents checked

### DIFF
--- a/crates/iota-sdk-ffi/src/types/object.rs
+++ b/crates/iota-sdk-ffi/src/types/object.rs
@@ -561,22 +561,24 @@ pub struct MoveStruct {
 
 impl From<iota_sdk::types::MoveStruct> for MoveStruct {
     fn from(value: iota_sdk::types::MoveStruct) -> Self {
-        let struct_tag: iota_sdk::types::StructTag = value.object_type.into();
+        let (object_type, version, contents) = value.into_parts();
+        let struct_tag: iota_sdk::types::StructTag = object_type.into();
         Self {
             struct_type: Arc::new(struct_tag.into()),
-            version: Arc::new(value.version.into()),
-            contents: value.contents,
+            version: Arc::new(version.into()),
+            contents,
         }
     }
 }
 
 impl From<MoveStruct> for iota_sdk::types::MoveStruct {
     fn from(value: MoveStruct) -> Self {
-        Self {
-            object_type: value.struct_type.0.clone().into(),
-            version: **value.version,
-            contents: value.contents,
-        }
+        iota_sdk::types::MoveStruct::new(
+            value.struct_type.0.clone().into(),
+            **value.version,
+            value.contents,
+        )
+        .expect("FFI MoveStruct should always have valid contents")
     }
 }
 

--- a/crates/iota-sdk-types/src/framework.rs
+++ b/crates/iota-sdk-types/src/framework.rs
@@ -30,22 +30,21 @@ impl Coin {
         match &object.data {
             super::ObjectData::Struct(move_struct) => {
                 let coin_type = move_struct
-                    .object_type
+                    .object_type()
                     .coin_type_opt()
                     .ok_or(CoinFromObjectError::NotACoin)?;
 
-                let contents = &move_struct.contents;
+                let contents = move_struct.contents();
                 if contents.len() != ObjectId::LENGTH + std::mem::size_of::<u64>() {
                     return Err(CoinFromObjectError::InvalidContentLength);
                 }
 
-                let id = ObjectId::new((&contents[..ObjectId::LENGTH]).try_into().unwrap());
                 let balance =
                     u64::from_le_bytes((&contents[ObjectId::LENGTH..]).try_into().unwrap());
 
                 Ok(Self {
                     coin_type: coin_type.clone(),
-                    id,
+                    id: move_struct.id(),
                     balance,
                 })
             }

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -160,8 +160,8 @@ pub use gas::GasCostSummary;
 pub use move_core::{Identifier, StructTag, TypeParseError, TypeTag};
 pub use move_package::{MovePackage, MovePackageData, TypeOrigin, UpgradeInfo, UpgradePolicy};
 pub use object::{
-    GenesisObject, MoveObjectType, MoveStruct, Object, ObjectData, ObjectReference, ObjectType,
-    Owner,
+    GenesisObject, MoveObjectType, MoveStruct, MoveStructContentsError, Object, ObjectData,
+    ObjectReference, ObjectType, Owner,
 };
 pub use object_id::ObjectId;
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -291,7 +291,6 @@ pub struct MoveStruct {
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
-    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
     version: Version,
     /// BCS bytes of a Move struct value.
     ///

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -282,30 +282,50 @@ impl std::str::FromStr for MoveObjectType {
 /// ; The first 32 bytes of the `bytes` contents are the object's object-id.
 /// ```
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
-// TODO hand-roll a Deserialize impl to enforce that an objectid is present
-// https://github.com/iotaledger/iota-rust-sdk/issues/1043
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MoveStruct {
     /// The type of this object. Uses optimized BCS serialization.
     #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "compressed-struct-tag"))]
-    pub object_type: MoveObjectType,
+    object_type: MoveObjectType,
     /// Number that increases each time a tx takes this object as a mutable
     /// input This is a lamport timestamp, not a sequentially increasing
     /// version
-    #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
-    pub version: Version,
-    /// BCS bytes of a Move struct value
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "::serde_with::As::<::serde_with::Bytes>")
-    )]
+    #[cfg_attr(feature = "bcs-schema", bcs_schema(as_type = "u64"))]
+    version: Version,
+    /// BCS bytes of a Move struct value.
+    ///
+    /// The first [`ObjectId::LENGTH`] bytes are always the object's
+    /// [`ObjectId`].
     #[cfg_attr(feature = "proptest", any(proptest::collection::size_range(32..=1024).lift()))]
-    pub contents: Vec<u8>,
+    contents: Vec<u8>,
 }
 
 impl MoveStruct {
+    /// Creates a new `MoveStruct`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `contents` is shorter than [`ObjectId::LENGTH`]
+    /// bytes, since every Move object must contain its [`ObjectId`] as the
+    /// leading bytes.
+    pub fn new(
+        object_type: MoveObjectType,
+        version: Version,
+        contents: Vec<u8>,
+    ) -> Result<Self, MoveStructContentsError> {
+        if contents.len() < ObjectId::LENGTH {
+            return Err(MoveStructContentsError {
+                actual: contents.len(),
+            });
+        }
+        Ok(Self {
+            object_type,
+            version,
+            contents,
+        })
+    }
+
     /// Returns the type of this Move object.
     pub fn object_type(&self) -> &MoveObjectType {
         &self.object_type
@@ -322,16 +342,11 @@ impl MoveStruct {
     }
 
     /// Returns the object's ID, extracted from the BCS-encoded contents.
+    ///
+    /// This is always valid because the constructor guarantees that `contents`
+    /// is at least [`ObjectId::LENGTH`] bytes long.
     pub fn id(&self) -> ObjectId {
-        Self::id_opt(&self.contents).unwrap()
-    }
-
-    /// Tries to extract an [`ObjectId`] from the leading bytes of `contents`.
-    pub fn id_opt(contents: &[u8]) -> Option<ObjectId> {
-        if contents.len() < ObjectId::LENGTH {
-            return None;
-        }
-        ObjectId::from_bytes(&contents[0..ObjectId::LENGTH]).ok()
+        ObjectId::from_bytes(&self.contents[..ObjectId::LENGTH]).unwrap()
     }
 
     /// Returns the version (lamport timestamp) of this object.
@@ -339,9 +354,41 @@ impl MoveStruct {
         self.version
     }
 
+    /// Sets the version (lamport timestamp) of this object.
+    pub fn set_version(&mut self, version: Version) {
+        self.version = version;
+    }
+
+    /// Sets the type of this object.
+    ///
+    /// The caller must ensure the existing [`contents`](Self::contents) are a
+    /// valid BCS encoding of the new `object_type`; this is not verified.
+    pub fn set_object_type(&mut self, object_type: MoveObjectType) {
+        self.object_type = object_type;
+    }
+
     /// Returns the raw BCS-encoded contents of this object.
     pub fn contents(&self) -> &[u8] {
         &self.contents
+    }
+
+    /// Replaces the BCS-encoded contents of this object.
+    ///
+    /// The caller must ensure the new contents are a valid BCS encoding of the
+    /// object's [`object_type`](Self::object_type); this is not verified.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `contents` is shorter than [`ObjectId::LENGTH`]
+    /// bytes.
+    pub fn set_contents(&mut self, contents: Vec<u8>) -> Result<(), MoveStructContentsError> {
+        if contents.len() < ObjectId::LENGTH {
+            return Err(MoveStructContentsError {
+                actual: contents.len(),
+            });
+        }
+        self.contents = contents;
+        Ok(())
     }
 
     /// Consumes the object and returns the raw BCS-encoded contents.
@@ -364,6 +411,17 @@ impl MoveStruct {
     pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Option<T> {
         bcs::from_bytes(self.contents()).ok()
     }
+}
+
+/// Error returned when [`MoveStruct`] contents are too short to contain an
+/// [`ObjectId`].
+#[derive(thiserror::Error, Debug, Clone)]
+#[error(
+    "MoveStruct contents must be at least {} bytes to contain an ObjectId, got {actual}",
+    ObjectId::LENGTH
+)]
+pub struct MoveStructContentsError {
+    actual: usize,
 }
 
 /// Type of an IOTA object
@@ -434,7 +492,7 @@ impl Object {
     /// Return this object's id
     pub fn object_id(&self) -> ObjectId {
         match &self.data {
-            ObjectData::Struct(struct_) => id_opt(&struct_.contents).unwrap(),
+            ObjectData::Struct(struct_) => struct_.id(),
             ObjectData::Package(package) => package.id,
         }
     }
@@ -452,7 +510,7 @@ impl Object {
     /// Return this object's version
     pub fn version(&self) -> Version {
         match &self.data {
-            ObjectData::Struct(struct_) => struct_.version,
+            ObjectData::Struct(struct_) => struct_.version(),
             ObjectData::Package(package) => package.version,
         }
     }
@@ -460,7 +518,7 @@ impl Object {
     /// Return this object's type
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.object_type).clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct(struct_.struct_tag().clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -518,19 +576,9 @@ impl Object {
     pub fn to_rust<T: serde::de::DeserializeOwned>(
         &self,
     ) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
-        let contents = &self.as_struct_opt().ok_or("not a struct")?.contents;
+        let contents = self.as_struct_opt().ok_or("not a struct")?.contents();
         Ok(bcs::from_bytes::<T>(contents)?)
     }
-}
-
-fn id_opt(contents: &[u8]) -> Option<ObjectId> {
-    if ObjectId::LENGTH > contents.len() {
-        return None;
-    }
-
-    Some(ObjectId::from(
-        Address::from_bytes(&contents[..ObjectId::LENGTH]).unwrap(),
-    ))
 }
 
 /// An object part of the initial chain state
@@ -559,21 +607,21 @@ impl GenesisObject {
 
     pub fn object_id(&self) -> ObjectId {
         match &self.data {
-            ObjectData::Struct(struct_) => id_opt(&struct_.contents).unwrap(),
+            ObjectData::Struct(struct_) => struct_.id(),
             ObjectData::Package(package) => package.id,
         }
     }
 
     pub fn version(&self) -> Version {
         match &self.data {
-            ObjectData::Struct(struct_) => struct_.version,
+            ObjectData::Struct(struct_) => struct_.version(),
             ObjectData::Package(package) => package.version,
         }
     }
 
     pub fn object_type(&self) -> ObjectType {
         match &self.data {
-            ObjectData::Struct(struct_) => ObjectType::Struct((*struct_.object_type).clone()),
+            ObjectData::Struct(struct_) => ObjectType::Struct(struct_.struct_tag().clone()),
             ObjectData::Package(_) => ObjectType::Package,
         }
     }
@@ -767,6 +815,54 @@ mod serialization {
         }
     }
 
+    #[derive(serde::Serialize)]
+    #[serde(rename = "MoveStruct", rename_all = "camelCase")]
+    struct ReadableMoveStructRef<'a> {
+        object_type: &'a MoveObjectType,
+        #[serde(with = "crate::_serde::ReadableDisplay")]
+        version: Version,
+        #[serde(with = "::serde_with::As::<::serde_with::Bytes>")]
+        contents: &'a [u8],
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename = "MoveStruct", rename_all = "camelCase")]
+    struct ReadableMoveStructOwned {
+        object_type: MoveObjectType,
+        #[serde(with = "crate::_serde::ReadableDisplay")]
+        version: Version,
+        #[serde(with = "::serde_with::As::<::serde_with::Bytes>")]
+        contents: Vec<u8>,
+    }
+
+    impl Serialize for MoveStruct {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            ReadableMoveStructRef {
+                object_type: &self.object_type,
+                version: self.version,
+                contents: &self.contents,
+            }
+            .serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for MoveStruct {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let ReadableMoveStructOwned {
+                object_type,
+                version,
+                contents,
+            } = ReadableMoveStructOwned::deserialize(deserializer)?;
+            MoveStruct::new(object_type, version, contents).map_err(serde::de::Error::custom)
+        }
+    }
+
     struct ReadableObjectType;
 
     impl SerializeAs<ObjectType> for ReadableObjectType {
@@ -841,7 +937,7 @@ mod serialization {
         fn readable_object_data(&self) -> ReadableObjectData {
             match &self.data {
                 ObjectData::Struct(struct_) => ReadableObjectData::Move(ReadableMoveStruct {
-                    contents: struct_.contents.clone(),
+                    contents: struct_.contents().to_vec(),
                 }),
                 ObjectData::Package(package) => ReadableObjectData::Package(ReadablePackage {
                     modules: package.modules.clone(),
@@ -917,16 +1013,14 @@ mod serialization {
                         ObjectType::Struct(tag),
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
-                        // check id matches in contents
-                        if id_opt(&contents).is_none_or(|id| id != object_id) {
+                        let move_struct = MoveStruct::new(tag.into(), version, contents)
+                            .map_err(serde::de::Error::custom)?;
+
+                        if move_struct.id() != object_id {
                             return Err(serde::de::Error::custom("id from contents doesn't match"));
                         }
 
-                        ObjectData::Struct(MoveStruct {
-                            object_type: tag.into(),
-                            version,
-                            contents,
-                        })
+                        ObjectData::Struct(move_struct)
                     }
                     _ => return Err(serde::de::Error::custom("type and data don't match")),
                 };
@@ -992,7 +1086,7 @@ mod serialization {
         fn readable_object_data(&self) -> ReadableObjectData {
             match &self.data {
                 ObjectData::Struct(struct_) => ReadableObjectData::Move(ReadableMoveStruct {
-                    contents: struct_.contents.clone(),
+                    contents: struct_.contents().to_vec(),
                 }),
                 ObjectData::Package(package) => ReadableObjectData::Package(ReadablePackage {
                     modules: package.modules.clone(),
@@ -1061,16 +1155,14 @@ mod serialization {
                         ObjectType::Struct(tag),
                         ReadableObjectData::Move(ReadableMoveStruct { contents }),
                     ) => {
-                        // check id matches in contents
-                        if id_opt(&contents).is_none_or(|id| id != object_id) {
+                        let move_struct = MoveStruct::new(tag.into(), version, contents)
+                            .map_err(serde::de::Error::custom)?;
+
+                        if move_struct.id() != object_id {
                             return Err(serde::de::Error::custom("id from contents doesn't match"));
                         }
 
-                        ObjectData::Struct(MoveStruct {
-                            object_type: tag.into(),
-                            version,
-                            contents,
-                        })
+                        ObjectData::Struct(move_struct)
                     }
                     _ => return Err(serde::de::Error::custom("type and data don't match")),
                 };
@@ -1125,16 +1217,19 @@ mod serialization {
         #[test]
         fn obj() {
             let o = Object {
-                data: ObjectData::Struct(MoveStruct {
-                    object_type: MoveObjectType::new(StructTag::new(
-                        Address::FRAMEWORK,
-                        Identifier::new("bar").unwrap(),
-                        Identifier::new("foo").unwrap(),
-                        Vec::new(),
-                    )),
-                    version: Version::from_u64(12),
-                    contents: ObjectId::ZERO.into(),
-                }),
+                data: ObjectData::Struct(
+                    MoveStruct::new(
+                        MoveObjectType::new(StructTag::new(
+                            Address::FRAMEWORK,
+                            Identifier::new("bar").unwrap(),
+                            Identifier::new("foo").unwrap(),
+                            Vec::new(),
+                        )),
+                        Version::from_u64(12),
+                        ObjectId::ZERO.into(),
+                    )
+                    .unwrap(),
+                ),
                 // owner: Owner::Address(Address::ZERO),
                 owner: Owner::Object(ObjectId::ZERO),
                 // owner: Owner::Immutable,

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -815,7 +815,7 @@ mod serialization {
     }
 
     #[derive(serde::Serialize)]
-    #[serde(rename = "MoveStruct", rename_all = "camelCase")]
+    #[serde(rename = "MoveStruct")]
     struct ReadableMoveStructRef<'a> {
         object_type: &'a MoveObjectType,
         #[serde(with = "crate::_serde::ReadableDisplay")]
@@ -825,7 +825,7 @@ mod serialization {
     }
 
     #[derive(serde::Deserialize)]
-    #[serde(rename = "MoveStruct", rename_all = "camelCase")]
+    #[serde(rename = "MoveStruct")]
     struct ReadableMoveStructOwned {
         object_type: MoveObjectType,
         #[serde(with = "crate::_serde::ReadableDisplay")]

--- a/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
+++ b/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
@@ -410,6 +410,7 @@ impl TestHarness {
             "checkpoint-transaction",
             Self::generate_checkpoint_transaction,
         );
+        overrides.insert("move-struct", Self::gen_move_struct);
 
         Self {
             grammar,
@@ -503,6 +504,25 @@ impl TestHarness {
         let mut out = encode_uleb128(PAYLOAD_LEN as u64);
         out.push(0x00); // Ed25519 scheme flag
         let mut buf = vec![0u8; 64 + 32];
+        self.rng.fill_bytes(&mut buf);
+        out.extend(buf);
+        out
+    }
+
+    /// Generate a valid `move-struct` in BCS wire form.
+    ///
+    /// Layout: compressed-struct-tag + u64 version + length-prefixed bytes.
+    /// `MoveStruct::new` rejects `contents` shorter than `ObjectId::LENGTH`
+    /// (32 bytes), since the leading bytes are the object's id; the grammar's
+    /// generic `bytes` rule cannot express that lower bound, so generate it
+    /// here directly.
+    fn gen_move_struct(&mut self) -> Vec<u8> {
+        let mut out = self.generate("compressed-struct-tag");
+        out.extend(self.rng.next_u64().to_le_bytes());
+        const MIN_LEN: usize = 32; // ObjectId::LENGTH
+        let len = MIN_LEN + (self.rng.next_u32() as usize) % 33; // 32..=64
+        out.extend(encode_uleb128(len as u64));
+        let mut buf = vec![0u8; len];
         self.rng.fill_bytes(&mut buf);
         out.extend(buf);
         out

--- a/crates/iota-sdk/examples/abstract_account.rs
+++ b/crates/iota-sdk/examples/abstract_account.rs
@@ -93,12 +93,13 @@ async fn setup_account(client: &Client) -> Result<ObjectId> {
                 let object = client.object(object_id, None).await?;
 
                 if let Some(object) = object {
-                    if object.as_struct().object_type.name()
+                    if object.as_struct().object_type().name()
                         == &Identifier::from_static("PackageMetadataV1")
                     {
                         package_metadata_id.replace(object_id);
                     }
-                    if object.as_struct().object_type.name() == &Identifier::from_static("Account")
+                    if object.as_struct().object_type().name()
+                        == &Identifier::from_static("Account")
                     {
                         account_id.replace(object_id);
                     }

--- a/crates/iota-sdk/examples/get_object.rs
+++ b/crates/iota-sdk/examples/get_object.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
             iota_types::ObjectType::Struct(tag) => format!("{tag}"),
         }
     );
-    println!("BCS bytes: {}", hex::encode(&obj.as_struct().contents));
+    println!("BCS bytes: {}", hex::encode(obj.as_struct().contents()));
 
     Ok(())
 }

--- a/crates/iota-sdk/examples/package_inspect.rs
+++ b/crates/iota-sdk/examples/package_inspect.rs
@@ -331,7 +331,7 @@ async fn resolve_upgrade_cap_id(client: &Client, package_id: ObjectId) -> Result
 
             if object
                 .as_struct_opt()
-                .is_some_and(|move_struct| move_struct.object_type.is_upgrade_cap())
+                .is_some_and(|move_struct| move_struct.object_type().is_upgrade_cap())
             {
                 return Ok(Some(changed_object.object_id));
             }

--- a/crates/iota-sdk/examples/publish_upgrade.rs
+++ b/crates/iota-sdk/examples/publish_upgrade.rs
@@ -101,7 +101,7 @@ async fn main() -> Result<()> {
                 let Some(obj) = client.object(object_id, None).await? else {
                     bail!("Missing object {object_id}");
                 };
-                if obj.as_struct().object_type.is_upgrade_cap() {
+                if obj.as_struct().object_type().is_upgrade_cap() {
                     println!("UpgradeCap: {object_id}");
                     println!("UpgradeCapOwner: {}", owner.into_address());
                     upgrade_cap.replace(object_id);


### PR DESCRIPTION
## Summary

Continues the SDK replacement series, stacked on top of `sdk-replacement/28-TransactionData`. Closes the long-standing TODO on `MoveStruct` to enforce that the BCS contents always carry a leading `ObjectId`, by making the fields private and gating construction through a fallible constructor.

- **`MoveStruct` fields are now private** in [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs): `object_type`, `version`, `contents`. Read access goes through the existing accessors (`object_type()`, `version()`, `contents()`); write access goes through new setters (`set_object_type`, `set_version`, `set_contents`). Direct field access and `MoveStruct { .. }` literal construction no longer compile.
- **New fallible constructor** `MoveStruct::new(object_type, version, contents) -> Result<Self, MoveStructContentsError>`: rejects contents shorter than `ObjectId::LENGTH` (32 bytes), since the leading bytes of every Move object's BCS contents are its `ObjectId`. `set_contents` enforces the same invariant; `set_version` and `set_object_type` are infallible.
- **`MoveStruct::id()` is now infallible** — the constructor's invariant guarantees the leading 32 bytes parse as an `ObjectId`, so the `unwrap()` is always sound. The previous `MoveStruct::id_opt(&[u8])` associated function and the equivalent free `id_opt` helper in `object.rs` are removed; callers that used to do `id_opt(&struct_.contents)` now call `struct_.id()` directly.
- **`MoveStruct` gets a hand-rolled `Serialize` / `Deserialize`** in the `serialization` module of [crates/iota-sdk-types/src/object.rs](crates/iota-sdk-types/src/object.rs), routed through new private `ReadableMoveStructRef` / `ReadableMoveStructOwned` proxies. Deserialization goes through `MoveStruct::new`, so the contents-length invariant is also enforced on the wire. BCS form is unchanged. JSON form changes only in field naming: the proxy uses `#[serde(rename_all = "camelCase")]`, so `object_type` becomes `objectType` (the other two fields are already camelCase / single-word). The `Object` / `GenesisObject` deserialization paths now construct via `MoveStruct::new` and then verify the contents-encoded id matches the outer `object_id`.
- **`MoveStructContentsError`** is added (using `thiserror`) and re-exported from the crate root in [crates/iota-sdk-types/src/lib.rs](crates/iota-sdk-types/src/lib.rs).
- **Internal call sites and examples updated** to use the accessors / constructor: `Coin::try_from(&Object)` in [crates/iota-sdk-types/src/framework.rs](crates/iota-sdk-types/src/framework.rs), the FFI bindings in [crates/iota-sdk-ffi/src/types/object.rs](crates/iota-sdk-ffi/src/types/object.rs), and the `iota-sdk` examples (`abstract_account`, `get_object`, `package_inspect`, `publish_upgrade`).

BCS round-trips identically. Breaking at the Rust API level for any caller that constructs `MoveStruct { .. }` directly, reads/writes the fields by name, or uses `MoveStruct::id_opt` / the free `id_opt` — replace with `MoveStruct::new(..)?`, the accessor/setter methods, and `.id()` respectively.
