### PR TITLE
chore: Add `strum::AsRefStr` to `ExecutionError`

### DIFF
--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -206,7 +206,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 // Reordering or inserting variants will break protocol compatibility.
 // New variants MUST be added at the end.
 // The `execution_error_bcs_discriminants` snapshot test enforces this.
-#[derive(Eq, PartialEq, Clone, Debug, Error)]
+#[derive(Eq, PartialEq, Clone, Debug, Error, strum::AsRefStr)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
 pub enum ExecutionError {


### PR DESCRIPTION
## Description

In https://github.com/iotaledger/iota/pull/11507 we need to be able to access the variant name of `ExecutionError` for the Display impl. So this PR derives the `strum::AsRefStr` with no args.