### PR TITLE
fix: surface HTTP status and body when GraphQL response decode fails

### DIFF
--- a/crates/iota-sdk-graphql-client/src/client.rs
+++ b/crates/iota-sdk-graphql-client/src/client.rs
@@ -120,7 +120,7 @@ impl Client {
         T: serde::de::DeserializeOwned,
         V: serde::Serialize,
     {
-        response_to_err(self.post_query::<GraphQlResponse<T>>(operation).await?)
+        response_to_err(self.post_query(operation).await?)
     }
 
     /// POST a JSON-serializable GraphQL request body and decode the JSON
@@ -155,8 +155,7 @@ impl Client {
         &self,
         json: serde_json::Map<String, serde_json::Value>,
     ) -> Result<GraphQlResponse<serde_json::Value>> {
-        self.post_query::<GraphQlResponse<serde_json::Value>>(&json)
-            .await
+        self.post_query(&json).await
     }
 
     /// Handle pagination filters and return the appropriate values. If limit is

--- a/crates/iota-sdk-graphql-client/src/client.rs
+++ b/crates/iota-sdk-graphql-client/src/client.rs
@@ -120,15 +120,29 @@ impl Client {
         T: serde::de::DeserializeOwned,
         V: serde::Serialize,
     {
-        response_to_err(
-            self.inner
-                .post(self.rpc_server().clone())
-                .json(&operation)
-                .send()
-                .await?
-                .json::<GraphQlResponse<T>>()
-                .await?,
-        )
+        response_to_err(self.post_query::<GraphQlResponse<T>>(operation).await?)
+    }
+
+    /// POST a JSON-serializable GraphQL request body and decode the JSON
+    /// response, surfacing the HTTP status and a truncated body on any non-2xx
+    /// response or on a decode failure.
+    async fn post_query<R>(&self, body: &impl serde::Serialize) -> Result<R>
+    where
+        R: serde::de::DeserializeOwned,
+    {
+        let resp = self
+            .inner
+            .post(self.rpc_server().clone())
+            .json(body)
+            .send()
+            .await?;
+        let status = resp.status();
+        let url = resp.url().clone();
+        let bytes = resp.bytes().await?;
+        if !status.is_success() {
+            return Err(Error::http(url, status, &bytes));
+        }
+        serde_json::from_slice::<R>(&bytes).map_err(|e| Error::decode(url, status, &bytes, e))
     }
 
     /// Run a JSON query on the GraphQL server and return the response.
@@ -141,15 +155,8 @@ impl Client {
         &self,
         json: serde_json::Map<String, serde_json::Value>,
     ) -> Result<GraphQlResponse<serde_json::Value>> {
-        let res = self
-            .inner
-            .post(self.rpc_server().clone())
-            .json(&json)
-            .send()
-            .await?
-            .json::<GraphQlResponse<serde_json::Value>>()
-            .await?;
-        Ok(res)
+        self.post_query::<GraphQlResponse<serde_json::Value>>(&json)
+            .await
     }
 
     /// Handle pagination filters and return the appropriate values. If limit is

--- a/crates/iota-sdk-graphql-client/src/error.rs
+++ b/crates/iota-sdk-graphql-client/src/error.rs
@@ -6,10 +6,28 @@ use std::num::{ParseIntError, TryFromIntError};
 
 use cynic::GraphQlError;
 use iota_types::{AddressParseError, DigestParseError, TypeParseError};
+use reqwest::{StatusCode, Url};
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Maximum number of body bytes retained in an HTTP/decode error. Load
+/// balancer and gateway pages can be hundreds of KB, so the body is truncated
+/// before being stored in the error.
+const MAX_ERROR_BODY_BYTES: usize = 512;
+
+/// Render a response body as a truncated, UTF-8-lossy string suitable for
+/// inclusion in an error message.
+fn truncated_body(bytes: &[u8]) -> String {
+    let truncated = bytes.len() > MAX_ERROR_BODY_BYTES;
+    let slice = &bytes[..bytes.len().min(MAX_ERROR_BODY_BYTES)];
+    let mut body = String::from_utf8_lossy(slice).into_owned();
+    if truncated {
+        body.push_str("… (truncated)");
+    }
+    body
+}
 
 /// General error type for the client. It is used to wrap all the possible
 /// errors that can occur.
@@ -38,6 +56,7 @@ pub enum Kind {
     Parse,
     Query,
     Missing,
+    Http,
     Other,
 }
 
@@ -87,6 +106,33 @@ impl Error {
         }
     }
 
+    /// Create an error for a non-success HTTP response, capturing the request
+    /// URL, the HTTP status (code + reason phrase) and a truncated, UTF-8-lossy
+    /// snapshot of the response body.
+    pub fn http(url: Url, status: StatusCode, body: &[u8]) -> Self {
+        Self::from_message(
+            Kind::Http,
+            format!(
+                "GraphQL request to {url} failed: HTTP {status}, body={:?}",
+                truncated_body(body)
+            ),
+        )
+    }
+
+    /// Create an error for a response whose body could not be parsed as JSON,
+    /// capturing the request URL, the HTTP status, a truncated, UTF-8-lossy
+    /// snapshot of the body and the underlying `serde_json` error.
+    pub fn decode(url: Url, status: StatusCode, body: &[u8], source: serde_json::Error) -> Self {
+        Self::from_message(
+            Kind::Deserialization,
+            format!(
+                "GraphQL request to {url} returned HTTP {status} but the body could not be parsed \
+                 as JSON (body={:?}): {source}",
+                truncated_body(body)
+            ),
+        )
+    }
+
     /// Create a Query kind of error with the original graphql errors.
     pub fn graphql_error(errors: Vec<GraphQlError>) -> Self {
         Self {
@@ -106,6 +152,7 @@ impl std::fmt::Display for Kind {
             Kind::Parse => write!(f, "Parse error:"),
             Kind::Query => write!(f, "Query error:"),
             Kind::Missing => write!(f, "Missing:"),
+            Kind::Http => write!(f, "HTTP error:"),
             Kind::Other => write!(f, "Error:"),
         }
     }
@@ -191,5 +238,41 @@ impl From<TryFromIntError> for Error {
 impl From<TypeParseError> for Error {
     fn from(error: TypeParseError) -> Self {
         Self::from_error(Kind::Parse, error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_error_surfaces_status_and_body() {
+        let url = Url::parse("https://graphql.devnet.iota.cafe").unwrap();
+        let error = Error::http(url, StatusCode::TOO_MANY_REQUESTS, b"Too Many Requests");
+        let message = error.to_string();
+        assert!(message.contains("https://graphql.devnet.iota.cafe"));
+        assert!(message.contains("HTTP 429 Too Many Requests"));
+        assert!(message.contains("Too Many Requests"));
+    }
+
+    #[test]
+    fn decode_error_surfaces_status_body_and_source() {
+        let url = Url::parse("https://graphql.devnet.iota.cafe").unwrap();
+        let serde_error = serde_json::from_slice::<serde_json::Value>(b"not json").unwrap_err();
+        let error = Error::decode(url, StatusCode::OK, b"not json", serde_error);
+        let message = error.to_string();
+        assert!(message.contains("https://graphql.devnet.iota.cafe"));
+        assert!(message.contains("HTTP 200 OK"));
+        assert!(message.contains("not json"));
+        // The underlying serde_json error text is included.
+        assert!(message.contains("expected"));
+    }
+
+    #[test]
+    fn body_is_truncated() {
+        let body = vec![b'a'; MAX_ERROR_BODY_BYTES + 100];
+        let rendered = truncated_body(&body);
+        assert!(rendered.contains("… (truncated)"));
+        assert_eq!(rendered.len(), MAX_ERROR_BODY_BYTES + "… (truncated)".len());
     }
 }

--- a/crates/iota-sdk-graphql-client/src/error.rs
+++ b/crates/iota-sdk-graphql-client/src/error.rs
@@ -62,7 +62,11 @@ pub enum Kind {
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.inner.source.as_deref().map(|e| e as _)
+        // `Display` already renders the inner error's own message inline, so we
+        // expose only its *underlying* cause here. Returning the inner error
+        // directly would make cause-chain formatters (e.g. `anyhow`/`eyre`
+        // `{:?}`) repeat that message verbatim under "Caused by".
+        self.inner.source.as_deref()?.source()
     }
 }
 
@@ -266,6 +270,53 @@ mod tests {
         assert!(message.contains("not json"));
         // The underlying serde_json error text is included.
         assert!(message.contains("expected"));
+    }
+
+    #[test]
+    fn http_error_has_no_duplicate_cause() {
+        // The full message lives in `Display`; there is no underlying cause, so
+        // `source()` must be `None` to avoid cause-chain formatters repeating
+        // the message under "Caused by".
+        use std::error::Error as _;
+
+        let url = Url::parse("https://graphql.devnet.iota.cafe").unwrap();
+        let error = Error::http(url, StatusCode::TOO_MANY_REQUESTS, b"Too Many Requests");
+        assert!(error.source().is_none());
+    }
+
+    #[test]
+    fn wrapped_error_exposes_underlying_cause_not_its_own_message() {
+        use std::error::Error as _;
+
+        #[derive(Debug)]
+        struct Inner;
+        impl std::fmt::Display for Inner {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "inner cause")
+            }
+        }
+        impl std::error::Error for Inner {}
+
+        #[derive(Debug)]
+        struct Outer(Inner);
+        impl std::fmt::Display for Outer {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "outer message")
+            }
+        }
+        impl std::error::Error for Outer {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let error = Error::from_error(Kind::Other, Outer(Inner));
+        // `Display` carries the wrapped error's own message exactly once.
+        assert!(error.to_string().contains("outer message"));
+        // `source()` skips that already-rendered message and exposes the
+        // deeper cause, so the chain does not repeat "outer message".
+        let source = error.source().expect("expected an underlying cause");
+        assert_eq!(source.to_string(), "inner cause");
     }
 
     #[test]


### PR DESCRIPTION
## Why

`run_query` / `run_query_from_json` used reqwest's `Response::json()`, which discards the HTTP status and body on a parse failure. A non-JSON response surfaced only as `expected value at line 1 column 1`, hiding the real cause (see #1181).

## What

- Both methods now share a `post_query` helper that reads the response explicitly: non-2xx returns an HTTP error, and a 2xx decode failure attaches context. Errors carry the request URL, HTTP status (code + reason) and a 512-byte truncated, UTF-8-lossy body via new `Error::http` / `Error::decode` constructors and a `Kind::Http` variant.
- Fixed a related quirk in `Error::source()`: it returned the inner error whose message `Display` already renders inline, so `anyhow`/`eyre` `{:?}` printed it twice. It now exposes only the deeper cause, so the message appears once. `Display` (used by FFI via `to_string()`) is unchanged.

A gateway error now reads:
```
HTTP error: GraphQL request to https://graphql.testnet.iota.cafe/ failed: HTTP 502 Bad Gateway, body="<html><body>502 Bad Gateway</body></html>"
```
instead of `expected value at line 1 column 1`.

Backward-compatible: existing `?`-propagating callers just get a better message.

## Test plan

- Unit tests for status/body surfacing, decode-with-source, body truncation, and no duplicate cause.
- `cargo clippy --all-targets` clean; nightly rustfmt applied.

Closes #1182

[run-ci]