### PR TITLE
chore: address three low-hanging fruit issues

### DIFF
--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -68,7 +68,7 @@ impl From<ExecutionStatus> for iota_sdk::types::ExecutionStatus {
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// 
+///
 /// execution-error =  insufficient-gas
 ///                 =/ invalid-gas-object
 ///                 =/ invariant-violation

--- a/crates/iota-sdk-graphql-client/src/api/dynamic_fields.rs
+++ b/crates/iota-sdk-graphql-client/src/api/dynamic_fields.rs
@@ -46,7 +46,7 @@ impl Client {
     ///
     /// # Example
     /// ```rust,ignore
-    /// 
+    ///
     /// let client = iota_graphql_client::Client::new_testnet();
     /// let address = ObjectId::system().into();
     /// let df = client.dynamic_field_with_name(address, "u64", 2u64).await.unwrap();

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -120,7 +120,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// 
+///
 /// execution-error =  insufficient-gas
 ///                 =/ invalid-gas-object
 ///                 =/ invariant-violation

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -19,7 +19,11 @@
 //! Below is a list of the available feature flags.
 //!
 //! - `serde`: Enables support for serializing and deserializing types to/from
-//!   BCS utilizing [serde] library.
+//!   BCS utilizing [serde] library. **Note:** The JSON serialization provided by
+//!   this crate is NOT guaranteed to be consistent with the IOTA monorepo's
+//!   JSON-RPC format. This SDK does not provide a JSON-RPC client, and the
+//!   derived serde implementations are optimized for BCS rather than JSON-RPC
+//!   compatibility.
 //! - `rand`: Enables support for generating random instances of a number of
 //!   types via the [rand] library.
 //! - `hash`: Enables support for hashing, which is required for deriving

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -407,8 +407,8 @@ impl MoveStruct {
 
     /// Deserializes the BCS-encoded contents into a Rust type.
     #[cfg(feature = "serde")]
-    pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Option<T> {
-        bcs::from_bytes(self.contents()).ok()
+    pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Result<T, bcs::Error> {
+        bcs::from_bytes(self.contents())
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -262,7 +262,7 @@ mod version_assignments {
 
     #[derive(serde::Serialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
+    enum ConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
@@ -270,19 +270,7 @@ mod version_assignments {
     /// ConsensusDeterminedVersionAssignments.
     #[derive(serde::Deserialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum ReadableConsensusDeterminedVersionAssignments {
-        CancelledTransactions(Vec<CancelledTransaction>),
-    }
-
-    #[derive(serde::Serialize)]
-    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions(&'a Vec<CancelledTransaction>),
-    }
-
-    #[derive(serde::Deserialize)]
-    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum BinaryConsensusDeterminedVersionAssignments {
+    enum ConsensusDeterminedVersionAssignmentsOwned {
         CancelledTransactions(Vec<CancelledTransaction>),
     }
 
@@ -291,25 +279,14 @@ mod version_assignments {
         where
             S: Serializer,
         {
-            if serializer.is_human_readable() {
-                let readable = match self {
-                    Self::CancelledTransactions {
-                        cancelled_transactions,
-                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
-                        cancelled_transactions,
-                    ),
-                };
-                readable.serialize(serializer)
-            } else {
-                let binary = match self {
-                    Self::CancelledTransactions {
-                        cancelled_transactions,
-                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
-                        cancelled_transactions,
-                    ),
-                };
-                binary.serialize(serializer)
+            match self {
+                Self::CancelledTransactions {
+                    cancelled_transactions,
+                } => ConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
+                    cancelled_transactions,
+                ),
             }
+            .serialize(serializer)
         }
     }
 
@@ -318,27 +295,15 @@ mod version_assignments {
         where
             D: Deserializer<'de>,
         {
-            if deserializer.is_human_readable() {
-                ReadableConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
-                    |readable| match readable {
-                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions(
-                            cancelled_transactions,
-                        ) => Self::CancelledTransactions {
-                            cancelled_transactions,
-                        },
+            ConsensusDeterminedVersionAssignmentsOwned::deserialize(deserializer).map(|owned| {
+                match owned {
+                    ConsensusDeterminedVersionAssignmentsOwned::CancelledTransactions(
+                        cancelled_transactions,
+                    ) => Self::CancelledTransactions {
+                        cancelled_transactions,
                     },
-                )
-            } else {
-                BinaryConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
-                    |binary| match binary {
-                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions(
-                            cancelled_transactions,
-                        ) => Self::CancelledTransactions {
-                            cancelled_transactions,
-                        },
-                    },
-                )
-            }
+                }
+            })
         }
     }
 


### PR DESCRIPTION
## Summary

This PR addresses three low-hanging fruit issues identified in the codebase:

1. **#1122: Preserve BCS error in `MoveStruct::to_rust`**
   - Changed return type from `Option<T>` to `Result<T, bcs::Error>`
   - Preserves underlying deserialization error instead of dropping it with `.ok()`

2. **#1117: Unify `ConsensusDeterminedVersionAssignments` helper structs**
   - Removed duplicate `Readable*` and `Binary*` helper enums
   - Reduced from 4 structs to 2 (Ref and Owned) since they now have identical tagging and casing

3. **#1095: Document serde JSON incompatibility**
   - Added explicit note in `lib.rs` that JSON serialization is NOT guaranteed to be consistent with the IOTA monorepo's JSON-RPC format
   - Clarifies that the SDK does not provide a JSON-RPC client

## Additional Changes

- Minor formatting fixes (trailing whitespace removal)

## Related

- Fixes #1122
- Fixes #1117
- Fixes #1095
- Slack thread: https://iotafoundation.slack.com/archives/C041C2EFG6A/p1779294018558339?thread_ts=1779293668.933319&cid=C041C2EFG6A

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvH4DLAqTDAa51ye4no6GM)_