### PR TITLE
feat(graphql)!: remove transaction signer filters

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/query_types.rs
+++ b/crates/iota-sdk-ffi/src/graphql/query_types.rs
@@ -113,7 +113,7 @@ pub struct TransactionsFilter {
     #[uniffi(default = None)]
     pub before_checkpoint: Option<u64>,
     #[uniffi(default = None)]
-    pub sign_address: Option<Arc<Address>>,
+    pub sent_address: Option<Arc<Address>>,
     #[uniffi(default = None)]
     pub recv_address: Option<Arc<Address>>,
     #[uniffi(default = None)]
@@ -134,7 +134,7 @@ impl From<iota_sdk::graphql_client::query_types::TransactionsFilter> for Transac
             after_checkpoint: value.after_checkpoint,
             at_checkpoint: value.at_checkpoint,
             before_checkpoint: value.before_checkpoint,
-            sign_address: value.sign_address.map(Into::into).map(Arc::new),
+            sent_address: value.sent_address.map(Into::into).map(Arc::new),
             recv_address: value.recv_address.map(Into::into).map(Arc::new),
             input_object: value.input_object.map(Into::into).map(Arc::new),
             changed_object: value.changed_object.map(Into::into).map(Arc::new),
@@ -155,7 +155,7 @@ impl From<TransactionsFilter> for iota_sdk::graphql_client::query_types::Transac
             after_checkpoint: value.after_checkpoint,
             at_checkpoint: value.at_checkpoint,
             before_checkpoint: value.before_checkpoint,
-            sign_address: value.sign_address.map(|v| **v),
+            sent_address: value.sent_address.map(|v| **v),
             recv_address: value.recv_address.map(|v| **v),
             input_object: value.input_object.map(|v| **v),
             changed_object: value.changed_object.map(|v| **v),

--- a/crates/iota-sdk-graphql-client-build/schema.graphql
+++ b/crates/iota-sdk-graphql-client-build/schema.graphql
@@ -149,18 +149,6 @@ The possible relationship types for a transaction block: sent or received.
 """
 enum AddressTransactionBlockRelationship {
   """
-  Transactions this address has sent. NOTE: this input filter has been
-  deprecated in favor of `SENT` which behaves identically but is named
-  more clearly. Both filters restrict transactions by their sender,
-  only, not signers in general.
-
-  This filter will be removed after 6 months with the 1.24.0 release.
-  """
-  SIGN
-    @deprecated(
-      reason: "Misleading semantics. Use `SENT` instead. This will be removed with the 1.24.0 release."
-    )
-  """
   Transactions this address has sent.
   """
   SENT
@@ -4796,16 +4784,46 @@ type Subscription {
   Subscribe to incoming transactions from the IOTA network.
 
   If no filter is provided, all transactions will be returned.
+
+  # Stream recovery
+
+  When `start_after` is provided with the digest of the last transaction
+  the client received, the stream resumes from the transaction
+  immediately after it. The identified transaction itself is not
+  emitted.
   """
   transactions(
+    startAfter: String
     filter: SubscriptionTransactionFilter
   ): TransactionBlockSubscriptionPayload!
   """
   Subscribe to incoming events from the IOTA network.
 
   If no filter is provided, all events will be returned.
+
+  # Stream recovery
+
+  Events are streamed in transaction order, all events from a single
+  transaction arrive contiguously before any events from the next one.
+
+  When `start_after` is provided with a transaction digest, the stream
+  resumes from the transaction immediately after it.
+
+  Because a single transaction can emit multiple events, a disconnection
+  may leave the client with only a partial set of events from the
+  transaction it was last receiving. A transaction is considered fully
+  received only once the client has seen an event from the following
+  transaction (a digest change signals the previous transaction is
+  complete).
+
+  On reconnect, clients should pass the digest of the last fully
+  received transaction as `start_after`. The stream resumes from the
+  next transaction, so no partial transaction is ever observed.
   """
-  events(filter: SubscriptionEventFilter): EventSubscriptionPayload!
+  events(
+    startAfter: String
+    filter: SubscriptionEventFilter
+  ): EventSubscriptionPayload!
 }
 
 """
@@ -5100,18 +5118,6 @@ input TransactionBlockFilter {
   Limit to transaction that occurred strictly before the given checkpoint.
   """
   beforeCheckpoint: UInt53
-  """
-  Limit to transactions that were sent by the given address. NOTE: this
-  input filter has been deprecated in favor of `sentAddress` which has
-  clearer semantics. Both filters restrict transactions by their sender,
-  only, not signers in general.
-
-  This filter will be removed after 6 months with the 1.24.0 release.
-  """
-  signAddress: IotaAddress
-    @deprecated(
-      reason: "Misleading semantics. Use `sentAddress` instead. This will be removed with the 1.24.0 release."
-    )
   """
   Limit to transactions that were sent by the given address.
   """

--- a/crates/iota-sdk-graphql-client/src/query_types/transaction.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/transaction.rs
@@ -188,7 +188,7 @@ pub struct TransactionsFilter {
     pub after_checkpoint: Option<u64>,
     pub at_checkpoint: Option<u64>,
     pub before_checkpoint: Option<u64>,
-    pub sign_address: Option<Address>,
+    pub sent_address: Option<Address>,
     pub recv_address: Option<Address>,
     pub input_object: Option<ObjectId>,
     pub changed_object: Option<ObjectId>,

--- a/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
+++ b/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
@@ -193,7 +193,7 @@ impl Indexer {
 
         let tx_filter = TransactionsFilter {
             function: self.config.filters.derived_tx_function(),
-            sign_address: self.config.filters.tx_sender,
+            sent_address: self.config.filters.tx_sender,
             after_checkpoint: range_start.checked_sub(1),
             before_checkpoint: Some(range_end.saturating_add(1)),
             ..Default::default()
@@ -323,7 +323,7 @@ impl Indexer {
 
         let tx_filter = TransactionsFilter {
             function: self.config.filters.tx_function.clone(),
-            sign_address: self.config.filters.tx_sender,
+            sent_address: self.config.filters.tx_sender,
             after_checkpoint: sequence.checked_sub(1),
             before_checkpoint: Some(sequence.saturating_add(1)),
             ..Default::default()


### PR DESCRIPTION
## Summary

https://github.com/iotaledger/iota/issues/9255

The GraphQL schema dropped the deprecated `signAddress` transaction filter (and `SIGN` relationship enum) in favor of `sentAddress` / `SENT`. This refreshes the bundled schema and renames the corresponding Rust field on `TransactionsFilter` from `sign_address` to `sent_address`, plus the same rename in the FFI mirror and the `polling-indexer` example.

Breaking change: callers using `TransactionsFilter::sign_address` must rename to `sent_address`. Semantics are unchanged — both always filtered by sender only.

The schema sync also brings in `startAfter` parameters on the `transactions` / `events` subscriptions, but those are not surfaced through any Rust API in this PR.

## Test plan
- [x] `make ci` passes