### PR TITLE
feat: use `impl AsRef<[u8]>` for `from_bytes` methods

### DIFF
--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -120,7 +120,8 @@ impl crate::ToFromBytes for Ed25519PrivateKey {
         self.0.to_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
+        let bytes = bytes.as_ref();
         if bytes.len() != Self::LENGTH {
             return Err(crate::PrivateKeyError::InvalidScheme(
                 "invalid ed25519 key length".to_string(),

--- a/crates/iota-sdk-crypto/src/lib.rs
+++ b/crates/iota-sdk-crypto/src/lib.rs
@@ -186,7 +186,7 @@ pub trait ToFromBytes {
     fn to_bytes(&self) -> Self::ByteArray;
 
     /// Create an instance from raw bytes
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error>
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error>
     where
         Self: Sized;
 }

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -125,7 +125,8 @@ impl crate::ToFromBytes for Secp256k1PrivateKey {
         self.0.to_bytes().into()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
+        let bytes = bytes.as_ref();
         if bytes.len() != Self::LENGTH {
             return Err(crate::PrivateKeyError::InvalidScheme(
                 "invalid secp256k1 key length".to_string(),
@@ -179,7 +180,7 @@ impl crate::FromMnemonic for Secp256k1PrivateKey {
         let seed = mnemonic.to_seed(password.into().unwrap_or_default());
         let child_xprv =
             bip32::XPrv::derive_from_path(seed, &bip32::DerivationPath::from_str(&path)?)?;
-        Self::from_bytes(&child_xprv.private_key().to_bytes())
+        Self::from_bytes(child_xprv.private_key().to_bytes())
     }
 }
 

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -125,7 +125,8 @@ impl crate::ToFromBytes for Secp256r1PrivateKey {
         self.0.to_bytes().into()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, Self::Error> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
+        let bytes = bytes.as_ref();
         if bytes.len() != Self::LENGTH {
             return Err(crate::PrivateKeyError::InvalidScheme(
                 "invalid secp256r1 key length".to_string(),
@@ -179,7 +180,7 @@ impl crate::FromMnemonic for Secp256r1PrivateKey {
         let seed = mnemonic.to_seed(password.into().unwrap_or_default());
         let child_xprv =
             bip32::XPrv::derive_from_path(seed, &bip32::DerivationPath::from_str(&path)?)?;
-        Self::from_bytes(&child_xprv.private_key().to_bytes())
+        Self::from_bytes(child_xprv.private_key().to_bytes())
     }
 }
 

--- a/crates/iota-sdk-crypto/src/simple.rs
+++ b/crates/iota-sdk-crypto/src/simple.rs
@@ -163,7 +163,8 @@ mod keypair {
         }
 
         /// Decode a SimpleKeypair from `flag || privkey` bytes
-        pub fn from_bytes(bytes: &[u8]) -> Result<Self, SignatureError> {
+        pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, SignatureError> {
+            let bytes = bytes.as_ref();
             if bytes.is_empty() {
                 return Err(SignatureError::from_source("empty bytes"));
             }

--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -258,7 +258,7 @@ impl Address {
         }
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, AddressParseError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, AddressParseError> {
         let bytes = bytes.as_ref();
         <[u8; Self::LENGTH]>::try_from(bytes)
             .map_err(|_| AddressParseError::InvalidByteLength {

--- a/crates/iota-sdk-types/src/crypto/bls12381.rs
+++ b/crates/iota-sdk-types/src/crypto/bls12381.rs
@@ -68,7 +68,7 @@ impl Bls12381PublicKey {
         &self.0
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, std::array::TryFromSliceError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, std::array::TryFromSliceError> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 }
@@ -178,7 +178,7 @@ impl Bls12381Signature {
         &self.0
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, std::array::TryFromSliceError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, std::array::TryFromSliceError> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 }

--- a/crates/iota-sdk-types/src/crypto/ed25519.rs
+++ b/crates/iota-sdk-types/src/crypto/ed25519.rs
@@ -64,7 +64,7 @@ impl PublicKeyExt for Ed25519PublicKey {
     }
 
     /// Tries to create an Ed25519PublicKey from bytes.
-    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Self::FromBytesErr> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::FromBytesErr> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 
@@ -174,7 +174,7 @@ impl Ed25519Signature {
         &self.0
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, std::array::TryFromSliceError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, std::array::TryFromSliceError> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 }

--- a/crates/iota-sdk-types/src/crypto/intent.rs
+++ b/crates/iota-sdk-types/src/crypto/intent.rs
@@ -108,7 +108,8 @@ impl Intent {
     }
 
     #[cfg(feature = "serde")]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, IntentError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, IntentError> {
+        let bytes = bytes.as_ref();
         if bytes.len() != INTENT_PREFIX_LENGTH {
             return Err(IntentError::Bytes);
         }

--- a/crates/iota-sdk-types/src/crypto/mod.rs
+++ b/crates/iota-sdk-types/src/crypto/mod.rs
@@ -152,7 +152,7 @@ pub trait PublicKeyExt: Sized {
     fn as_bytes(&self) -> &[u8];
 
     /// Tries to create a PublicKey from bytes.
-    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Self::FromBytesErr>;
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::FromBytesErr>;
 
     /// Returns the signature scheme for this public key.
     fn scheme(&self) -> SignatureScheme;

--- a/crates/iota-sdk-types/src/crypto/secp256k1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256k1.rs
@@ -66,7 +66,7 @@ impl PublicKeyExt for Secp256k1PublicKey {
     }
 
     /// Tries to create a Secp256k1PublicKey from bytes.
-    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Self::FromBytesErr> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::FromBytesErr> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 
@@ -176,7 +176,7 @@ impl Secp256k1Signature {
         &self.0
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, std::array::TryFromSliceError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, std::array::TryFromSliceError> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 }

--- a/crates/iota-sdk-types/src/crypto/secp256r1.rs
+++ b/crates/iota-sdk-types/src/crypto/secp256r1.rs
@@ -66,7 +66,7 @@ impl PublicKeyExt for Secp256r1PublicKey {
     }
 
     /// Tries to create a Secp256r1PublicKey from bytes.
-    fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, Self::FromBytesErr> {
+    fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::FromBytesErr> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 
@@ -176,7 +176,7 @@ impl Secp256r1Signature {
         &self.0
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, std::array::TryFromSliceError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, std::array::TryFromSliceError> {
         <[u8; Self::LENGTH]>::try_from(bytes.as_ref()).map(Self)
     }
 }

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -655,7 +655,7 @@ mod serialization {
             }
         }
 
-        pub fn from_bytes(bytes: &[u8]) -> Result<Self, bcs::Error> {
+        pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, bcs::Error> {
             Self::from_serialized_bytes(bytes).map_err(serde::de::Error::custom)
         }
 

--- a/crates/iota-sdk-types/src/digest.rs
+++ b/crates/iota-sdk-types/src/digest.rs
@@ -109,7 +109,7 @@ impl Digest {
     }
 
     /// Generates a digest from bytes.
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, DigestParseError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, DigestParseError> {
         let bytes = bytes.as_ref();
         <[u8; Self::LENGTH]>::try_from(bytes)
             .map_err(|_| DigestParseError::InvalidByteLength {

--- a/crates/iota-sdk-types/src/object_id.rs
+++ b/crates/iota-sdk-types/src/object_id.rs
@@ -121,7 +121,7 @@ impl ObjectId {
         Self(address)
     }
 
-    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self, AddressParseError> {
+    pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, AddressParseError> {
         Address::from_bytes(bytes).map(Self)
     }
 


### PR DESCRIPTION
## Summary

Refactor `from_bytes` methods across the crypto and types modules to accept `impl AsRef<[u8]>` instead of `&[u8]`, improving API ergonomics and reducing unnecessary allocations.

## Changes

- **Trait definition** (`iota-sdk-crypto/src/lib.rs`): Updated `ToFromBytes::from_bytes` signature to accept `impl AsRef<[u8]>`
- **Implementations**: Updated all implementations to match the new signature:
  - `Ed25519PrivateKey::from_bytes`
  - `Secp256k1PrivateKey::from_bytes`
  - `Secp256r1PrivateKey::from_bytes`
  - `SimpleKeypair::from_bytes`
  - `Intent::from_bytes`
  - `Signature::from_bytes` (serialization module)
- **Call sites**: Removed unnecessary `&` dereference operators when passing owned byte arrays to `from_bytes`

## Implementation Details

Each implementation now:
1. Accepts `impl AsRef<[u8]>` to support both `&[u8]` and owned types like `Vec<u8>` and byte arrays
2. Immediately converts to `&[u8]` via `as_ref()` for internal use
3. Maintains identical error handling and validation logic

This change allows callers to pass owned byte arrays directly (e.g., `child_xprv.private_key().to_bytes()`) without requiring an explicit reference, while remaining backward compatible with existing code that passes `&[u8]`.

https://claude.ai/code/session_017PGhPz5KFF5QRczwmEvfVm