### PR TITLE
fix: preserve BCS error in MoveStruct::to_rust

### DIFF
--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -572,8 +572,8 @@ impl Object {
     }
 
     #[cfg(feature = "serde")]
-    pub fn to_rust<T: serde::de::DeserializeOwned>(
-        &self,
+    pub fn to_rust<'de, T: serde::Deserialize<'de>>(
+        &'de self,
     ) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
         let contents = self.as_struct_opt().ok_or("not a struct")?.contents();
         Ok(bcs::from_bytes::<T>(contents)?)

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -407,8 +407,8 @@ impl MoveStruct {
 
     /// Deserializes the BCS-encoded contents into a Rust type.
     #[cfg(feature = "serde")]
-    pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Option<T> {
-        bcs::from_bytes(self.contents()).ok()
+    pub fn to_rust<'de, T: serde::Deserialize<'de>>(&'de self) -> Result<T, bcs::Error> {
+        bcs::from_bytes(self.contents())
     }
 }
 


### PR DESCRIPTION
Changed `MoveStruct::to_rust()` return type from `Option<T>` to `Result<T, bcs::Error>` to preserve the underlying BCS deserialization error instead of silently dropping it with `.ok()`.

Fixes #1122

Slack thread: https://iotafoundation.slack.com/archives/C041C2EFG6A/p1779296737295369?thread_ts=1779293668.933319&cid=C041C2EFG6A

---
_Generated by [Claude Code](https://claude.ai/code/session_017XKpZdzYuQnboW6uTbGmED)_