### PR TITLE
Add IOTA Names examples

### DIFF
--- a/bindings/csharp/examples/IotaNames/Program.cs
+++ b/bindings/csharp/examples/IotaNames/Program.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+using IotaSdk;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var client = GraphQlClient.NewTestnet();
+
+        var sender = Address.Zero();
+
+        var iotaNamesPackageAddress = Address.FromHex("0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea");
+        var iotaNamesObjectId = ObjectId.FromHex("0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec");
+        var stdAddress = Address.Std();
+
+        var name = "name.iota";
+        Console.WriteLine($"Looking up name: {name}");
+
+        var builder = new TransactionBuilder(sender).WithClient(client);
+
+        builder.MoveCall(
+            iotaNamesPackageAddress,
+            new Identifier("iota_names"),
+            new Identifier("registry"),
+            new[] { PtbArgument.SharedMut(iotaNamesObjectId) },
+            new[] { TypeTag.NewStruct(new StructTag(iotaNamesPackageAddress, new Identifier("registry"), new Identifier("Registry"))) },
+            new[] { "iota_names" }
+        );
+
+        builder.MoveCall(
+            iotaNamesPackageAddress,
+            new Identifier("name"),
+            new Identifier("new"),
+            new[] { PtbArgument.String(name) },
+            [],
+            new[] { "name" }
+        );
+
+        builder.MoveCall(
+            iotaNamesPackageAddress,
+            new Identifier("registry"),
+            new Identifier("lookup"),
+            new[] { PtbArgument.Assigned("iota_names"), PtbArgument.Assigned("name") },
+            [],
+            new[] { "name_record_opt" }
+        );
+
+        builder.MoveCall(
+            stdAddress,
+            new Identifier("option"),
+            new Identifier("borrow"),
+            new[] { PtbArgument.Assigned("name_record_opt") },
+            new[] { TypeTag.NewStruct(new StructTag(iotaNamesPackageAddress, new Identifier("name_record"), new Identifier("NameRecord"))) },
+            new[] { "name_record" }
+        );
+
+        builder.MoveCall(
+            iotaNamesPackageAddress,
+            new Identifier("name_record"),
+            new Identifier("target_address"),
+            new[] { PtbArgument.Assigned("name_record") },
+            [],
+            new[] { "target_address_opt" }
+        );
+
+        builder.MoveCall(
+            stdAddress,
+            new Identifier("option"),
+            new Identifier("borrow"),
+            new[] { PtbArgument.Assigned("target_address_opt") },
+            new[] { TypeTag.NewAddress() },
+            new[] { "target_address" }
+        );
+
+        var res = await builder.DryRun(true);
+
+        if (res.error != null)
+        {
+            throw new Exception($"Failed to lookup name: {res.error}");
+        }
+
+        if (res.results.Length > 0)
+        {
+            var lastEffect = res.results[res.results.Length - 1];
+            if (lastEffect.returnValues.Length > 0)
+            {
+                var returnValue = lastEffect.returnValues[0];
+                if (returnValue.typeTag.IsAddress() && returnValue.bcs.Length == 32)
+                {
+                    var resolvedAddress = Address.FromBytes(returnValue.bcs);
+                    Console.WriteLine($"Resolved address: {resolvedAddress.ToHex()}");
+                }
+                else
+                {
+                    Console.WriteLine($"Last result is not an address type or has wrong length: {returnValue.bcs.Length}");
+                }
+            }
+            else
+            {
+                Console.WriteLine("No return value in last effect");
+            }
+        }
+        else
+        {
+            Console.WriteLine("No results found");
+        }
+    }
+}

--- a/bindings/go/examples/iota_names/main.go
+++ b/bindings/go/examples/iota_names/main.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/iotaledger/iota-rust-sdk/bindings/go/iota_sdk"
+)
+
+func objIdFromHex(hex string) *iota_sdk.ObjectId {
+	id, err := iota_sdk.ObjectIdFromHex(hex)
+	if err != nil {
+		log.Fatalf("Failed to parse object ID: %v", err)
+	}
+	return id
+}
+
+func addrFromHex(hex string) *iota_sdk.Address {
+	address, err := iota_sdk.AddressFromHex(hex)
+	if err != nil {
+		log.Fatalf("Failed to parse address: %v", err)
+	}
+	return address
+}
+
+func identifier(ident string) *iota_sdk.Identifier {
+	identifier, err := iota_sdk.NewIdentifier(ident)
+	if err != nil {
+		log.Fatalf("Failed to parse identifier: %v", err)
+	}
+	return identifier
+}
+
+func main() {
+	client := iota_sdk.GraphQlClientNewTestnet()
+
+	sender := iota_sdk.AddressZero()
+
+	iotaNamesPackageAddress := addrFromHex("0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea")
+
+	iotaNamesObjectId := objIdFromHex("0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec")
+
+	stdAddress := iota_sdk.AddressStd()
+
+	name := "name.iota"
+	fmt.Printf("Looking up name: %s\n", name)
+
+	builder := iota_sdk.NewTransactionBuilder(sender).WithClient(client)
+
+	// Create identifiers
+	iotaNamesModule := identifier("iota_names")
+	nameModule := identifier("name")
+	nameNewFn := identifier("new")
+	lookupFn := identifier("lookup")
+	optionModule := identifier("option")
+	borrowFn := identifier("borrow")
+	targetAddressFn := identifier("target_address")
+	registryModule := identifier("registry")
+	registryName := identifier("Registry")
+
+	registryType := iota_sdk.NewStructTag(iotaNamesPackageAddress, registryModule, registryName, []*iota_sdk.TypeTag{})
+
+	nameRecordModule := identifier("name_record")
+	nameRecordName := identifier("NameRecord")
+	nameRecordType := iota_sdk.NewStructTag(iotaNamesPackageAddress, nameRecordModule, nameRecordName, []*iota_sdk.TypeTag{})
+
+	// 1. Get the registry
+	builder.MoveCall(
+		iotaNamesPackageAddress,
+		iotaNamesModule,
+		registryModule,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentSharedMut(iotaNamesObjectId)},
+		[]*iota_sdk.TypeTag{iota_sdk.TypeTagNewStruct(registryType)},
+		[]string{"iota_names"},
+	)
+
+	// 2. Create name from string
+	builder.MoveCall(
+		iotaNamesPackageAddress,
+		nameModule,
+		nameNewFn,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentString(name)},
+		nil,
+		[]string{"name"},
+	)
+
+	// 3. Lookup name record
+	builder.MoveCall(
+		iotaNamesPackageAddress,
+		registryModule,
+		lookupFn,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("iota_names"), iota_sdk.PtbArgumentAssigned("name")},
+		nil,
+		[]string{"name_record_opt"},
+	)
+
+	// 4. Borrow name record from option
+	builder.MoveCall(
+		stdAddress,
+		optionModule,
+		borrowFn,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record_opt")},
+		[]*iota_sdk.TypeTag{iota_sdk.TypeTagNewStruct(nameRecordType)},
+		[]string{"name_record"},
+	)
+
+	// 5. Get target address from name record
+	builder.MoveCall(
+		iotaNamesPackageAddress,
+		nameRecordModule,
+		targetAddressFn,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("name_record")},
+		nil,
+		[]string{"target_address_opt"},
+	)
+
+	// 6. Borrow address from option
+	builder.MoveCall(
+		stdAddress,
+		optionModule,
+		borrowFn,
+		[]*iota_sdk.PtbArgument{iota_sdk.PtbArgumentAssigned("target_address_opt")},
+		[]*iota_sdk.TypeTag{iota_sdk.TypeTagNewAddress()},
+		[]string{"target_address"},
+	)
+
+	res, err := builder.DryRun(true)
+	if err != nil {
+		log.Fatalf("Failed to dry run transaction: %v", err)
+	}
+
+	if res.Error != nil {
+		log.Fatalf("Failed to lookup name: %v", *res.Error)
+	}
+
+	// Extract the resolved address from the last result
+	if len(res.Results) > 0 {
+		lastEffect := res.Results[len(res.Results)-1]
+		if len(lastEffect.ReturnValues) > 0 {
+			returnValue := lastEffect.ReturnValues[0]
+			if returnValue.TypeTag.IsAddress() && len(returnValue.Bcs) == 32 {
+				resolvedAddress, err := iota_sdk.AddressFromBytes(returnValue.Bcs)
+				if err != nil {
+					log.Fatalf("Failed to create address from bytes: %v", err)
+				}
+				fmt.Printf("Resolved address: %s\n", resolvedAddress.ToHex())
+			} else {
+				fmt.Printf("Last result is not an address type or has wrong length: %d\n", len(returnValue.Bcs))
+			}
+		} else {
+			fmt.Println("No return value in last effect")
+		}
+	} else {
+		fmt.Println("No results found")
+	}
+}

--- a/bindings/kotlin/examples/IotaNames.kt
+++ b/bindings/kotlin/examples/IotaNames.kt
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import iota_sdk.*
+import kotlin.collections.emptyList
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    try {
+        val client = GraphQlClient.newTestnet()
+
+        val sender = Address.zero()
+
+        val iotaNamesPackageAddress =
+            Address.fromHex("0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea")
+        val iotaNamesObjectId =
+            ObjectId.fromHex("0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec")
+        val stdAddress = Address.std()
+
+        val name = "name.iota"
+        println("Looking up name: $name")
+
+        val builder = TransactionBuilder(sender).withClient(client)
+
+        // 1. Get the registry
+        builder.moveCall(
+            iotaNamesPackageAddress,
+            Identifier("iota_names"),
+            Identifier("registry"),
+            listOf(PtbArgument.sharedMut(iotaNamesObjectId)),
+            listOf(
+                TypeTag.newStruct(
+                    StructTag(
+                        iotaNamesPackageAddress,
+                        Identifier("registry"),
+                        Identifier("Registry"),
+                    )
+                )
+            ),
+            listOf("iota_names"),
+        )
+
+        // 2. Create name from string
+        // BCS encode the string: length (as varint) + UTF-8 bytes
+        builder.moveCall(
+            iotaNamesPackageAddress,
+            Identifier("name"),
+            Identifier("new"),
+            listOf(PtbArgument.string(name)),
+            emptyList(),
+            listOf("name"),
+        )
+
+        // 3. Lookup name record
+        builder.moveCall(
+            iotaNamesPackageAddress,
+            Identifier("registry"),
+            Identifier("lookup"),
+            listOf(PtbArgument.assigned("iota_names"), PtbArgument.assigned("name")),
+            emptyList(),
+            listOf("name_record_opt"),
+        )
+
+        // 4. Borrow name record from option
+        builder.moveCall(
+            stdAddress,
+            Identifier("option"),
+            Identifier("borrow"),
+            listOf(PtbArgument.assigned("name_record_opt")),
+            listOf(
+                TypeTag.newStruct(
+                    StructTag(
+                        iotaNamesPackageAddress,
+                        Identifier("name_record"),
+                        Identifier("NameRecord"),
+                    )
+                )
+            ),
+            listOf("name_record"),
+        )
+
+        // 5. Get target address from name record
+        builder.moveCall(
+            iotaNamesPackageAddress,
+            Identifier("name_record"),
+            Identifier("target_address"),
+            listOf(PtbArgument.assigned("name_record")),
+            emptyList(),
+            listOf("target_address_opt"),
+        )
+
+        // 6. Borrow address from option
+        builder.moveCall(
+            stdAddress,
+            Identifier("option"),
+            Identifier("borrow"),
+            listOf(PtbArgument.assigned("target_address_opt")),
+            listOf(TypeTag.newAddress()),
+            listOf("target_address"),
+        )
+
+        val res = builder.dryRun(true)
+
+        if (res.error != null) {
+            throw Exception("Failed to lookup name: ${res.error}")
+        }
+
+        // Extract the resolved address from the last result
+        if (res.results.isNotEmpty()) {
+            val lastEffect = res.results.last()
+            if (lastEffect.returnValues.isNotEmpty()) {
+                val returnValue = lastEffect.returnValues.first()
+                if (returnValue.typeTag.isAddress() && returnValue.bcs.size == 32) {
+                    val resolvedAddress = Address.fromBytes(returnValue.bcs)
+                    println("Resolved address: ${resolvedAddress.toHex()}")
+                } else {
+                    println(
+                        "Last result is not an address type or has wrong length: ${returnValue.bcs.size}"
+                    )
+                }
+            } else {
+                println("No return value in last effect")
+            }
+        } else {
+            println("No results found")
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
+        kotlin.system.exitProcess(1)
+    }
+}

--- a/bindings/python/examples/iota_names.py
+++ b/bindings/python/examples/iota_names.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 IOTA Stiftung
+# SPDX-License-Identifier: Apache-2.0
+
+from lib.iota_sdk import *
+
+import asyncio
+
+
+async def main():
+    client = GraphQlClient.new_testnet()
+
+    sender = Address.zero()
+
+    iota_names_package_address = Address.from_hex(
+        "0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea")
+    iota_names_object_id = ObjectId.from_hex(
+        "0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec")
+    std_address = Address.std()
+
+    name = "name.iota"
+    print(f"Looking up name: {name}")
+
+    builder = TransactionBuilder(sender).with_client(client)
+
+    # 1. Get the registry
+    builder.move_call(
+        iota_names_package_address,
+        Identifier("iota_names"),
+        Identifier("registry"),
+        [PtbArgument.shared_mut(iota_names_object_id)],
+        [
+            TypeTag.new_struct(
+                StructTag(
+                    iota_names_package_address,
+                    Identifier("registry"),
+                    Identifier("Registry"),
+                ))
+        ],
+        ["iota_names"],
+    )
+
+    # 2. Create name from string
+    builder.move_call(
+        iota_names_package_address,
+        Identifier("name"),
+        Identifier("new"),
+        [PtbArgument.string(name)],
+        names=["name"],
+    )
+
+    # 3. Lookup name record
+    builder.move_call(
+        iota_names_package_address,
+        Identifier("registry"),
+        Identifier("lookup"),
+        [PtbArgument.assigned("iota_names"),
+         PtbArgument.assigned("name")],
+        names=["name_record_opt"],
+    )
+
+    # 4. Borrow name record from option
+    builder.move_call(
+        std_address,
+        Identifier("option"),
+        Identifier("borrow"),
+        [PtbArgument.assigned("name_record_opt")],
+        [
+            TypeTag.new_struct(
+                StructTag(
+                    iota_names_package_address,
+                    Identifier("name_record"),
+                    Identifier("NameRecord"),
+                ))
+        ],
+        ["name_record"],
+    )
+
+    # 5. Get target address from name record
+    builder.move_call(
+        iota_names_package_address,
+        Identifier("name_record"),
+        Identifier("target_address"),
+        [PtbArgument.assigned("name_record")],
+        names=["target_address_opt"],
+    )
+
+    # 6. Borrow address from option
+    builder.move_call(
+        std_address,
+        Identifier("option"),
+        Identifier("borrow"),
+        [PtbArgument.assigned("target_address_opt")],
+        [TypeTag.new_address()],
+        ["target_address"],
+    )
+
+    res = await builder.dry_run(True)
+
+    if res.error is not None:
+        raise Exception(f"Failed to lookup name: {res.error}")
+
+    # Extract the resolved address from the last result
+    if len(res.results) > 0:
+        last_effect = res.results[-1]
+        if len(last_effect.return_values) > 0:
+            return_value = last_effect.return_values[0]
+            if return_value.type_tag.is_address() and len(
+                    return_value.bcs) == 32:
+                resolved_address = Address.from_bytes(return_value.bcs)
+                print(f"Resolved address: {resolved_address.to_hex()}")
+            else:
+                print(
+                    f"Last result is not an address type or has wrong length: {len(return_value.bcs)}"
+                )
+        else:
+            print("No return value in last effect")
+    else:
+        print("No results found")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bindings/swift/examples/IotaNames.swift
+++ b/bindings/swift/examples/IotaNames.swift
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+import Foundation
+import IotaSDK
+
+@main
+struct IotaNamesExample {
+  static func main() async throws {
+    let client = GraphQlClient.newTestnet()
+
+    let sender = Address.zero()
+
+    let iotaNamesPackageAddress = try Address.fromHex(
+      hex: "0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea")
+    let iotaNamesObjectId = try ObjectId.fromHex(
+      hex: "0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec")
+    let stdAddress = Address.std()
+
+    let name = "name.iota"
+    print("Looking up name: \(name)")
+
+    let builder = TransactionBuilder(sender: sender).withClient(client: client)
+
+    // 1. Get the registry
+    _ = try builder.moveCall(
+      package: iotaNamesPackageAddress,
+      module: Identifier(identifier: "iota_names"),
+      function: Identifier(identifier: "registry"),
+      arguments: [PtbArgument.sharedMut(id: iotaNamesObjectId)],
+      typeArgs: [
+        TypeTag.newStruct(
+          structTag: StructTag(
+            address: iotaNamesPackageAddress,
+            module: Identifier(identifier: "registry"),
+            name: Identifier(identifier: "Registry")
+          ))
+      ],
+      names: ["iota_names"]
+    )
+
+    // 2. Create name from string
+    _ = try builder.moveCall(
+      package: iotaNamesPackageAddress,
+      module: Identifier(identifier: "name"),
+      function: Identifier(identifier: "new"),
+      arguments: [PtbArgument.string(string: name)],
+      names: ["name"]
+    )
+
+    // 3. Lookup name record
+    _ = try builder.moveCall(
+      package: iotaNamesPackageAddress,
+      module: Identifier(identifier: "registry"),
+      function: Identifier(identifier: "lookup"),
+      arguments: [PtbArgument.assigned(name: "iota_names"), PtbArgument.assigned(name: "name")],
+      names: ["name_record_opt"]
+    )
+
+    // 4. Borrow name record from option
+    _ = try builder.moveCall(
+      package: stdAddress,
+      module: Identifier(identifier: "option"),
+      function: Identifier(identifier: "borrow"),
+      arguments: [PtbArgument.assigned(name: "name_record_opt")],
+      typeArgs: [
+        TypeTag.newStruct(
+          structTag: StructTag(
+            address: iotaNamesPackageAddress,
+            module: Identifier(identifier: "name_record"),
+            name: Identifier(identifier: "NameRecord")
+          ))
+      ],
+      names: ["name_record"]
+    )
+
+    // 5. Get target address from name record
+    _ = try builder.moveCall(
+      package: iotaNamesPackageAddress,
+      module: Identifier(identifier: "name_record"),
+      function: Identifier(identifier: "target_address"),
+      arguments: [PtbArgument.assigned(name: "name_record")],
+      names: ["target_address_opt"]
+    )
+
+    // 6. Borrow address from option
+    _ = try builder.moveCall(
+      package: stdAddress,
+      module: Identifier(identifier: "option"),
+      function: Identifier(identifier: "borrow"),
+      arguments: [PtbArgument.assigned(name: "target_address_opt")],
+      typeArgs: [TypeTag.newAddress()],
+      names: ["target_address"]
+    )
+
+    let res = try await builder.dryRun(skipChecks: true)
+
+    if res.error != nil {
+      throw NSError(
+        domain: "IotaNames", code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "Failed to lookup name: \(res.error!)"])
+    }
+
+    // Extract the resolved address from the last result
+    if res.results.count > 0 {
+      let lastEffect = res.results[res.results.count - 1]
+      if lastEffect.returnValues.count > 0 {
+        let returnValue = lastEffect.returnValues[0]
+        if returnValue.typeTag.isAddress() && returnValue.bcs.count == 32 {
+          let resolvedAddress = try Address.fromBytes(bytes: returnValue.bcs)
+          print("Resolved address: \(resolvedAddress.toHex())")
+        } else {
+          print(
+            "Last result is not an address type or has wrong length: \(returnValue.bcs.count)"
+          )
+        }
+      } else {
+        print("No return value in last effect")
+      }
+    } else {
+      print("No results found")
+    }
+  }
+}

--- a/crates/iota-sdk/examples/iota_names.rs
+++ b/crates/iota-sdk/examples/iota_names.rs
@@ -1,0 +1,99 @@
+// Copyright (c) 2025 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use eyre::Result;
+use iota_sdk::{
+    graphql_client::Client,
+    transaction_builder::{SharedMut, TransactionBuilder, assigned},
+    types::{Address, Identifier, ObjectId, StructTag, TypeTag},
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_testnet();
+
+    let sender = Address::from_str("0x0")?;
+
+    let iota_names_package_address =
+        Address::from_str("0x7fff6e95f385349bec98d17121ab2bfa3e134f2f0b1ccefc270313415f7835ea")?;
+    let iota_names_object_id =
+        ObjectId::from_str("0x7cab491740d51e0d75b26bf9984e49ba2e32a2d0694cabcee605543ed13c7dec")?;
+    let name = "name.iota";
+
+    println!("Looking up name: {name}");
+
+    let mut builder = TransactionBuilder::new(sender).with_client(client);
+
+    // Step 1: Get the shared registry object
+    builder
+        .move_call(iota_names_package_address, "iota_names", "registry")
+        .arguments([SharedMut(iota_names_object_id)])
+        .type_tags([TypeTag::Struct(Box::new(StructTag::new(
+            iota_names_package_address,
+            Identifier::new("registry")?,
+            Identifier::new("Registry")?,
+            vec![],
+        )))])
+        .assign("iota_names");
+
+    // Step 2: Create the name object from the string
+    builder
+        .move_call(iota_names_package_address, "name", "new")
+        .arguments([name])
+        .assign("name");
+
+    // Step 3: Look up the name record in the registry
+    builder
+        .move_call(iota_names_package_address, "registry", "lookup")
+        .arguments((assigned("iota_names"), assigned("name")))
+        .assign("name_record_opt");
+
+    // Step 4: Borrow the name record from the option
+    builder
+        .move_call(Address::STD, "option", "borrow")
+        .arguments([assigned("name_record_opt")])
+        .type_tags([TypeTag::Struct(Box::new(StructTag::new(
+            iota_names_package_address,
+            Identifier::new("name_record")?,
+            Identifier::new("NameRecord")?,
+            vec![],
+        )))])
+        .assign("name_record");
+
+    // Step 5: Get the target address from the name record
+    builder
+        .move_call(iota_names_package_address, "name_record", "target_address")
+        .arguments([assigned("name_record")])
+        .assign("target_address_opt");
+
+    // Step 6: Borrow the address from the option (this returns the resolved
+    // address)
+    builder
+        .move_call(Address::STD, "option", "borrow")
+        .arguments([assigned("target_address_opt")])
+        .generics::<Address>()
+        .assign("target_address");
+
+    let res = builder.dry_run(true).await?;
+
+    if let Some(err) = res.error {
+        eyre::bail!("Failed to lookup name: {err}");
+    }
+
+    // Extract the resolved address from the last result
+    match res
+        .results
+        .last()
+        .and_then(|effect| effect.return_values.first())
+        .filter(|rv| matches!(rv.type_tag, TypeTag::Address))
+        .and_then(|rv| TryInto::<[u8; 32]>::try_into(rv.bcs.as_slice()).ok())
+        .map(Address::from)
+    {
+        Some(resolved_address) => println!("Resolved address: {resolved_address}"),
+        None => println!("Failed to extract address from results"),
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #514.

Adds IOTA Names lookup examples for Rust and bindings:
- Rust
- Python
- Go
- C#
- Kotlin
- Swift

Validation:
- `cargo check --example iota_names -p iota-sdk`