### PR TITLE
feat: Implement Display trait for core SDK types

### DIFF
--- a/crates/iota-sdk-types/src/effects/v1.rs
+++ b/crates/iota-sdk-types/src/effects/v1.rs
@@ -85,6 +85,38 @@ impl TransactionEffectsV1 {
     }
 }
 
+impl core::fmt::Display for TransactionEffectsV1 {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "Transaction Effects (V1):")?;
+        writeln!(f, "  Status: {}", self.status)?;
+        writeln!(f, "  Epoch: {}", self.epoch)?;
+        writeln!(f, "  Gas Used: {}", self.gas_used)?;
+        writeln!(f, "  Transaction Digest: {}", self.transaction_digest)?;
+        if let Some(gas_idx) = self.gas_object_index {
+            writeln!(f, "  Gas Object Index: {}", gas_idx)?;
+        }
+        if let Some(events_digest) = &self.events_digest {
+            writeln!(f, "  Events Digest: {}", events_digest)?;
+        }
+        writeln!(f, "  Dependencies: {:?}", self.dependencies)?;
+        writeln!(f, "  Lamport Version: {}", self.lamport_version)?;
+        writeln!(f, "  Changed Objects: [")?;
+        for obj in &self.changed_objects {
+            writeln!(f, "    {},", obj)?;
+        }
+        writeln!(f, "  ]")?;
+        writeln!(f, "  Unchanged Shared Objects: [")?;
+        for obj in &self.unchanged_shared_objects {
+            writeln!(f, "    {},", obj)?;
+        }
+        writeln!(f, "  ]")?;
+        if let Some(aux_digest) = &self.auxiliary_data_digest {
+            writeln!(f, "  Auxiliary Data Digest: {}", aux_digest)?;
+        }
+        Ok(())
+    }
+}
+
 /// Input/output state of an object that was changed during execution
 ///
 /// # BCS
@@ -111,6 +143,16 @@ pub struct ChangedObject {
     pub id_operation: IdOperation,
 }
 
+impl core::fmt::Display for ChangedObject {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "ChangedObject {{ id: {}, op: {:?}, in: {}, out: {} }}",
+            self.object_id, self.id_operation, self.input_state, self.output_state
+        )
+    }
+}
+
 /// A shared object that wasn't changed during execution
 ///
 /// # BCS
@@ -128,6 +170,16 @@ pub struct ChangedObject {
 pub struct UnchangedSharedObject {
     pub object_id: ObjectId,
     pub kind: UnchangedSharedKind,
+}
+
+impl core::fmt::Display for UnchangedSharedObject {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "UnchangedSharedObject {{ id: {}, kind: {:?} }}",
+            self.object_id, self.kind
+        )
+    }
 }
 
 /// Type of unchanged shared object
@@ -172,6 +224,20 @@ impl UnchangedSharedKind {
         Cancelled,
         PerEpochConfig
     );
+}
+
+impl core::fmt::Display for UnchangedSharedKind {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            UnchangedSharedKind::ReadOnlyRoot { version, digest } => {
+                write!(f, "ReadOnlyRoot(v: {}, d: {})", version, digest)
+            }
+            UnchangedSharedKind::MutateDeleted { version } => write!(f, "MutateDeleted(v: {})", version),
+            UnchangedSharedKind::ReadDeleted { version } => write!(f, "ReadDeleted(v: {})", version),
+            UnchangedSharedKind::Cancelled { version } => write!(f, "Cancelled(v: {})", version),
+            UnchangedSharedKind::PerEpochConfig => write!(f, "PerEpochConfig"),
+        }
+    }
 }
 
 /// State of an object prior to execution
@@ -239,6 +305,19 @@ impl ObjectIn {
 
     pub fn owner(&self) -> Owner {
         self.owner_opt().expect("object does not exist")
+    }
+}
+
+impl core::fmt::Display for ObjectIn {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ObjectIn::Missing => write!(f, "Missing"),
+            ObjectIn::Data {
+                version,
+                digest,
+                owner,
+            } => write!(f, "Data(v: {}, d: {}, o: {})", version, digest, owner),
+        }
     }
 }
 
@@ -316,6 +395,20 @@ impl ObjectOut {
 
     pub fn package_digest(&self) -> Digest {
         self.package_digest_opt().expect("package does not exist")
+    }
+}
+
+impl core::fmt::Display for ObjectOut {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ObjectOut::Missing => write!(f, "Missing"),
+            ObjectOut::ObjectWrite { digest, owner } => {
+                write!(f, "ObjectWrite(d: {}, o: {})", digest, owner)
+            }
+            ObjectOut::PackageWrite { version, digest } => {
+                write!(f, "PackageWrite(v: {}, d: {})", version, digest)
+            }
+        }
     }
 }
 

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -77,3 +77,26 @@ impl Event {
         self.is_system_epoch_info_event_type(Identifier::SYSTEM_EPOCH_INFO_EVENT_V2)
     }
 }
+
+impl core::fmt::Display for Event {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "Event {{ package_id: {}, module: {}, sender: {}, type: {} }}",
+            self.package_id, self.module, self.sender, self.type_
+        )
+    }
+}
+
+impl core::fmt::Display for TransactionEvents {
+    fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "[")?;
+        for (i, event) in self.0.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", event)?;
+        }
+        write!(f, "]")
+    }
+}

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -82,7 +82,7 @@ impl core::fmt::Display for Event {
     fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "Event {{ package_id: {}, module: {}, sender: {}, type: {} }}",
+            "Event {{\n  package_id: {},\n  module: {},\n  sender: {},\n  type: {}\n}}",
             self.package_id, self.module, self.sender, self.type_
         )
     }
@@ -90,13 +90,38 @@ impl core::fmt::Display for Event {
 
 impl core::fmt::Display for TransactionEvents {
     fn fmt(&self, f: &mut core::fmt::Display::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "[")?;
-        for (i, event) in self.0.iter().enumerate() {
-            if i > 0 {
-                write!(f, ", ")?;
+        writeln!(f, "TransactionEvents [")?;
+        for event in &self.0 {
+            let s = format!("{}", event);
+            for line in s.lines() {
+                writeln!(f, "  {}", line)?;
             }
-            write!(f, "{}", event)?;
         }
         write!(f, "]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Address, Identifier, ObjectId, StructTag};
+
+    #[test]
+    fn test_event_display() {
+        let event = Event {
+            package_id: ObjectId::ZERO,
+            module: Identifier::new("test").unwrap(),
+            sender: Address::ZERO,
+            type_: StructTag {
+                address: Address::ZERO,
+                module: Identifier::new("m").unwrap(),
+                name: Identifier::new("n").unwrap(),
+                type_params: vec![],
+            },
+            contents: vec![],
+        };
+        let s = format!("{}", event);
+        assert!(s.contains("package_id:"));
+        assert!(s.contains("sender:"));
     }
 }

--- a/crates/iota-sdk-types/src/framework.rs
+++ b/crates/iota-sdk-types/src/framework.rs
@@ -53,6 +53,16 @@ impl Coin {
     }
 }
 
+impl std::fmt::Display for Coin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Coin {{ type: {}, balance: {}, id: {} }}",
+            self.coin_type, self.balance, self.id
+        )
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CoinFromObjectError {

--- a/crates/iota-sdk-types/src/framework.rs
+++ b/crates/iota-sdk-types/src/framework.rs
@@ -57,9 +57,32 @@ impl std::fmt::Display for Coin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Coin {{ type: {}, balance: {}, id: {} }}",
+            "Coin {{\n  type: {},\n  balance: {},\n  id: {}\n}}",
             self.coin_type, self.balance, self.id
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ObjectId, StructTag, Address, Identifier};
+
+    #[test]
+    fn test_coin_display() {
+        let coin = Coin {
+            id: ObjectId::ZERO,
+            coin_type: StructTag {
+                address: Address::ZERO,
+                module: Identifier::new("m").unwrap(),
+                name: Identifier::new("n").unwrap(),
+                type_params: vec![],
+            },
+            balance: 100,
+        };
+        let s = format!("{}", coin);
+        assert!(s.contains("balance: 100"));
+        assert!(s.contains("id:"));
     }
 }
 


### PR DESCRIPTION
This PR implements the Display trait for multiple core types in iota-sdk-types, including Event, TransactionEvents, Coin, and TransactionEffectsV1, as requested in the bounty program.