### PR TITLE
refactor(types): align more readable forms with the default serialization

### DIFF
--- a/crates/iota-sdk-types/src/move_package.rs
+++ b/crates/iota-sdk-types/src/move_package.rs
@@ -119,8 +119,6 @@ pub struct TypeOrigin {
     pub module_name: Identifier,
     /// The name of the data type. Either refers to an enum or a struct
     /// identifier.
-    // `struct_name` alias to support backwards compatibility with the old name
-    #[cfg_attr(feature = "serde", serde(alias = "struct_name"))]
     pub datatype_name: Identifier,
     /// ID of the package, where the given type first appeared.
     pub package: ObjectId,

--- a/crates/iota-sdk-types/src/object.rs
+++ b/crates/iota-sdk-types/src/object.rs
@@ -16,6 +16,7 @@ use super::{Address, Digest, MovePackage, ObjectId, StructTag, TypeTag, Version}
 /// object-reference = object-id u64 digest
 /// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct ObjectReference {
@@ -879,35 +880,6 @@ mod serialization {
 
                 Ok(GenesisObject { data, owner })
             }
-        }
-    }
-
-    // Custom serialization to be backwards compatible with the JSON RPC
-    #[derive(serde::Deserialize, serde::Serialize)]
-    struct TupleObjectReference(ObjectId, Version, Digest);
-
-    impl Serialize for ObjectReference {
-        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            TupleObjectReference(self.object_id, self.version, self.digest).serialize(serializer)
-        }
-    }
-
-    impl<'de> Deserialize<'de> for ObjectReference {
-        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-        {
-            let TupleObjectReference(object_id, version, digest) =
-                TupleObjectReference::deserialize(deserializer)?;
-
-            Ok(ObjectReference {
-                object_id,
-                version,
-                digest,
-            })
         }
     }
 

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -14,30 +14,21 @@ mod input_argument {
         transaction::{Input, SharedObjectReference},
     };
 
+    // Mirrors the default derived serialization of `Input`; the manual impl
+    // only exists to keep the BCS form as the `CallArg`/`ObjectArg` protocol
+    // encoding below.
     #[derive(serde::Deserialize, serde::Serialize)]
-    struct PureInput {
-        #[serde(with = "::serde_with::As::<crate::_serde::Base64Encoded>")]
-        value: Vec<u8>,
-    }
-
-    #[derive(serde::Deserialize, serde::Serialize)]
-    #[serde(rename_all = "snake_case")]
     #[serde(rename = "Input")]
     enum ReadableInput {
         /// A move value serialized as BCS.
         ///
         /// For normal operations this is required to be a move primitive type
         /// and not contain structs or objects.
-        Pure(PureInput),
+        Pure(#[serde(with = "crate::_serde::ReadableBase64Encoded")] Vec<u8>),
         /// A move object that is either immutable or address owned
         ImmutableOrOwned(ObjectReference),
         /// A move object whose owner is "Shared"
-        Shared {
-            object_id: ObjectId,
-            #[serde(with = "crate::_serde::ReadableDisplay")]
-            initial_shared_version: Version,
-            mutable: bool,
-        },
+        Shared(SharedObjectReference),
         /// A move object that is attempted to be received in this transaction.
         Receiving(ObjectReference),
     }
@@ -68,19 +59,11 @@ mod input_argument {
         {
             if serializer.is_human_readable() {
                 let readable = match self.clone() {
-                    Input::Pure(value) => ReadableInput::Pure(PureInput { value }),
+                    Input::Pure(value) => ReadableInput::Pure(value),
                     Input::ImmutableOrOwned(object_ref) => {
                         ReadableInput::ImmutableOrOwned(object_ref)
                     }
-                    Input::Shared(SharedObjectReference {
-                        object_id,
-                        initial_shared_version,
-                        mutable,
-                    }) => ReadableInput::Shared {
-                        object_id,
-                        initial_shared_version,
-                        mutable,
-                    },
+                    Input::Shared(shared) => ReadableInput::Shared(shared),
                     Input::Receiving(object_ref) => ReadableInput::Receiving(object_ref),
                 };
                 readable.serialize(serializer)
@@ -115,19 +98,11 @@ mod input_argument {
         {
             if deserializer.is_human_readable() {
                 ReadableInput::deserialize(deserializer).map(|readable| match readable {
-                    ReadableInput::Pure(PureInput { value }) => Input::Pure(value),
+                    ReadableInput::Pure(value) => Input::Pure(value),
                     ReadableInput::ImmutableOrOwned(object_ref) => {
                         Input::ImmutableOrOwned(object_ref)
                     }
-                    ReadableInput::Shared {
-                        object_id,
-                        initial_shared_version,
-                        mutable,
-                    } => Input::Shared(SharedObjectReference {
-                        object_id,
-                        initial_shared_version,
-                        mutable,
-                    }),
+                    ReadableInput::Shared(shared) => Input::Shared(shared),
                     ReadableInput::Receiving(object_ref) => Input::Receiving(object_ref),
                 })
             } else {
@@ -327,14 +302,15 @@ mod tests {
 
     #[test]
     fn input_argument() {
+        let object_ref = serde_json::json!({
+            "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "version": "1",
+            "digest": "11111111111111111111111111111111"
+        });
         let test_cases = [
             (
                 Input::Pure(vec![1, 2, 3, 4]),
-                serde_json::json!({
-                  "pure": {
-                    "value": "AQIDBA=="
-                  }
-                }),
+                serde_json::json!({ "Pure": "AQIDBA==" }),
             ),
             (
                 Input::ImmutableOrOwned(ObjectReference::new(
@@ -342,13 +318,7 @@ mod tests {
                     Version::from_u64(1),
                     Digest::ZERO,
                 )),
-                serde_json::json!({
-                  "immutable_or_owned": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
-                    "1",
-                    "11111111111111111111111111111111"
-                  ]
-                }),
+                serde_json::json!({ "ImmutableOrOwned": object_ref }),
             ),
             (
                 Input::Shared(SharedObjectReference {
@@ -357,7 +327,7 @@ mod tests {
                     mutable: true,
                 }),
                 serde_json::json!({
-                  "shared": {
+                  "Shared": {
                     "object_id": "0x0000000000000000000000000000000000000000000000000000000000000000",
                     "initial_shared_version": "1",
                     "mutable": true
@@ -370,13 +340,7 @@ mod tests {
                     Version::from_u64(1),
                     Digest::ZERO,
                 )),
-                serde_json::json!({
-                  "receiving": [
-                    "0x0000000000000000000000000000000000000000000000000000000000000000",
-                    "1",
-                    "11111111111111111111111111111111"
-                  ]
-                }),
+                serde_json::json!({ "Receiving": object_ref }),
             ),
         ];
 


### PR DESCRIPTION
## Why

Continues the readable-serialization cleanup: the JSON form is no longer SDK-owned, so it should mirror what a plain derive of the base type produces rather than carry bespoke representations.

## What

- **`ObjectReference`** — drop the JSON-RPC 3-tuple form; serialize as the struct `{object_id, version, digest}` (plain derive).
- **`TypeOrigin`** — drop the `struct_name` deserialization alias.
- **`Input`** — simplify the readable form to a plain mirror of `Input`: drop the `PureInput { value }` wrapper, the flattened `Shared` fields, and the snake_case rename. `Pure` stays base64 (now a direct string). The manual impl is kept only for the BCS `CallArg`/`ObjectArg` protocol encoding, which is unchanged.

Resulting `Input` JSON:
```jsonc
{ "Pure": "AQIDBA==" }
{ "ImmutableOrOwned": { "object_id": …, "version": "1", "digest": … } }
{ "Shared": { "object_id": …, "initial_shared_version": "1", "mutable": true } }
{ "Receiving": { … } }
```

**JSON-only changes**; BCS is unchanged.

## Test plan

- `bcs-schema.abnf` regenerates with **no diff**; the `input_argument`/`transaction_fixtures` tests (updated for the new JSON) and all round-trip proptests pass.
- Full `iota-sdk-types` suite (280), clippy (`-Dwarnings`), and workspace build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)