### PR TITLE
fix(graphql-client): disable idle connection pool to avoid LB 429s

### DIFF
--- a/crates/iota-sdk-graphql-client/src/client.rs
+++ b/crates/iota-sdk-graphql-client/src/client.rs
@@ -48,9 +48,19 @@ impl Client {
     pub fn new(server: &str) -> Result<Self> {
         let rpc = reqwest::Url::parse(server)?;
 
+        let builder = reqwest::Client::builder().user_agent(USER_AGENT);
+        // The GraphQL load balancers apply a per-connection rate limit and
+        // return HTTP 429 once a burst of requests reuses the same pooled
+        // keep-alive connection. Disabling the idle connection pool makes every
+        // request use a fresh connection, so no connection accumulates enough
+        // requests to trip the limit. `pool_max_idle_per_host` is not available
+        // on the wasm32 reqwest backend, where the browser manages connections.
+        #[cfg(not(target_arch = "wasm32"))]
+        let builder = builder.pool_max_idle_per_host(0);
+
         let client = Client {
             rpc,
-            inner: reqwest::Client::builder().user_agent(USER_AGENT).build()?,
+            inner: builder.build()?,
             service_config: Default::default(),
         };
         Ok(client)


### PR DESCRIPTION
## Why

The devnet/testnet GraphQL load balancers apply a per-connection rate limit and return HTTP 429 once a burst of requests reuses the same pooled keep-alive connection. This is the root cause of the flaky transaction-builder doctests in CI (Fixes https://github.com/iotaledger/iota-rust-sdk/issues/1181).

## What

Disable reqwest's idle connection pool (`pool_max_idle_per_host(0)`) so every request opens a fresh connection. No connection ever accumulates enough requests to trip the per-connection cap, so the 429 is *prevented* rather than reacted to — this is the fix verified in the issue. Gated to non-wasm32, since reqwest's wasm backend has no pool controls (the browser manages connections).

The trade-off is one TCP+TLS handshake per request (~50–100ms), acceptable for the SDK's short, sequential GraphQL queries.

> An earlier revision tried keeping the pool and retrying once on a fresh connection. CI showed that's insufficient: the first attempt still rides the pooled connection that saturates the cap, and reactive retries under parallel doctests can themselves catch a 429. Disabling the pool prevents the 429 entirely and is simpler.

## Test plan

- `cargo clippy -- -Dwarnings`, nightly fmt, native + `wasm32-unknown-unknown` builds, offline unit tests pass locally.
- [run-ci] to exercise the previously-flaky doctests against the live network.

https://claude.ai/code/session_01Rg44DHJmk4sRcrFNCsgNrv