### PR TITLE
refactor: unify ConsensusDeterminedVersionAssignments helper structs

### DIFF
--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -262,7 +262,7 @@ mod version_assignments {
 
     #[derive(serde::Serialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum ReadableConsensusDeterminedVersionAssignmentsRef<'a> {
+    enum ConsensusDeterminedVersionAssignmentsRef<'a> {
         CancelledTransactions(&'a Vec<CancelledTransaction>),
     }
 
@@ -270,19 +270,7 @@ mod version_assignments {
     /// ConsensusDeterminedVersionAssignments.
     #[derive(serde::Deserialize)]
     #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum ReadableConsensusDeterminedVersionAssignments {
-        CancelledTransactions(Vec<CancelledTransaction>),
-    }
-
-    #[derive(serde::Serialize)]
-    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum BinaryConsensusDeterminedVersionAssignmentsRef<'a> {
-        CancelledTransactions(&'a Vec<CancelledTransaction>),
-    }
-
-    #[derive(serde::Deserialize)]
-    #[serde(rename = "ConsensusDeterminedVersionAssignments")]
-    enum BinaryConsensusDeterminedVersionAssignments {
+    enum ConsensusDeterminedVersionAssignmentsOwned {
         CancelledTransactions(Vec<CancelledTransaction>),
     }
 
@@ -291,25 +279,14 @@ mod version_assignments {
         where
             S: Serializer,
         {
-            if serializer.is_human_readable() {
-                let readable = match self {
-                    Self::CancelledTransactions {
-                        cancelled_transactions,
-                    } => ReadableConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
-                        cancelled_transactions,
-                    ),
-                };
-                readable.serialize(serializer)
-            } else {
-                let binary = match self {
-                    Self::CancelledTransactions {
-                        cancelled_transactions,
-                    } => BinaryConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
-                        cancelled_transactions,
-                    ),
-                };
-                binary.serialize(serializer)
+            match self {
+                Self::CancelledTransactions {
+                    cancelled_transactions,
+                } => ConsensusDeterminedVersionAssignmentsRef::CancelledTransactions(
+                    cancelled_transactions,
+                ),
             }
+            .serialize(serializer)
         }
     }
 
@@ -318,27 +295,15 @@ mod version_assignments {
         where
             D: Deserializer<'de>,
         {
-            if deserializer.is_human_readable() {
-                ReadableConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
-                    |readable| match readable {
-                        ReadableConsensusDeterminedVersionAssignments::CancelledTransactions(
-                            cancelled_transactions,
-                        ) => Self::CancelledTransactions {
-                            cancelled_transactions,
-                        },
+            ConsensusDeterminedVersionAssignmentsOwned::deserialize(deserializer).map(|owned| {
+                match owned {
+                    ConsensusDeterminedVersionAssignmentsOwned::CancelledTransactions(
+                        cancelled_transactions,
+                    ) => Self::CancelledTransactions {
+                        cancelled_transactions,
                     },
-                )
-            } else {
-                BinaryConsensusDeterminedVersionAssignments::deserialize(deserializer).map(
-                    |binary| match binary {
-                        BinaryConsensusDeterminedVersionAssignments::CancelledTransactions(
-                            cancelled_transactions,
-                        ) => Self::CancelledTransactions {
-                            cancelled_transactions,
-                        },
-                    },
-                )
-            }
+                }
+            })
         }
     }
 


### PR DESCRIPTION
Reduced from 4 helper enums to 2 (Ref and Owned) since readable and binary serialization now have identical tagging and casing. Removed `is_human_readable()` checks from serialize/deserialize implementations.

Fixes #1117

Slack thread: https://iotafoundation.slack.com/archives/C041C2EFG6A/p1779296737295369?thread_ts=1779293668.933319&cid=C041C2EFG6A

---
_Generated by [Claude Code](https://claude.ai/code/session_017XKpZdzYuQnboW6uTbGmED)_