### PR TITLE
chore: document JSON serialization incompatibility with JSON-RPC

### DIFF
--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -19,11 +19,8 @@
 //! Below is a list of the available feature flags.
 //!
 //! - `serde`: Enables support for serializing and deserializing types to/from
-//!   BCS utilizing [serde] library. **Note:** The JSON serialization provided by
-//!   this crate is NOT guaranteed to be consistent with the IOTA monorepo's
-//!   JSON-RPC format. This SDK does not provide a JSON-RPC client, and the
-//!   derived serde implementations are optimized for BCS rather than JSON-RPC
-//!   compatibility.
+//!   BCS utilizing [serde] library. Note: JSON serialization is NOT guaranteed
+//!   to match the IOTA monorepo's JSON-RPC format.
 //! - `rand`: Enables support for generating random instances of a number of
 //!   types via the [rand] library.
 //! - `hash`: Enables support for hashing, which is required for deriving

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -19,7 +19,11 @@
 //! Below is a list of the available feature flags.
 //!
 //! - `serde`: Enables support for serializing and deserializing types to/from
-//!   BCS utilizing [serde] library.
+//!   BCS utilizing [serde] library. **Note:** The JSON serialization provided by
+//!   this crate is NOT guaranteed to be consistent with the IOTA monorepo's
+//!   JSON-RPC format. This SDK does not provide a JSON-RPC client, and the
+//!   derived serde implementations are optimized for BCS rather than JSON-RPC
+//!   compatibility.
 //! - `rand`: Enables support for generating random instances of a number of
 //!   types via the [rand] library.
 //! - `hash`: Enables support for hashing, which is required for deriving


### PR DESCRIPTION
Added explicit note in `lib.rs` that the serde-derived JSON serialization is NOT guaranteed to match the IOTA monorepo's JSON-RPC format. The SDK does not provide a JSON-RPC client, and the serde implementations are optimized for BCS rather than JSON-RPC compatibility.

Fixes #1095

Slack thread: https://iotafoundation.slack.com/archives/C041C2EFG6A/p1779296737295369?thread_ts=1779293668.933319&cid=C041C2EFG6A

---
_Generated by [Claude Code](https://claude.ai/code/session_017XKpZdzYuQnboW6uTbGmED)_