### PR TITLE
feat!: separate Event and GraphQlEvent types

### DIFF
--- a/bindings/csharp/examples/PackageEvents/Program.cs
+++ b/bindings/csharp/examples/PackageEvents/Program.cs
@@ -16,8 +16,8 @@ class Program
 
         foreach (var evt in events.data)
         {
-            // Sender and module are optional: system events (e.g.
-            // 0x3::validator::StakingRequestEvent) have neither.
+            // Sender and module are optional: events emitted by the system or at
+            // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
             Console.WriteLine($"Type: {evt.@type}");
             Console.WriteLine($"Sender: {evt.sender?.ToHex() ?? "none"}");
             Console.WriteLine($"Module: {evt.module ?? "none"}");

--- a/bindings/csharp/examples/PackageEvents/Program.cs
+++ b/bindings/csharp/examples/PackageEvents/Program.cs
@@ -16,8 +16,8 @@ class Program
 
         foreach (var evt in events.data)
         {
-            // Sender and module are optional: events emitted by the system or at
-            // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
+            // Sender and module are optional: some events (such as system- or
+            // genesis-emitted ones) carry neither.
             Console.WriteLine($"Type: {evt.@type}");
             Console.WriteLine($"Sender: {evt.sender?.ToHex() ?? "none"}");
             Console.WriteLine($"Module: {evt.module ?? "none"}");

--- a/bindings/csharp/examples/PackageEvents/Program.cs
+++ b/bindings/csharp/examples/PackageEvents/Program.cs
@@ -16,9 +16,11 @@ class Program
 
         foreach (var evt in events.data)
         {
+            // Sender and module are optional: system events (e.g.
+            // 0x3::validator::StakingRequestEvent) have neither.
             Console.WriteLine($"Type: {evt.@type}");
-            Console.WriteLine($"Sender: {evt.sender.ToHex()}");
-            Console.WriteLine($"Module: {evt.module}");
+            Console.WriteLine($"Sender: {evt.sender?.ToHex() ?? "none"}");
+            Console.WriteLine($"Module: {evt.module ?? "none"}");
             Console.WriteLine($"JSON: {evt.json}");
         }
     }

--- a/bindings/go/examples/package_events/main.go
+++ b/bindings/go/examples/package_events/main.go
@@ -32,8 +32,8 @@ func main() {
 	}
 
 	for _, event := range events.Data {
-		// Sender and Module are optional: events emitted by the system or at
-		// genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
+		// Sender and Module are optional: some events (such as system- or
+		// genesis-emitted ones) carry neither.
 		sender := "none"
 		if event.Sender != nil {
 			sender = event.Sender.ToHex()

--- a/bindings/go/examples/package_events/main.go
+++ b/bindings/go/examples/package_events/main.go
@@ -32,9 +32,19 @@ func main() {
 	}
 
 	for _, event := range events.Data {
+		// Sender and Module are optional: system events (e.g.
+		// 0x3::validator::StakingRequestEvent) have neither.
+		sender := "none"
+		if event.Sender != nil {
+			sender = event.Sender.ToHex()
+		}
+		module := "none"
+		if event.Module != nil {
+			module = *event.Module
+		}
 		fmt.Println("Type: ", event.Type)
-		fmt.Println("Sender: ", event.Sender.ToHex())
-		fmt.Println("Module: ", event.Module)
+		fmt.Println("Sender: ", sender)
+		fmt.Println("Module: ", module)
 		fmt.Println("JSON: ", event.Json)
 	}
 }

--- a/bindings/go/examples/package_events/main.go
+++ b/bindings/go/examples/package_events/main.go
@@ -36,7 +36,7 @@ func main() {
 		// genesis-emitted ones) carry neither.
 		sender := "none"
 		if event.Sender != nil {
-			sender = event.Sender.ToHex()
+			sender = (*event.Sender).ToHex()
 		}
 		module := "none"
 		if event.Module != nil {

--- a/bindings/go/examples/package_events/main.go
+++ b/bindings/go/examples/package_events/main.go
@@ -32,8 +32,8 @@ func main() {
 	}
 
 	for _, event := range events.Data {
-		// Sender and Module are optional: system events (e.g.
-		// 0x3::validator::StakingRequestEvent) have neither.
+		// Sender and Module are optional: events emitted by the system or at
+		// genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
 		sender := "none"
 		if event.Sender != nil {
 			sender = event.Sender.ToHex()

--- a/bindings/kotlin/examples/PackageEvents.kt
+++ b/bindings/kotlin/examples/PackageEvents.kt
@@ -22,8 +22,8 @@ fun main() = runBlocking {
             )
 
         for (event in events.data) {
-            // Sender and module are optional: system events (e.g.
-            // 0x3::validator::StakingRequestEvent) have neither.
+            // Sender and module are optional: events emitted by the system or at
+            // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
             println("Type: ${event.type}")
             println("Sender: ${event.sender?.toHex() ?: "none"}")
             println("Module: ${event.module ?: "none"}")

--- a/bindings/kotlin/examples/PackageEvents.kt
+++ b/bindings/kotlin/examples/PackageEvents.kt
@@ -22,9 +22,11 @@ fun main() = runBlocking {
             )
 
         for (event in events.data) {
+            // Sender and module are optional: system events (e.g.
+            // 0x3::validator::StakingRequestEvent) have neither.
             println("Type: ${event.type}")
-            println("Sender: ${event.sender}")
-            println("Module: ${event.module}")
+            println("Sender: ${event.sender?.toHex() ?: "none"}")
+            println("Module: ${event.module ?: "none"}")
             println("JSON: ${event.json}")
         }
     } catch (e: Exception) {

--- a/bindings/kotlin/examples/PackageEvents.kt
+++ b/bindings/kotlin/examples/PackageEvents.kt
@@ -22,8 +22,8 @@ fun main() = runBlocking {
             )
 
         for (event in events.data) {
-            // Sender and module are optional: events emitted by the system or at
-            // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
+            // Sender and module are optional: some events (such as system- or
+            // genesis-emitted ones) carry neither.
             println("Type: ${event.type}")
             println("Sender: ${event.sender?.toHex() ?: "none"}")
             println("Module: ${event.module ?: "none"}")

--- a/bindings/python/examples/package_events.py
+++ b/bindings/python/examples/package_events.py
@@ -18,9 +18,13 @@ async def main():
     )
 
     for event in events.data:
+        # Sender and module are optional: system events (e.g.
+        # 0x3::validator::StakingRequestEvent) have neither.
+        sender = event.sender.to_hex() if event.sender is not None else "none"
+        module = event.module if event.module is not None else "none"
         print(f"Type: {event.type}")
-        print(f"Sender: {event.sender.to_hex()}")
-        print(f"Module: {event.module}")
+        print(f"Sender: {sender}")
+        print(f"Module: {module}")
         print(f"JSON: {event.json}")
 
 

--- a/bindings/python/examples/package_events.py
+++ b/bindings/python/examples/package_events.py
@@ -18,8 +18,8 @@ async def main():
     )
 
     for event in events.data:
-        # Sender and module are optional: system events (e.g.
-        # 0x3::validator::StakingRequestEvent) have neither.
+        # Sender and module are optional: events emitted by the system or at
+        # genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
         sender = event.sender.to_hex() if event.sender is not None else "none"
         module = event.module if event.module is not None else "none"
         print(f"Type: {event.type}")

--- a/bindings/python/examples/package_events.py
+++ b/bindings/python/examples/package_events.py
@@ -18,8 +18,8 @@ async def main():
     )
 
     for event in events.data:
-        # Sender and module are optional: events emitted by the system or at
-        # genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
+        # Sender and module are optional: some events (such as system- or
+        # genesis-emitted ones) carry neither.
         sender = event.sender.to_hex() if event.sender is not None else "none"
         module = event.module if event.module is not None else "none"
         print(f"Type: {event.type}")

--- a/bindings/swift/examples/PackageEvents.swift
+++ b/bindings/swift/examples/PackageEvents.swift
@@ -17,9 +17,11 @@ struct PackageEventsExample {
     )
 
     for event in events.data {
+      // Sender and module are optional: system events (e.g.
+      // 0x3::validator::StakingRequestEvent) have neither.
       print("Type: \(event.type)")
-      print("Sender: \(event.sender.toHex())")
-      print("Module: \(event.module)")
+      print("Sender: \(event.sender?.toHex() ?? "none")")
+      print("Module: \(event.module ?? "none")")
       print("JSON: \(event.json)")
     }
   }

--- a/bindings/swift/examples/PackageEvents.swift
+++ b/bindings/swift/examples/PackageEvents.swift
@@ -17,8 +17,8 @@ struct PackageEventsExample {
     )
 
     for event in events.data {
-      // Sender and module are optional: system events (e.g.
-      // 0x3::validator::StakingRequestEvent) have neither.
+      // Sender and module are optional: events emitted by the system or at
+      // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
       print("Type: \(event.type)")
       print("Sender: \(event.sender?.toHex() ?? "none")")
       print("Module: \(event.module ?? "none")")

--- a/bindings/swift/examples/PackageEvents.swift
+++ b/bindings/swift/examples/PackageEvents.swift
@@ -17,8 +17,8 @@ struct PackageEventsExample {
     )
 
     for event in events.data {
-      // Sender and module are optional: events emitted by the system or at
-      // genesis (sender 0x0, e.g. the genesis StakingRequestEvents) have neither.
+      // Sender and module are optional: some events (such as system- or
+      // genesis-emitted ones) carry neither.
       print("Type: \(event.type)")
       print("Sender: \(event.sender?.toHex() ?? "none")")
       print("Module: \(event.module ?? "none")")

--- a/crates/iota-sdk-ffi/src/graphql/api/events.rs
+++ b/crates/iota-sdk-ffi/src/graphql/api/events.rs
@@ -20,7 +20,7 @@ impl GraphQLClient {
         filter: Option<EventFilter>,
         pagination_filter: Option<PaginationFilter>,
     ) -> Result<EventPage> {
-        Ok(self
+        let (page_info, events) = self
             .0
             .read()
             .await
@@ -29,7 +29,11 @@ impl GraphQLClient {
                 pagination_filter.unwrap_or_default(),
             )
             .await?
-            .map(Into::into)
-            .into())
+            .into_parts();
+        let events = events
+            .into_iter()
+            .map(crate::graphql::query_types::GraphQlEvent::try_from)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(iota_sdk::graphql_client::pagination::Page::new(page_info, events).into())
     }
 }

--- a/crates/iota-sdk-ffi/src/graphql/api/events.rs
+++ b/crates/iota-sdk-ffi/src/graphql/api/events.rs
@@ -3,11 +3,15 @@
 
 //! Events API implementation.
 
-use iota_sdk::graphql_client::pagination::PaginationFilter;
+use iota_sdk::graphql_client::pagination::{Page, PaginationFilter};
 
 use crate::{
     error::Result,
-    graphql::{client::GraphQLClient, pagination::EventPage, query_types::EventFilter},
+    graphql::{
+        client::GraphQLClient,
+        pagination::EventPage,
+        query_types::{EventFilter, GraphQlEvent},
+    },
 };
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -32,8 +36,8 @@ impl GraphQLClient {
             .into_parts();
         let events = events
             .into_iter()
-            .map(crate::graphql::query_types::GraphQlEvent::try_from)
+            .map(GraphQlEvent::try_from)
             .collect::<Result<Vec<_>>>()?;
-        Ok(iota_sdk::graphql_client::pagination::Page::new(page_info, events).into())
+        Ok(Page::new(page_info, events).into())
     }
 }

--- a/crates/iota-sdk-ffi/src/graphql/pagination.rs
+++ b/crates/iota-sdk-ffi/src/graphql/pagination.rs
@@ -4,11 +4,12 @@
 use iota_sdk::graphql_client::query_types::PageInfo;
 
 use crate::{
-    graphql::query_types::{DynamicFieldOutput, Epoch, TransactionDataEffects, Validator},
+    graphql::query_types::{
+        DynamicFieldOutput, Epoch, GraphQlEvent, TransactionDataEffects, Validator,
+    },
     types::{
         checkpoint::CheckpointSummary,
         coin::Coin,
-        events::GraphQlEvent,
         iota_names::NameRegistration,
         object::{MovePackage, Object},
         transaction::{SignedTransaction, TransactionEffects},

--- a/crates/iota-sdk-ffi/src/graphql/pagination.rs
+++ b/crates/iota-sdk-ffi/src/graphql/pagination.rs
@@ -8,7 +8,7 @@ use crate::{
     types::{
         checkpoint::CheckpointSummary,
         coin::Coin,
-        events::Event,
+        events::GraphQlEvent,
         iota_names::NameRegistration,
         object::{MovePackage, Object},
         transaction::{SignedTransaction, TransactionEffects},
@@ -41,7 +41,7 @@ macro_rules! define_paged_record {
 define_paged_record!(SignedTransactionPage, SignedTransaction);
 define_paged_record!(TransactionDataEffectsPage, TransactionDataEffects);
 define_paged_record!(DynamicFieldOutputPage, DynamicFieldOutput);
-define_paged_record!(EventPage, Event);
+define_paged_record!(EventPage, GraphQlEvent);
 define_paged_record!(EpochPage, Epoch);
 define_paged_record!(ValidatorPage, Validator);
 

--- a/crates/iota-sdk-ffi/src/graphql/query_types.rs
+++ b/crates/iota-sdk-ffi/src/graphql/query_types.rs
@@ -432,6 +432,73 @@ impl From<EventFilter> for iota_sdk::graphql_client::query_types::EventFilter {
     }
 }
 
+/// An event as returned by the GraphQL `events` query.
+///
+/// This is a faithful view of the GraphQL response, distinct from the chain
+/// [`Event`](crate::types::events::Event). Three fields are optional, for two
+/// different reasons:
+///
+/// - `package_id`, `module` and `sender` are absent for events emitted by the
+///   system or at genesis (e.g. the genesis validator
+///   `0x3::validator::StakingRequestEvent`s): on chain their sender is the zero
+///   address and their emitting module can't be resolved, both of which the
+///   GraphQL server reports as `null`.
+/// - `timestamp` is absent for events not yet included in a checkpoint (e.g.
+///   from a dry run or a just-executed transaction).
+///
+/// `type_`, `contents`, `data` and `json` are always present (non-null in the
+/// GraphQL schema). Unlike the chain `Event`, this type is not
+/// BCS/JSON-serializable as a chain event.
+#[derive(uniffi::Record)]
+pub struct GraphQlEvent {
+    /// Package id of the top-level function invoked by a MoveCall command which
+    /// triggered this event to be emitted. `None` for system events.
+    pub package_id: Option<Arc<ObjectId>>,
+    /// Module name of the top-level function invoked by a MoveCall command
+    /// which triggered this event to be emitted. `None` for system events.
+    pub module: Option<String>,
+    /// Address of the account that sent the transaction where this event was
+    /// emitted. `None` for system events.
+    pub sender: Option<Arc<Address>>,
+    /// The type of the event emitted
+    pub type_: String,
+    /// BCS serialized bytes of the event
+    pub contents: Vec<u8>,
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    pub timestamp: Option<String>,
+    /// Structured contents of a Move value
+    pub data: String,
+    /// Representation of a Move value in JSON
+    pub json: String,
+}
+
+impl TryFrom<iota_sdk::graphql_client::query_types::Event> for GraphQlEvent {
+    type Error = crate::error::SdkFfiError;
+
+    fn try_from(value: iota_sdk::graphql_client::query_types::Event) -> crate::error::Result<Self> {
+        let (package_id, module) = match value.sending_module {
+            Some(sending_module) => (
+                Some(Arc::new(ObjectId(iota_sdk::types::ObjectId::from(
+                    sending_module.package.address,
+                )))),
+                Some(sending_module.name),
+            ),
+            None => (None, None),
+        };
+        Ok(Self {
+            package_id,
+            module,
+            sender: value.sender.map(|s| Arc::new(Address(s.address))),
+            type_: value.type_.repr,
+            contents: base64ct::Base64::decode_vec(&value.bcs.0)
+                .map_err(crate::error::SdkFfiError::custom)?,
+            timestamp: value.timestamp.map(|t| t.0),
+            data: value.data.0.to_string(),
+            json: value.json.to_string(),
+        })
+    }
+}
+
 #[derive(uniffi::Record)]
 pub struct ObjectFilter {
     #[uniffi(default = None)]

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -3,7 +3,6 @@
 
 use std::{str::FromStr, sync::Arc};
 
-use base64ct::Encoding;
 use iota_sdk::types::{Identifier, StructTag};
 
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
 /// field is required and the type round-trips through BCS/JSON. For events
 /// returned by the GraphQL `events` query — which may originate from system
 /// transactions and therefore lack a sender or emitting module — see
-/// [`GraphQlEvent`].
+/// [`GraphQlEvent`](crate::graphql::query_types::GraphQlEvent).
 ///
 /// # BCS
 ///
@@ -65,62 +64,6 @@ impl From<iota_sdk::types::Event> for Event {
             sender: Arc::new(value.sender.into()),
             type_: value.type_.to_string(),
             contents: value.contents,
-        }
-    }
-}
-
-/// An event as returned by the GraphQL `events` query.
-///
-/// Unlike the core chain [`Event`], events emitted by the system or at genesis
-/// have a zero (`0x0`) sender and an unresolvable emitting module — the GraphQL
-/// server returns `null` for both (e.g. the genesis validator
-/// `0x3::validator::StakingRequestEvent`s) — so `package_id`, `module`,
-/// `sender` and `timestamp` are optional. This type is a faithful, non-lossy
-/// view of the GraphQL response and is not BCS/JSON-serializable as a chain
-/// event.
-#[derive(uniffi::Record)]
-pub struct GraphQlEvent {
-    /// Package id of the top-level function invoked by a MoveCall command which
-    /// triggered this event to be emitted. `None` for system events.
-    pub package_id: Option<Arc<ObjectId>>,
-    /// Module name of the top-level function invoked by a MoveCall command
-    /// which triggered this event to be emitted. `None` for system events.
-    pub module: Option<String>,
-    /// Address of the account that sent the transaction where this event was
-    /// emitted. `None` for system events.
-    pub sender: Option<Arc<Address>>,
-    /// The type of the event emitted
-    pub type_: String,
-    /// BCS serialized bytes of the event
-    pub contents: Vec<u8>,
-    /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    pub timestamp: Option<String>,
-    /// Structured contents of a Move value
-    pub data: String,
-    /// Representation of a Move value in JSON
-    pub json: String,
-}
-
-impl From<iota_sdk::graphql_client::query_types::Event> for GraphQlEvent {
-    fn from(value: iota_sdk::graphql_client::query_types::Event) -> Self {
-        let (package_id, module) = match value.sending_module {
-            Some(sending_module) => (
-                Some(Arc::new(ObjectId(iota_sdk::types::ObjectId::from(
-                    sending_module.package.address,
-                )))),
-                Some(sending_module.name),
-            ),
-            None => (None, None),
-        };
-        Self {
-            package_id,
-            module,
-            sender: value.sender.map(|s| Arc::new(Address(s.address))),
-            type_: value.type_.repr,
-            contents: base64ct::Base64::decode_vec(&value.bcs.0).unwrap_or_default(),
-            timestamp: value.timestamp.map(|t| t.0),
-            data: value.data.0.to_string(),
-            json: value.json.to_string(),
         }
     }
 }

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -4,16 +4,20 @@
 use std::{str::FromStr, sync::Arc};
 
 use base64ct::Encoding;
-use iota_sdk::{
-    graphql_client::query_types::{
-        Base64, DateTime, GQLAddress, MoveData, MoveModuleQuery, MovePackageQuery, MoveType,
-    },
-    types::{Identifier, StructTag},
+use iota_sdk::types::{Identifier, StructTag};
+
+use crate::{
+    error::Result,
+    types::{address::Address, digest::Digest, object::ObjectId},
 };
 
-use crate::types::{address::Address, digest::Digest, object::ObjectId};
-
-/// An event
+/// An event emitted during the successful execution of a transaction.
+///
+/// This mirrors the core chain [`iota_sdk::types::Event`] one-to-one: every
+/// field is required and the type round-trips through BCS/JSON. For events
+/// returned by the GraphQL `events` query — which may originate from system
+/// transactions and therefore lack a sender or emitting module — see
+/// [`GraphQlEvent`].
 ///
 /// # BCS
 ///
@@ -37,65 +41,19 @@ pub struct Event {
     pub type_: String,
     /// BCS serialized bytes of the event
     pub contents: Vec<u8>,
-    /// UTC timestamp in milliseconds since epoch (1/1/1970)
-    pub timestamp: String,
-    /// Structured contents of a Move value
-    pub data: String,
-    /// Representation of a Move value in JSON
-    pub json: String,
 }
 
-impl From<iota_sdk::graphql_client::query_types::Event> for Event {
-    fn from(value: iota_sdk::graphql_client::query_types::Event) -> Self {
-        let sending_module = value.sending_module.as_ref().unwrap();
-        Self {
-            package_id: Arc::new(ObjectId(iota_sdk::types::ObjectId::from(
-                sending_module.package.address,
-            ))),
-            module: sending_module.name.clone(),
-            sender: Arc::new(Address(value.sender.as_ref().unwrap().address)),
-            type_: value.type_.repr.clone(),
-            contents: base64ct::Base64::decode_vec(&value.bcs.0).unwrap_or_default(),
-            timestamp: value.timestamp.as_ref().unwrap().0.clone(),
-            data: value.data.0.to_string(),
-            json: value.json.to_string(),
-        }
-    }
-}
+impl TryFrom<Event> for iota_sdk::types::Event {
+    type Error = crate::error::SdkFfiError;
 
-impl From<Event> for iota_sdk::types::Event {
-    fn from(value: Event) -> Self {
-        Self {
+    fn try_from(value: Event) -> Result<Self> {
+        Ok(Self {
             package_id: (**value.package_id),
-            module: Identifier::from_str(&value.module).unwrap(),
+            module: Identifier::from_str(&value.module)?,
             sender: (**value.sender),
-            type_: StructTag::from_str(&value.type_).unwrap(),
+            type_: StructTag::from_str(&value.type_)?,
             contents: value.contents,
-        }
-    }
-}
-
-impl From<Event> for iota_sdk::graphql_client::query_types::Event {
-    fn from(value: Event) -> Self {
-        Self {
-            sending_module: Some(MoveModuleQuery {
-                package: MovePackageQuery {
-                    address: iota_sdk::types::Address::from(**value.package_id),
-                    bcs: None,
-                },
-                name: value.module.clone(),
-            }),
-            sender: Some(GQLAddress {
-                address: (**value.sender),
-            }),
-            type_: MoveType {
-                repr: value.type_.clone(),
-            },
-            bcs: Base64(base64ct::Base64::encode_string(&value.contents)),
-            timestamp: Some(DateTime(value.timestamp.clone())),
-            data: MoveData(serde_json::from_str(&value.data).unwrap_or_default()),
-            json: serde_json::Value::from_str(&value.json).unwrap_or_default(),
-        }
+        })
     }
 }
 
@@ -107,9 +65,60 @@ impl From<iota_sdk::types::Event> for Event {
             sender: Arc::new(value.sender.into()),
             type_: value.type_.to_string(),
             contents: value.contents,
-            timestamp: String::new(),
-            data: String::new(),
-            json: String::new(),
+        }
+    }
+}
+
+/// An event as returned by the GraphQL `events` query.
+///
+/// Unlike the core chain [`Event`], events emitted by system transactions
+/// (e.g. `0x3::validator::StakingRequestEvent`) have no sender or emitting
+/// module, so `package_id`, `module`, `sender` and `timestamp` are optional.
+/// This type is a faithful, non-lossy view of the GraphQL response and is not
+/// BCS/JSON-serializable as a chain event.
+#[derive(uniffi::Record)]
+pub struct GraphQlEvent {
+    /// Package id of the top-level function invoked by a MoveCall command which
+    /// triggered this event to be emitted. `None` for system events.
+    pub package_id: Option<Arc<ObjectId>>,
+    /// Module name of the top-level function invoked by a MoveCall command
+    /// which triggered this event to be emitted. `None` for system events.
+    pub module: Option<String>,
+    /// Address of the account that sent the transaction where this event was
+    /// emitted. `None` for system events.
+    pub sender: Option<Arc<Address>>,
+    /// The type of the event emitted
+    pub type_: String,
+    /// BCS serialized bytes of the event
+    pub contents: Vec<u8>,
+    /// UTC timestamp in milliseconds since epoch (1/1/1970)
+    pub timestamp: Option<String>,
+    /// Structured contents of a Move value
+    pub data: String,
+    /// Representation of a Move value in JSON
+    pub json: String,
+}
+
+impl From<iota_sdk::graphql_client::query_types::Event> for GraphQlEvent {
+    fn from(value: iota_sdk::graphql_client::query_types::Event) -> Self {
+        let (package_id, module) = match value.sending_module {
+            Some(sending_module) => (
+                Some(Arc::new(ObjectId(iota_sdk::types::ObjectId::from(
+                    sending_module.package.address,
+                )))),
+                Some(sending_module.name),
+            ),
+            None => (None, None),
+        };
+        Self {
+            package_id,
+            module,
+            sender: value.sender.map(|s| Arc::new(Address(s.address))),
+            type_: value.type_.repr,
+            contents: base64ct::Base64::decode_vec(&value.bcs.0).unwrap_or_default(),
+            timestamp: value.timestamp.map(|t| t.0),
+            data: value.data.0.to_string(),
+            json: value.json.to_string(),
         }
     }
 }
@@ -129,10 +138,13 @@ pub struct TransactionEvents(pub iota_sdk::types::TransactionEvents);
 #[uniffi::export]
 impl TransactionEvents {
     #[uniffi::constructor]
-    pub fn new(events: Vec<Event>) -> Self {
-        Self(iota_sdk::types::TransactionEvents(
-            events.into_iter().map(Into::into).collect(),
-        ))
+    pub fn new(events: Vec<Event>) -> Result<Self> {
+        Ok(Self(iota_sdk::types::TransactionEvents(
+            events
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_>>()?,
+        )))
     }
 
     pub fn events(&self) -> Vec<Event> {
@@ -144,7 +156,31 @@ impl TransactionEvents {
     }
 }
 
-crate::export_iota_types_bcs_conversion!(Event);
+/// Create an [`Event`] from BCS encoded bytes.
+#[uniffi::export]
+pub fn event_from_bcs(bcs: Vec<u8>) -> Result<Event> {
+    Ok(bcs::from_bytes::<iota_sdk::types::Event>(&bcs)?.into())
+}
+
+/// Convert an [`Event`] to BCS encoded bytes.
+#[uniffi::export]
+pub fn event_to_bcs(data: Event) -> Result<Vec<u8>> {
+    let data: iota_sdk::types::Event = data.try_into()?;
+    Ok(bcs::to_bytes(&data)?)
+}
+
+/// Create an [`Event`] from a JSON encoded string.
+#[uniffi::export]
+pub fn event_from_json(json: &str) -> Result<Event> {
+    Ok(serde_json::from_str::<iota_sdk::types::Event>(json)?.into())
+}
+
+/// Convert an [`Event`] to a JSON encoded string.
+#[uniffi::export]
+pub fn event_to_json(data: Event) -> Result<String> {
+    let data: iota_sdk::types::Event = data.try_into()?;
+    Ok(serde_json::to_string(&data)?)
+}
+
 crate::export_iota_types_objects_bcs_conversion!(TransactionEvents);
-crate::export_iota_types_json_conversion!(Event);
 crate::export_iota_types_objects_json_conversion!(TransactionEvents);

--- a/crates/iota-sdk-ffi/src/types/events.rs
+++ b/crates/iota-sdk-ffi/src/types/events.rs
@@ -71,11 +71,13 @@ impl From<iota_sdk::types::Event> for Event {
 
 /// An event as returned by the GraphQL `events` query.
 ///
-/// Unlike the core chain [`Event`], events emitted by system transactions
-/// (e.g. `0x3::validator::StakingRequestEvent`) have no sender or emitting
-/// module, so `package_id`, `module`, `sender` and `timestamp` are optional.
-/// This type is a faithful, non-lossy view of the GraphQL response and is not
-/// BCS/JSON-serializable as a chain event.
+/// Unlike the core chain [`Event`], events emitted by the system or at genesis
+/// have a zero (`0x0`) sender and an unresolvable emitting module — the GraphQL
+/// server returns `null` for both (e.g. the genesis validator
+/// `0x3::validator::StakingRequestEvent`s) — so `package_id`, `module`,
+/// `sender` and `timestamp` are optional. This type is a faithful, non-lossy
+/// view of the GraphQL response and is not BCS/JSON-serializable as a chain
+/// event.
 #[derive(uniffi::Record)]
 pub struct GraphQlEvent {
     /// Package id of the top-level function invoked by a MoveCall command which

--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -914,11 +914,14 @@ pub struct GenesisTransaction(iota_sdk::types::GenesisTransaction);
 #[uniffi::export]
 impl GenesisTransaction {
     #[uniffi::constructor]
-    pub fn new(objects: Vec<Arc<GenesisObject>>, events: Vec<Event>) -> Self {
-        Self(iota_sdk::types::GenesisTransaction {
+    pub fn new(objects: Vec<Arc<GenesisObject>>, events: Vec<Event>) -> crate::error::Result<Self> {
+        Ok(Self(iota_sdk::types::GenesisTransaction {
             objects: objects.iter().map(|object| object.0.clone()).collect(),
-            events: events.into_iter().map(Into::into).collect(),
-        })
+            events: events
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<crate::error::Result<_>>()?,
+        }))
     }
 
     pub fn objects(&self) -> Vec<Arc<GenesisObject>> {


### PR DESCRIPTION
Fixes #1159

## Summary

The FFI `Event` struct conflated two things: the GraphQL `events()` result (optional sender/module, plus `data`/`json`/`timestamp`) and the chain `iota_sdk::types::Event` (all fields required, BCS-serializable). It `.unwrap()`'d the optional GraphQL fields and panicked on system/genesis events (e.g. `0x3::validator::StakingRequestEvent`, whose sender/module are `null`).

This splits the two concerns:

- **`Event`** (`types::events`) — the chain type, all fields required.
- **`GraphQlEvent`** (`graphql::query_types`, alongside `EventFilter` and the other query-result types) — the GraphQL view, with `package_id`/`module`/`sender`/`timestamp` optional and `type_`/`contents`/`data`/`json` always present.

Both conversions into the chain type are now `TryFrom`, so there are no panics and no silent `0x0`/empty defaults: `event_to_bcs`/`event_to_json` and a malformed GraphQL `bcs` now fail cleanly instead of producing an incorrect/empty result.

## Breaking changes

Generated binding surface (the FFI crate is unpublished; bindings are regenerated):

- `Event` drops the GraphQL-only `timestamp`/`data`/`json` fields.
- `client.events()` now returns `GraphQlEvent`.
- `TransactionEvents::new()` and `GenesisTransaction::new()` are now fallible (`Result`).

## Test plan

- clippy / build / fmt green.
- Go, Python, Swift, C#, and Kotlin `package_events` examples updated to handle the optional `sender`/`module` and verified to build.

https://claude.ai/code/session_01PVTttCUHhsgKhFhyDzR8kg