### PR TITLE
chore: warn `uninlined_format_args` clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
 
 [workspace.lints.clippy]
 redundant_clone = "warn"
+uninlined_format_args = "warn"
 
 [workspace.dependencies]
 # external dependencies

--- a/crates/iota-sdk-bcs-schema/Cargo.toml
+++ b/crates/iota-sdk-bcs-schema/Cargo.toml
@@ -15,3 +15,6 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true
+
+[lints]
+workspace = true

--- a/crates/iota-sdk-crypto/src/simple.rs
+++ b/crates/iota-sdk-crypto/src/simple.rs
@@ -169,7 +169,7 @@ mod keypair {
             }
 
             let flag = SignatureScheme::from_byte(bytes[0]).map_err(|e| {
-                SignatureError::from_source(format!("invalid signature scheme: {:?}", e))
+                SignatureError::from_source(format!("invalid signature scheme: {e:?}"))
             })?;
             let key_bytes = &bytes[1..];
 

--- a/crates/iota-sdk-grpc-proto-build/src/codegen/accessor_config.rs
+++ b/crates/iota-sdk-grpc-proto-build/src/codegen/accessor_config.rs
@@ -93,8 +93,7 @@ impl AccessorTypes {
                 }
                 _ => {
                     panic!(
-                        "Unknown accessor type '{}'. Valid types are: getter, getter_opt, set, with, mut, mut_opt, all, default",
-                        part
+                        "Unknown accessor type '{part}'. Valid types are: getter, getter_opt, set, with, mut, mut_opt, all, default"
                     );
                 }
             }
@@ -102,8 +101,7 @@ impl AccessorTypes {
 
         if has_all && has_other_accessors {
             panic!(
-                "Cannot combine 'all' with other accessor types in '{}'. Use 'all' alone, or list specific types.",
-                s
+                "Cannot combine 'all' with other accessor types in '{s}'. Use 'all' alone, or list specific types."
             );
         }
 
@@ -111,8 +109,7 @@ impl AccessorTypes {
         // already includes default)
         if result.contains(AccessorTypes::DEFAULT) && result.contains(AccessorTypes::GETTER) {
             panic!(
-                "Cannot combine 'default' with 'getter' or 'all' in '{}'. The 'getter' accessor already generates default helpers. Use 'default' only with non-getter accessors like 'set,with,default'.",
-                s
+                "Cannot combine 'default' with 'getter' or 'all' in '{s}'. The 'getter' accessor already generates default helpers. Use 'default' only with non-getter accessors like 'set,with,default'."
             );
         }
 
@@ -194,7 +191,7 @@ pub fn parse_proto_accessors_from_pool(pool: &prost_reflect::DescriptorPool) -> 
             };
 
             if let Some(accessor_types) = accessor_types {
-                let key = format!("{}.{}", message_name, field_name);
+                let key = format!("{message_name}.{field_name}");
                 map.insert(key, accessor_types);
             }
         }

--- a/crates/iota-sdk-grpc-proto-build/src/codegen/accessors.rs
+++ b/crates/iota-sdk-grpc-proto-build/src/codegen/accessors.rs
@@ -293,8 +293,7 @@ fn generate_selective_accessors_for_field(
     let base_field_type_path = field.resolve_rust_type_path(context, &package);
     let field_type_path = if is_boxed_in_accessor {
         TokenStream::from_str(&format!(
-            "::prost::alloc::boxed::Box<{}>",
-            base_field_type_path
+            "::prost::alloc::boxed::Box<{base_field_type_path}>"
         ))
         .unwrap()
     } else {
@@ -808,7 +807,7 @@ fn type_default(field: &Field, context: &Context, package: &str) -> String {
         Type::Bytes => String::from("&[]"),
         Type::Group | Type::Message => {
             let ty = context.resolve_ident(package, field.inner.type_name());
-            format!("{}::default_instance() as _", ty)
+            format!("{ty}::default_instance() as _")
         }
     }
 }
@@ -826,7 +825,7 @@ fn ref_return_type(field: &Field, context: &Context, package: &str) -> String {
         Type::Bytes => String::from("&[u8]"),
         Type::Group | Type::Message => {
             let ty = context.resolve_ident(package, field.inner.type_name());
-            format!("&{}", ty)
+            format!("&{ty}")
         }
     }
 }

--- a/crates/iota-sdk-grpc-proto-build/src/codegen/generate_fields.rs
+++ b/crates/iota-sdk-grpc-proto-build/src/codegen/generate_fields.rs
@@ -176,7 +176,7 @@ fn collect_external_types(
                 let field_message_name = full_type_name.split('.').next_back().unwrap();
 
                 // Check if this type is external (from a different package)
-                let is_external = !full_type_name.starts_with(&format!(".{}", current_package));
+                let is_external = !full_type_name.starts_with(&format!(".{current_package}"));
 
                 if is_external {
                     // Check if this external type is a transparent wrapper
@@ -395,7 +395,7 @@ fn build_nested_messages_map(messages: &[DescriptorProto]) -> HashMap<String, St
                 // Merge deeper nested messages
                 for (nested_name, nested_parent) in deeper_nested {
                     nested_messages
-                        .insert(nested_name, format!("{}::{}", parent_module, nested_parent));
+                        .insert(nested_name, format!("{parent_module}::{nested_parent}"));
                 }
             }
         }
@@ -810,7 +810,7 @@ fn generate_field_path_builders_impl(
 
 // Helper function to check if a field should be boxed based on its path
 fn should_box_field(message_type: &str, field_name: &str, boxed_types: &[String]) -> bool {
-    let field_path = format!("{}.{}", message_type, field_name);
+    let field_path = format!("{message_type}.{field_name}");
     boxed_types.iter().any(|boxed_path| {
         // Remove leading dot if present
         let boxed_path = boxed_path.strip_prefix('.').unwrap_or(boxed_path);
@@ -897,7 +897,7 @@ fn generate_field_chain_methods(
             };
 
             // Check if this field should be boxed
-            let full_message_type = format!(".{}.{}", package, message_name);
+            let full_message_type = format!(".{package}.{message_name}");
             if should_box_field(&full_message_type, field.name(), boxed_types) {
                 quote! {
                     pub fn #name(mut self) -> Box<#return_type> {

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/command.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/command.rs
@@ -35,7 +35,7 @@ impl TryFrom<iota_types::transaction::Argument> for Argument {
             }
             _ => {
                 return Err(GrpcConversionError::UnsupportedArgumentType {
-                    arg_type: format!("{:?}", arg),
+                    arg_type: format!("{arg:?}"),
                 });
             }
         };

--- a/crates/iota-sdk-grpc-types/src/proto/mod.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/mod.rs
@@ -126,12 +126,11 @@ impl std::fmt::Display for GrpcConversionError {
             Self::UnsupportedArgumentType { arg_type } => {
                 write!(
                     f,
-                    "Unsupported argument type for gRPC conversion: {}",
-                    arg_type
+                    "Unsupported argument type for gRPC conversion: {arg_type}"
                 )
             }
             Self::BcsSerializationFailed { message } => {
-                write!(f, "Failed to serialize BCS data: {}", message)
+                write!(f, "Failed to serialize BCS data: {message}")
             }
         }
     }


### PR DESCRIPTION
## Summary
- Enable `clippy::uninlined_format_args` as a workspace-level `warn` lint in the root [Cargo.toml](Cargo.toml).
- Add `[lints] workspace = true` to [crates/iota-sdk-bcs-schema/Cargo.toml](crates/iota-sdk-bcs-schema/Cargo.toml) so it inherits workspace lints like the other crates.
- Fix the existing `uninlined_format_args` warnings in `iota-sdk-crypto`, `iota-sdk-grpc-proto-build`, and `iota-sdk-grpc-types`.

## Test plan
- [x] `cargo clippy --workspace --all-targets`