### PR TITLE
chore: more derived traits on `TransactionEvents`

### DIFF
--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -13,7 +13,7 @@ use super::{Address, Identifier, ObjectId, StructTag};
 /// ```text
 /// transaction-events = vector event
 /// ```
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, derive_more::Deref, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/events.rs
+++ b/crates/iota-sdk-types/src/events.rs
@@ -13,7 +13,7 @@ use super::{Address, Identifier, ObjectId, StructTag};
 /// ```text
 /// transaction-events = vector event
 /// ```
-#[derive(Clone, Debug, Default, derive_more::Deref, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, derive_more::Deref, derive_more::DerefMut, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]


### PR DESCRIPTION
## Summary
Adds `Default` and `derive_more::Deref` to `TransactionEvents`. `Default` enables empty construction; `Deref` exposes the inner `Vec<Event>` for slice-like access without an extra accessor.

## Test plan
- [x] `make ci` passes — derives are compiler-checked