### PR TITLE
refactor(graphql-client): reorganize query_types module structure

### DIFF
--- a/crates/iota-sdk-graphql-client/src/api/events.rs
+++ b/crates/iota-sdk-graphql-client/src/api/events.rs
@@ -11,7 +11,7 @@ use crate::{
     Client,
     error::Result,
     pagination::{Direction, Page, PaginationFilter},
-    query_types::{Event, EventFilter, EventsQuery, EventsQueryArgs},
+    query_types::{Event, EventFilter, EventsArgs, EventsQuery},
     streams::stream_paginated_query,
 };
 
@@ -37,7 +37,7 @@ impl Client {
     ) -> Result<Page<Event>> {
         let pagination = self.pagination_filter(pagination_filter).await;
 
-        let operation = EventsQuery::build(EventsQueryArgs {
+        let operation = EventsQuery::build(EventsArgs {
             filter: filter.into(),
             after: pagination.after.as_deref(),
             before: pagination.before.as_deref(),

--- a/crates/iota-sdk-graphql-client/src/api/objects.rs
+++ b/crates/iota-sdk-graphql-client/src/api/objects.rs
@@ -13,7 +13,7 @@ use crate::{
     Client,
     error::Result,
     pagination::{Direction, Page, PaginationFilter},
-    query_types::{ObjectFilter, ObjectQuery, ObjectQueryArgs, ObjectsQuery, ObjectsQueryArgs},
+    query_types::{ObjectArgs, ObjectFilter, ObjectQuery, ObjectsArgs, ObjectsQuery},
     streams::stream_paginated_query,
 };
 
@@ -41,7 +41,7 @@ impl Client {
         object_id: ObjectId,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<Object>> {
-        let operation = ObjectQuery::build(ObjectQueryArgs {
+        let operation = ObjectQuery::build(ObjectArgs {
             object_id,
             version: version.into().map(|v| v.as_u64()),
         });
@@ -83,7 +83,7 @@ impl Client {
         pagination_filter: PaginationFilter,
     ) -> Result<Page<Object>> {
         let pagination = self.pagination_filter(pagination_filter).await;
-        let operation = ObjectsQuery::build(ObjectsQueryArgs {
+        let operation = ObjectsQuery::build(ObjectsArgs {
             after: pagination.after,
             before: pagination.before,
             filter: filter.into(),
@@ -115,7 +115,7 @@ impl Client {
     /// Return the object's bcs content [`Vec<u8>`] based on the provided
     /// [`Address`](iota_types::Address).
     pub async fn object_bcs(&self, object_id: ObjectId) -> Result<Option<Vec<u8>>> {
-        let operation = ObjectQuery::build(ObjectQueryArgs {
+        let operation = ObjectQuery::build(ObjectArgs {
             object_id,
             version: None,
         });
@@ -141,7 +141,7 @@ impl Client {
         object_id: ObjectId,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<serde_json::Value>> {
-        let operation = ObjectQuery::build(ObjectQueryArgs {
+        let operation = ObjectQuery::build(ObjectArgs {
             object_id,
             version: version.into().map(|v| v.as_u64()),
         });
@@ -165,7 +165,7 @@ impl Client {
         object_id: ObjectId,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<Vec<u8>>> {
-        let operation = ObjectQuery::build(ObjectQueryArgs {
+        let operation = ObjectQuery::build(ObjectArgs {
             object_id,
             version: version.into().map(|v| v.as_u64()),
         });

--- a/crates/iota-sdk-graphql-client/src/api/package.rs
+++ b/crates/iota-sdk-graphql-client/src/api/package.rs
@@ -14,9 +14,9 @@ use crate::{
     pagination::PaginationFilter,
     query_types::{
         LatestPackageQuery, MoveFunction, MoveModule, MovePackageVersionFilter,
-        NormalizedMoveFunctionQuery, NormalizedMoveFunctionQueryArgs, NormalizedMoveModuleQuery,
-        NormalizedMoveModuleQueryArgs, PackageArgs, PackageCheckpointFilter, PackageQuery,
-        PackageVersionsArgs, PackageVersionsQuery, PackagesQuery, PackagesQueryArgs,
+        NormalizedMoveFunctionArgs, NormalizedMoveFunctionQuery, NormalizedMoveModuleArgs,
+        NormalizedMoveModuleQuery, PackageArgs, PackageCheckpointFilter, PackageQuery,
+        PackageVersionsArgs, PackageVersionsQuery, PackagesArgs, PackagesQuery,
     },
 };
 
@@ -134,7 +134,7 @@ impl Client {
     ) -> Result<Page<MovePackage>> {
         let pagination = self.pagination_filter(pagination_filter).await;
 
-        let operation = PackagesQuery::build(PackagesQueryArgs {
+        let operation = PackagesQuery::build(PackagesArgs {
             after: pagination.after.as_deref(),
             before: pagination.before.as_deref(),
             first: pagination.first,
@@ -175,7 +175,7 @@ impl Client {
         function: &str,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<MoveFunction>> {
-        let operation = NormalizedMoveFunctionQuery::build(NormalizedMoveFunctionQueryArgs {
+        let operation = NormalizedMoveFunctionQuery::build(NormalizedMoveFunctionArgs {
             address: package,
             module,
             function,
@@ -207,7 +207,7 @@ impl Client {
         let friends = self.pagination_filter(pagination_filter_friends).await;
         let functions = self.pagination_filter(pagination_filter_functions).await;
         let structs = self.pagination_filter(pagination_filter_structs).await;
-        let operation = NormalizedMoveModuleQuery::build(NormalizedMoveModuleQueryArgs {
+        let operation = NormalizedMoveModuleQuery::build(NormalizedMoveModuleArgs {
             package,
             module,
             version: version.into().map(|v| v.as_u64()),

--- a/crates/iota-sdk-graphql-client/src/api/transactions.rs
+++ b/crates/iota-sdk-graphql-client/src/api/transactions.rs
@@ -22,7 +22,7 @@ use crate::{
         ExecuteTransactionArgs, ExecuteTransactionQuery, TransactionBlockArgs,
         TransactionBlockCheckpointQuery, TransactionBlockEffectsQuery,
         TransactionBlockIndexedQuery, TransactionBlockQuery, TransactionBlockWithEffectsQuery,
-        TransactionBlocksEffectsQuery, TransactionBlocksQuery, TransactionBlocksQueryArgs,
+        TransactionBlocksArgs, TransactionBlocksEffectsQuery, TransactionBlocksQuery,
         TransactionBlocksWithEffectsQuery, TransactionsFilter,
     },
     streams::stream_paginated_query,
@@ -77,7 +77,7 @@ impl Client {
     ) -> Result<Page<SignedTransaction>> {
         let pagination = self.pagination_filter(pagination_filter).await;
 
-        let operation = TransactionBlocksQuery::build(TransactionBlocksQueryArgs {
+        let operation = TransactionBlocksQuery::build(TransactionBlocksArgs {
             after: pagination.after,
             before: pagination.before,
             filter: filter.into(),
@@ -119,7 +119,7 @@ impl Client {
     ) -> Result<Page<TransactionEffects>> {
         let pagination = self.pagination_filter(pagination_filter).await;
 
-        let operation = TransactionBlocksEffectsQuery::build(TransactionBlocksQueryArgs {
+        let operation = TransactionBlocksEffectsQuery::build(TransactionBlocksArgs {
             after: pagination.after,
             before: pagination.before,
             filter: filter.into(),
@@ -175,7 +175,7 @@ impl Client {
     ) -> Result<Page<TransactionDataEffects>> {
         let pagination = self.pagination_filter(pagination_filter).await;
 
-        let operation = TransactionBlocksWithEffectsQuery::build(TransactionBlocksQueryArgs {
+        let operation = TransactionBlocksWithEffectsQuery::build(TransactionBlocksArgs {
             after: pagination.after,
             before: pagination.before,
             filter: filter.into(),

--- a/crates/iota-sdk-graphql-client/src/query_types/active_validators.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/active_validators.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{Base64, BigInt, GQLAddress, MoveObject, ObjectId, PageInfo, schema};
@@ -31,7 +31,7 @@ pub struct ActiveValidatorsArgs<'a> {
     variables = "ActiveValidatorsArgs"
 )]
 pub struct EpochValidator {
-    pub validator_set: Option<ValidatorSetQuery>,
+    pub validator_set: Option<ActiveValidatorSet>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
@@ -40,10 +40,16 @@ pub struct EpochValidator {
     graphql_type = "ValidatorSet",
     variables = "ActiveValidatorsArgs"
 )]
-pub struct ValidatorSetQuery {
+pub struct ActiveValidatorSet {
     #[arguments(after: $after, before: $before, first: $first, last: $last)]
     pub active_validators: ValidatorConnection,
 }
+
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `ActiveValidatorSet` for naming consistency (fragments do not carry the `Query` suffix)"
+)]
+pub type ValidatorSetQuery = ActiveValidatorSet;
 
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "ValidatorConnection")]

--- a/crates/iota-sdk-graphql-client/src/query_types/common.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/common.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared scalars and fragments used across multiple query type modules.
+
+use cynic::impl_scalar;
+pub use iota_types::{Address, ObjectId};
+pub use serde_json::Value as JsonValue;
+
+use super::schema;
+use crate::error;
+
+// ===========================================================================
+// Scalars
+// ===========================================================================
+
+impl_scalar!(Address, schema::IotaAddress);
+impl_scalar!(ObjectId, schema::IotaAddress);
+impl_scalar!(u64, schema::UInt53);
+impl_scalar!(JsonValue, schema::JSON);
+
+#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
+#[cynic(graphql_type = "Base64")]
+pub struct Base64(pub String);
+
+#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
+#[cynic(graphql_type = "BigInt")]
+pub struct BigInt(pub String);
+
+#[derive(Clone, cynic::Scalar, Debug)]
+#[cynic(graphql_type = "DateTime")]
+pub struct DateTime(pub String);
+
+#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
+#[cynic(graphql_type = "MoveData")]
+pub struct MoveData(pub serde_json::Value);
+
+// ===========================================================================
+// Types used in several queries
+// ===========================================================================
+
+#[derive(Clone, Copy, cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "Address")]
+pub struct GQLAddress {
+    pub address: Address,
+}
+
+#[derive(Clone, cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveObject")]
+pub struct MoveObject {
+    pub bcs: Option<Base64>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveObject")]
+pub struct MoveObjectContents {
+    pub contents: Option<MoveValue>,
+}
+
+#[derive(cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveValue")]
+pub struct MoveValue {
+    pub type_: MoveType,
+    pub bcs: Base64,
+    pub json: Option<JsonValue>,
+}
+
+#[derive(Clone, cynic::QueryFragment, Debug)]
+#[cynic(schema = "rpc", graphql_type = "MoveType")]
+pub struct MoveType {
+    pub repr: String,
+}
+
+// ===========================================================================
+// Utility Types
+// ===========================================================================
+
+#[derive(Clone, cynic::QueryFragment, Debug, Default)]
+#[cynic(schema = "rpc", graphql_type = "PageInfo")]
+/// Information about pagination in a connection.
+pub struct PageInfo {
+    /// When paginating backwards, are there more items?
+    pub has_previous_page: bool,
+    /// Are there more items when paginating forwards?
+    pub has_next_page: bool,
+    /// When paginating backwards, the cursor to continue.
+    pub start_cursor: Option<String>,
+    /// When paginating forwards, the cursor to continue.
+    pub end_cursor: Option<String>,
+}
+
+impl TryFrom<BigInt> for u64 {
+    type Error = error::Error;
+
+    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
+        Ok(value.0.parse::<u64>()?)
+    }
+}

--- a/crates/iota-sdk-graphql-client/src/query_types/events.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/events.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{
@@ -12,24 +12,30 @@ use crate::query_types::{
 // ===========================================================================
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "Query", variables = "EventsQueryArgs")]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "EventsArgs")]
 pub struct EventsQuery {
     #[arguments(after: $after, before: $before, filter: $filter, first: $first, last: $last)]
     pub events: EventConnection,
 }
 
 // ===========================================================================
-// Events Query Args
+// Events Args
 // ===========================================================================
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct EventsQueryArgs<'a> {
+pub struct EventsArgs<'a> {
     pub filter: Option<EventFilter>,
     pub after: Option<&'a str>,
     pub before: Option<&'a str>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }
+
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `EventsArgs` for naming consistency"
+)]
+pub type EventsQueryArgs<'a> = EventsArgs<'a>;
 
 // ===========================================================================
 // Events Types

--- a/crates/iota-sdk-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/mod.rs
@@ -22,9 +22,11 @@ mod protocol_config;
 mod service_config;
 mod transaction;
 
+#[allow(deprecated)]
+pub use active_validators::ValidatorSetQuery;
 pub use active_validators::{
-    ActiveValidatorsArgs, ActiveValidatorsQuery, EpochValidator, Validator, ValidatorConnection,
-    ValidatorCredentials, ValidatorSetQuery,
+    ActiveValidatorSet, ActiveValidatorsArgs, ActiveValidatorsQuery, EpochValidator, Validator,
+    ValidatorConnection, ValidatorCredentials,
 };
 pub use balance::{Balance, BalanceArgs, BalanceQuery, Owner};
 pub use chain::ChainIdentifierQuery;

--- a/crates/iota-sdk-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/mod.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 mod active_validators;
@@ -7,6 +7,7 @@ mod balance;
 mod chain;
 mod checkpoint;
 mod coin;
+mod common;
 mod dry_run;
 mod dynamic_fields;
 mod epoch;
@@ -32,7 +33,10 @@ pub use checkpoint::{
     CheckpointsQuery,
 };
 pub use coin::{CoinMetadata, CoinMetadataArgs, CoinMetadataQuery};
-use cynic::impl_scalar;
+pub use common::{
+    Address, Base64, BigInt, DateTime, GQLAddress, JsonValue, MoveData, MoveObject,
+    MoveObjectContents, MoveType, MoveValue, ObjectId, PageInfo,
+};
 pub use dry_run::{
     DryRunArgs, DryRunEffect, DryRunMutation, DryRunQuery, DryRunResult, DryRunReturn, GasCoin,
     Input, ObjectRef, ResultArg, TransactionArgument, TransactionMetadata,
@@ -50,7 +54,6 @@ pub use iota_names::{
     NameRegistration, NameRegistrationConnection, ResolveIotaNamesAddressArgs,
     ResolveIotaNamesAddressQuery,
 };
-use iota_types::{Address, ObjectId};
 pub use move_view_call::{MoveViewCallArgs, MoveViewCallQuery, MoveViewResult};
 pub use normalized_move::{
     MoveAbility, MoveEnum, MoveEnumConnection, MoveEnumVariant, MoveField, MoveFunction,
@@ -71,7 +74,6 @@ pub use protocol_config::{
     ProtocolConfigAttr, ProtocolConfigFeatureFlag, ProtocolConfigQuery, ProtocolConfigs,
     ProtocolVersionArgs,
 };
-use serde_json::Value as JsonValue;
 pub use service_config::{Feature, ServiceConfig, ServiceConfigQuery};
 pub use transaction::{
     TransactionBlock, TransactionBlockArgs, TransactionBlockCheckpointQuery,
@@ -81,94 +83,5 @@ pub use transaction::{
     TransactionBlocksWithEffectsQuery, TransactionsFilter,
 };
 
-use crate::error;
-
 #[cynic::schema("rpc")]
 pub mod schema {}
-
-// ===========================================================================
-// Scalars
-// ===========================================================================
-
-impl_scalar!(Address, schema::IotaAddress);
-impl_scalar!(ObjectId, schema::IotaAddress);
-impl_scalar!(u64, schema::UInt53);
-impl_scalar!(JsonValue, schema::JSON);
-
-#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
-#[cynic(graphql_type = "Base64")]
-pub struct Base64(pub String);
-
-#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
-#[cynic(graphql_type = "BigInt")]
-pub struct BigInt(pub String);
-
-#[derive(Clone, cynic::Scalar, Debug)]
-#[cynic(graphql_type = "DateTime")]
-pub struct DateTime(pub String);
-
-#[derive(Clone, cynic::Scalar, Debug, derive_more::From)]
-#[cynic(graphql_type = "MoveData")]
-pub struct MoveData(pub serde_json::Value);
-
-// ===========================================================================
-// Types used in several queries
-// ===========================================================================
-
-#[derive(Clone, Copy, cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "Address")]
-pub struct GQLAddress {
-    pub address: Address,
-}
-
-#[derive(Clone, cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveObject")]
-pub struct MoveObject {
-    pub bcs: Option<Base64>,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveObject")]
-pub struct MoveObjectContents {
-    pub contents: Option<MoveValue>,
-}
-
-#[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveValue")]
-pub struct MoveValue {
-    pub type_: MoveType,
-    pub bcs: Base64,
-    pub json: Option<JsonValue>,
-}
-
-#[derive(Clone, cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "MoveType")]
-pub struct MoveType {
-    pub repr: String,
-}
-
-// ===========================================================================
-// Utility Types
-// ===========================================================================
-
-#[derive(Clone, cynic::QueryFragment, Debug, Default)]
-#[cynic(schema = "rpc", graphql_type = "PageInfo")]
-/// Information about pagination in a connection.
-pub struct PageInfo {
-    /// When paginating backwards, are there more items?
-    pub has_previous_page: bool,
-    /// Are there more items when paginating forwards?
-    pub has_next_page: bool,
-    /// When paginating backwards, the cursor to continue.
-    pub start_cursor: Option<String>,
-    /// When paginating forwards, the cursor to continue.
-    pub end_cursor: Option<String>,
-}
-
-impl TryFrom<BigInt> for u64 {
-    type Error = error::Error;
-
-    fn try_from(value: BigInt) -> Result<Self, Self::Error> {
-        Ok(value.0.parse::<u64>()?)
-    }
-}

--- a/crates/iota-sdk-graphql-client/src/query_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/mod.rs
@@ -48,7 +48,9 @@ pub use dynamic_fields::{
     DynamicFieldsOwnerQuery, DynamicObjectFieldQuery,
 };
 pub use epoch::{Epoch, EpochArgs, EpochQuery, EpochSummaryQuery, ValidatorSet};
-pub use events::{Event, EventConnection, EventFilter, EventsQuery, EventsQueryArgs};
+#[allow(deprecated)]
+pub use events::EventsQueryArgs;
+pub use events::{Event, EventConnection, EventFilter, EventsArgs, EventsQuery};
 pub use execute_tx::{ExecuteTransactionArgs, ExecuteTransactionQuery, ExecutionResult};
 pub use iota_names::{
     IotaNamesAddressDefaultNameQuery, IotaNamesAddressRegistrationsQuery, IotaNamesDefaultNameArgs,
@@ -61,27 +63,33 @@ pub use normalized_move::{
     MoveAbility, MoveEnum, MoveEnumConnection, MoveEnumVariant, MoveField, MoveFunction,
     MoveFunctionConnection, MoveFunctionTypeParameter, MoveModule, MoveModuleConnection,
     MoveModuleQuery, MoveStructConnection, MoveStructQuery, MoveStructTypeParameter,
-    MoveVisibility, NormalizedMoveFunctionQuery, NormalizedMoveFunctionQueryArgs,
-    NormalizedMoveModuleQuery, NormalizedMoveModuleQueryArgs, OpenMoveType,
+    MoveVisibility, NormalizedMoveFunctionArgs, NormalizedMoveFunctionQuery,
+    NormalizedMoveModuleArgs, NormalizedMoveModuleQuery, OpenMoveType,
 };
-pub use object::{
-    ObjectFilter, ObjectKey, ObjectQuery, ObjectQueryArgs, ObjectsQuery, ObjectsQueryArgs,
-};
+#[allow(deprecated)]
+pub use normalized_move::{NormalizedMoveFunctionQueryArgs, NormalizedMoveModuleQueryArgs};
+pub use object::{ObjectArgs, ObjectFilter, ObjectKey, ObjectQuery, ObjectsArgs, ObjectsQuery};
+#[allow(deprecated)]
+pub use object::{ObjectQueryArgs, ObjectsQueryArgs};
+#[allow(deprecated)]
+pub use packages::PackagesQueryArgs;
 pub use packages::{
     LatestPackageQuery, MovePackageConnection, MovePackageQuery, MovePackageVersionFilter,
     PackageArgs, PackageCheckpointFilter, PackageQuery, PackageVersionsArgs, PackageVersionsQuery,
-    PackagesQuery, PackagesQueryArgs,
+    PackagesArgs, PackagesQuery,
 };
 pub use protocol_config::{
     ProtocolConfigAttr, ProtocolConfigFeatureFlag, ProtocolConfigQuery, ProtocolConfigs,
     ProtocolVersionArgs,
 };
 pub use service_config::{Feature, ServiceConfig, ServiceConfigQuery};
+#[allow(deprecated)]
+pub use transaction::TransactionBlocksQueryArgs;
 pub use transaction::{
     TransactionBlock, TransactionBlockArgs, TransactionBlockCheckpointQuery,
     TransactionBlockEffectsQuery, TransactionBlockIndexedQuery, TransactionBlockKindInput,
     TransactionBlockQuery, TransactionBlockWithEffects, TransactionBlockWithEffectsQuery,
-    TransactionBlocksEffectsQuery, TransactionBlocksQuery, TransactionBlocksQueryArgs,
+    TransactionBlocksArgs, TransactionBlocksEffectsQuery, TransactionBlocksQuery,
     TransactionBlocksWithEffectsQuery, TransactionsFilter,
 };
 

--- a/crates/iota-sdk-graphql-client/src/query_types/normalized_move/function.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/normalized_move/function.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{Address, MoveFunction, schema};
@@ -8,7 +8,7 @@ use crate::query_types::{Address, MoveFunction, schema};
 #[cynic(
     schema = "rpc",
     graphql_type = "Query",
-    variables = "NormalizedMoveFunctionQueryArgs"
+    variables = "NormalizedMoveFunctionArgs"
 )]
 pub struct NormalizedMoveFunctionQuery {
     #[arguments(address: $address, version: $version)]
@@ -16,18 +16,24 @@ pub struct NormalizedMoveFunctionQuery {
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct NormalizedMoveFunctionQueryArgs<'a> {
+pub struct NormalizedMoveFunctionArgs<'a> {
     pub address: Address,
     pub version: Option<u64>,
     pub module: &'a str,
     pub function: &'a str,
 }
 
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `NormalizedMoveFunctionArgs` for naming consistency"
+)]
+pub type NormalizedMoveFunctionQueryArgs<'a> = NormalizedMoveFunctionArgs<'a>;
+
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(
     schema = "rpc",
     graphql_type = "MovePackage",
-    variables = "NormalizedMoveFunctionQueryArgs"
+    variables = "NormalizedMoveFunctionArgs"
 )]
 pub struct MovePackage {
     #[arguments(name: $module)]
@@ -38,7 +44,7 @@ pub struct MovePackage {
 #[cynic(
     schema = "rpc",
     graphql_type = "MoveModule",
-    variables = "NormalizedMoveFunctionQueryArgs"
+    variables = "NormalizedMoveFunctionArgs"
 )]
 pub struct MoveModule {
     #[arguments(name: $function)]

--- a/crates/iota-sdk-graphql-client/src/query_types/normalized_move/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/normalized_move/mod.rs
@@ -1,15 +1,19 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 mod function;
 mod module;
 
-pub use function::{NormalizedMoveFunctionQuery, NormalizedMoveFunctionQueryArgs};
+#[allow(deprecated)]
+pub use function::NormalizedMoveFunctionQueryArgs;
+pub use function::{NormalizedMoveFunctionArgs, NormalizedMoveFunctionQuery};
+#[allow(deprecated)]
+pub use module::NormalizedMoveModuleQueryArgs;
 pub use module::{
     MoveEnum, MoveEnumConnection, MoveEnumVariant, MoveField, MoveFunctionConnection, MoveModule,
     MoveModuleConnection, MoveModuleQuery, MoveStructConnection, MoveStructQuery,
-    MoveStructTypeParameter, NormalizedMoveModuleQuery, NormalizedMoveModuleQueryArgs,
+    MoveStructTypeParameter, NormalizedMoveModuleArgs, NormalizedMoveModuleQuery,
 };
 
 use crate::query_types::schema;

--- a/crates/iota-sdk-graphql-client/src/query_types/normalized_move/module.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/normalized_move/module.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{
@@ -10,7 +10,7 @@ use crate::query_types::{
 #[cynic(
     schema = "rpc",
     graphql_type = "Query",
-    variables = "NormalizedMoveModuleQueryArgs"
+    variables = "NormalizedMoveModuleArgs"
 )]
 pub struct NormalizedMoveModuleQuery {
     #[arguments(address: $package, version: $version)]
@@ -18,7 +18,7 @@ pub struct NormalizedMoveModuleQuery {
 }
 
 #[derive(Clone, cynic::QueryVariables, Debug)]
-pub struct NormalizedMoveModuleQueryArgs<'a> {
+pub struct NormalizedMoveModuleArgs<'a> {
     pub package: Address,
     pub module: &'a str,
     pub version: Option<u64>,
@@ -40,11 +40,17 @@ pub struct NormalizedMoveModuleQueryArgs<'a> {
     pub last_friends: Option<i32>,
 }
 
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `NormalizedMoveModuleArgs` for naming consistency"
+)]
+pub type NormalizedMoveModuleQueryArgs<'a> = NormalizedMoveModuleArgs<'a>;
+
 #[derive(Clone, cynic::QueryFragment, Debug)]
 #[cynic(
     schema = "rpc",
     graphql_type = "MovePackage",
-    variables = "NormalizedMoveModuleQueryArgs"
+    variables = "NormalizedMoveModuleArgs"
 )]
 pub struct MovePackage {
     #[arguments(name: $module)]
@@ -55,7 +61,7 @@ pub struct MovePackage {
 #[cynic(
     schema = "rpc",
     graphql_type = "MoveModule",
-    variables = "NormalizedMoveModuleQueryArgs"
+    variables = "NormalizedMoveModuleArgs"
 )]
 pub struct MoveModule {
     pub file_format_version: i32,

--- a/crates/iota-sdk-graphql-client/src/query_types/object.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/object.rs
@@ -1,5 +1,5 @@
 // Copyright (c) Mysten Labs, Inc.
-// Modifications Copyright (c) 2025 IOTA Stiftung
+// Modifications Copyright (c) 2025-2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::query_types::{Address, Base64, MoveObjectContents, ObjectId, PageInfo, schema};
@@ -9,37 +9,48 @@ use crate::query_types::{Address, Base64, MoveObjectContents, ObjectId, PageInfo
 // ===========================================================================
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "Query", variables = "ObjectQueryArgs")]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "ObjectArgs")]
 pub struct ObjectQuery {
     #[arguments(address: $object_id, version: $version)]
     pub object: Option<Object>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]
-#[cynic(schema = "rpc", graphql_type = "Query", variables = "ObjectsQueryArgs")]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "ObjectsArgs")]
 pub struct ObjectsQuery {
     #[arguments(after: $after, before: $before, filter: $filter, first: $first, last: $last)]
     pub objects: ObjectConnection,
 }
 
 // ===========================================================================
-// Object(s) Query Args
+// Object(s) Args
 // ===========================================================================
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct ObjectQueryArgs {
+pub struct ObjectArgs {
     pub object_id: ObjectId,
     pub version: Option<u64>,
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct ObjectsQueryArgs {
+pub struct ObjectsArgs {
     pub after: Option<String>,
     pub before: Option<String>,
     pub filter: Option<ObjectFilter>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }
+
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `ObjectArgs` for naming consistency"
+)]
+pub type ObjectQueryArgs = ObjectArgs;
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `ObjectsArgs` for naming consistency"
+)]
+pub type ObjectsQueryArgs = ObjectsArgs;
 
 // ===========================================================================
 // Object(s) Types

--- a/crates/iota-sdk-graphql-client/src/query_types/packages.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/packages.rs
@@ -46,24 +46,26 @@ pub struct MovePackageQuery {
 // ===========================================================================
 
 #[derive(Clone, cynic::QueryFragment, Debug)]
-#[cynic(
-    schema = "rpc",
-    graphql_type = "Query",
-    variables = "PackagesQueryArgs"
-)]
+#[cynic(schema = "rpc", graphql_type = "Query", variables = "PackagesArgs")]
 pub struct PackagesQuery {
     #[arguments(after: $after, before: $before, filter: $filter, first: $first, last: $last)]
     pub packages: MovePackageConnection,
 }
 
 #[derive(Clone, cynic::QueryVariables, Debug)]
-pub struct PackagesQueryArgs<'a> {
+pub struct PackagesArgs<'a> {
     pub after: Option<&'a str>,
     pub before: Option<&'a str>,
     pub filter: Option<PackageCheckpointFilter>,
     pub first: Option<i32>,
     pub last: Option<i32>,
 }
+
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `PackagesArgs` for naming consistency"
+)]
+pub type PackagesQueryArgs<'a> = PackagesArgs<'a>;
 
 #[derive(Clone, cynic::InputObject, Debug)]
 #[cynic(schema = "rpc", graphql_type = "MovePackageCheckpointFilter")]

--- a/crates/iota-sdk-graphql-client/src/query_types/transaction.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/transaction.rs
@@ -75,7 +75,7 @@ pub struct TransactionBlockIndexedQuery {
 #[cynic(
     schema = "rpc",
     graphql_type = "Query",
-    variables = "TransactionBlocksQueryArgs"
+    variables = "TransactionBlocksArgs"
 )]
 pub struct TransactionBlocksQuery {
     #[arguments(first: $first, after: $after, last: $last, before: $before, filter: $filter)]
@@ -86,7 +86,7 @@ pub struct TransactionBlocksQuery {
 #[cynic(
     schema = "rpc",
     graphql_type = "Query",
-    variables = "TransactionBlocksQueryArgs"
+    variables = "TransactionBlocksArgs"
 )]
 pub struct TransactionBlocksWithEffectsQuery {
     #[arguments(first: $first, after: $after, last: $last, before: $before, filter: $filter)]
@@ -97,7 +97,7 @@ pub struct TransactionBlocksWithEffectsQuery {
 #[cynic(
     schema = "rpc",
     graphql_type = "Query",
-    variables = "TransactionBlocksQueryArgs"
+    variables = "TransactionBlocksArgs"
 )]
 pub struct TransactionBlocksEffectsQuery {
     #[arguments(first: $first, after: $after, last: $last, before: $before, filter: $filter)]
@@ -113,13 +113,19 @@ pub struct TransactionBlockArgs {
 }
 
 #[derive(cynic::QueryVariables, Debug)]
-pub struct TransactionBlocksQueryArgs {
+pub struct TransactionBlocksArgs {
     pub first: Option<i32>,
     pub after: Option<String>,
     pub last: Option<i32>,
     pub before: Option<String>,
     pub filter: Option<TransactionsFilter>,
 }
+
+#[deprecated(
+    since = "0.0.2",
+    note = "renamed to `TransactionBlocksArgs` for naming consistency"
+)]
+pub type TransactionBlocksQueryArgs = TransactionBlocksArgs;
 
 // ===========================================================================
 // Transaction Block(s) Types


### PR DESCRIPTION
Resolves #512. Builds on @MrSufferer's prior work in #1057.

Addresses the reviewer feedback that stalled #1057 (the `Lookup` suffix, `ExecuteTransactionMutationArgs` inconsistency, `active_validators.rs` consistency, copyright dates, the policy script). Renames are public-API-safe via `#[deprecated]` aliases — no breaking changes per `CLAUDE.md` rule #1.

## What changed

- **Extract `common.rs`** — pull shared scalars (`Base64`, `BigInt`, `DateTime`, `MoveData`) and cross-cutting fragments (`GQLAddress`, `MoveObject`, `MoveObjectContents`, `MoveValue`, `MoveType`, `PageInfo`) out of `query_types/mod.rs` into a dedicated module.
- **Rename `ValidatorSetQuery` → `ActiveValidatorSet`** — fragment projections do not carry the `Query` suffix; `ValidatorSet` itself is reserved for the canonical projection in `epoch.rs`. Addresses *"No consistency?"* on `active_validators.rs:57`.
- **Standardize `*Args` suffix** for cynic `QueryVariables` structs — 18 of 25 types already used plain `*Args`; renames the remaining 7 (`EventsQueryArgs`, `ObjectQueryArgs`, `ObjectsQueryArgs`, `PackagesQueryArgs`, `TransactionBlocksQueryArgs`, `NormalizedMoveFunctionQueryArgs`, `NormalizedMoveModuleQueryArgs`) to match. Addresses the *"`ExecuteTransactionMutationArgs` is inconsistent with the rest of the `QueryArgs`"* review on PR #1057.

All renamed types are kept as `#[deprecated]` type aliases so existing downstream code continues to compile with a warning.

## Key design decisions (pre-flagged)

- **`*Args` over `*QueryArgs`** — picked the majority (18 vs 7) to maximize "no churn" for existing users. Open to flipping the other way if @DaughterOfMars prefers.
- **Kept `NormalizedMove*` prefix** — mirrors the GraphQL schema verbatim. PR #1057 renamed to `MoveSchema*`; happy to flip if preferred, but the default here is "minimal rename surface".
- **No `Lookup` suffix introduced** — per the *"Do we really need the `Lookup` suffix?"* feedback on PR #1057.
- **Deprecation aliases everywhere** — no hard breaks; one release cycle of warnings before any removal.

## Out of scope (separate follow-up PRs)

- FFI mirror in `iota-sdk-ffi` (next PR after this lands)
- Bindings regeneration
- CI naming-policy script (per *"What is this?"* on PR #1057, dropped)
- `TransactionsFilter` → `TransactionBlockFilter` (touches 60+ binding call sites — belongs in the FFI/bindings PR)
- `execute_tx.rs` merge into `transaction.rs` (collision on `TransactionBlockEffects` field types; needs schema-compat work)
- `docs/ai/` folder, `iota-sdk-ffi/Cargo.toml` — both rejected on PR #1057

## Verification

- `cargo check -p iota-sdk-graphql-client -p iota-sdk-ffi -p iota-sdk --all-features --all-targets`
- `cargo clippy -p iota-sdk-graphql-client --all-features --all-targets -- -D warnings`
- `cargo +nightly fmt -p iota-sdk-graphql-client -- --check`