### PR TITLE
chore: rename `ClientMethods` to `TransactionBuilderClient`

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/mod.rs
+++ b/crates/iota-sdk-ffi/src/graphql/mod.rs
@@ -5,11 +5,11 @@ use serde_json::Value;
 
 pub mod api;
 pub mod client;
-pub mod client_methods;
 pub mod faucet;
 pub mod output_types;
 pub mod pagination;
 pub mod query_types;
+pub mod transaction_builder_client;
 
 uniffi::custom_type!(Value, String, {
     remote,

--- a/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
+++ b/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
@@ -3,7 +3,7 @@
 
 use iota_sdk::{
     graphql_client::{Client, DryRunResult, WaitForTx},
-    transaction_builder::{ClientMethods, ObjectsPage, ProtocolConfig},
+    transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient},
     types::{
         Address, Digest, Object, ObjectId, StructTag, Transaction, TransactionEffects, Version,
     },
@@ -11,8 +11,8 @@ use iota_sdk::{
 
 use crate::graphql::client::GraphQLClient;
 
-impl ClientMethods for GraphQLClient {
-    type Error = <Client as ClientMethods>::Error;
+impl TransactionBuilderClient for GraphQLClient {
+    type Error = <Client as TransactionBuilderClient>::Error;
     type DryRunResult = DryRunResult;
 
     async fn object(
@@ -20,7 +20,7 @@ impl ClientMethods for GraphQLClient {
         object_id: ObjectId,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<Object>, Self::Error> {
-        ClientMethods::object(&*self.0.read().await, object_id, version).await
+        TransactionBuilderClient::object(&*self.0.read().await, object_id, version).await
     }
 
     async fn objects(
@@ -30,36 +30,37 @@ impl ClientMethods for GraphQLClient {
         cursor: Option<Vec<u8>>,
         limit: Option<usize>,
     ) -> Result<ObjectsPage, Self::Error> {
-        ClientMethods::objects(&*self.0.read().await, struct_tag, owner, cursor, limit).await
+        TransactionBuilderClient::objects(&*self.0.read().await, struct_tag, owner, cursor, limit)
+            .await
     }
 
     async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
-        ClientMethods::protocol_config(&*self.0.read().await).await
+        TransactionBuilderClient::protocol_config(&*self.0.read().await).await
     }
 
     async fn transaction(
         &self,
         digest: Digest,
     ) -> Result<Option<iota_sdk::types::SignedTransaction>, Self::Error> {
-        ClientMethods::transaction(&*self.0.read().await, digest).await
+        TransactionBuilderClient::transaction(&*self.0.read().await, digest).await
     }
 
     async fn transaction_effects(
         &self,
         digest: Digest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
-        ClientMethods::transaction_effects(&*self.0.read().await, digest).await
+        TransactionBuilderClient::transaction_effects(&*self.0.read().await, digest).await
     }
 
     async fn reference_gas_price(
         &self,
         epoch: impl Into<Option<u64>>,
     ) -> Result<Option<u64>, Self::Error> {
-        ClientMethods::reference_gas_price(&*self.0.read().await, epoch).await
+        TransactionBuilderClient::reference_gas_price(&*self.0.read().await, epoch).await
     }
 
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-        ClientMethods::estimate_tx_budget(&*self.0.read().await, tx).await
+        TransactionBuilderClient::estimate_tx_budget(&*self.0.read().await, tx).await
     }
 
     async fn dry_run_tx(
@@ -67,7 +68,7 @@ impl ClientMethods for GraphQLClient {
         tx: &Transaction,
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
-        ClientMethods::dry_run_tx(&*self.0.read().await, tx, skip_checks).await
+        TransactionBuilderClient::dry_run_tx(&*self.0.read().await, tx, skip_checks).await
     }
 
     async fn execute_tx(
@@ -76,10 +77,10 @@ impl ClientMethods for GraphQLClient {
         tx: &Transaction,
         wait_for: impl Into<Option<WaitForTx>>,
     ) -> Result<TransactionEffects, Self::Error> {
-        ClientMethods::execute_tx(&*self.0.read().await, signatures, tx, wait_for).await
+        TransactionBuilderClient::execute_tx(&*self.0.read().await, signatures, tx, wait_for).await
     }
 
     async fn wait_for_tx(&self, digest: Digest, wait_for: WaitForTx) -> Result<(), Self::Error> {
-        ClientMethods::wait_for_tx(&*self.0.read().await, digest, wait_for).await
+        TransactionBuilderClient::wait_for_tx(&*self.0.read().await, digest, wait_for).await
     }
 }

--- a/crates/iota-sdk-graphql-client/src/lib.rs
+++ b/crates/iota-sdk-graphql-client/src/lib.rs
@@ -6,13 +6,13 @@
 
 mod api;
 mod client;
-mod client_methods;
 pub mod error;
 pub mod faucet;
 pub mod output_types;
 pub mod pagination;
 pub mod query_types;
 pub mod streams;
+mod transaction_builder_client;
 
 #[cfg(test)]
 mod test_utils;

--- a/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
@@ -1,9 +1,9 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of [`ClientMethods`] for the GraphQL [`Client`].
+//! Implementation of [`TransactionBuilderClient`] for the GraphQL [`Client`].
 
-use iota_transaction_builder::{ClientMethods, ObjectsPage, ProtocolConfig, WaitForTx};
+use iota_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx};
 use iota_types::{
     Address, Digest, Object, ObjectId, SignedTransaction, StructTag, Transaction,
     TransactionEffects, UserSignature, Version,
@@ -15,7 +15,7 @@ use crate::{
     query_types::ObjectFilter,
 };
 
-impl ClientMethods for Client {
+impl TransactionBuilderClient for Client {
     type Error = crate::error::Error;
     type DryRunResult = DryRunResult;
 

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -34,7 +34,7 @@
 //! ```
 
 pub mod api;
-mod client_methods;
+mod transaction_builder_client;
 
 // Re-export all read mask constants (per-method fields)
 pub use api::{

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of [`ClientMethods`] for the GRPC [`Client`].
+//! Implementation of [`TransactionBuilderClient`] for the GRPC [`Client`].
 
 use std::time::Duration;
 
 use iota_grpc_types::{
     read_mask_fields::EpochField, v1::transaction_execution_service::SimulatedTransaction,
 };
-use iota_transaction_builder::{ClientMethods, ObjectsPage, ProtocolConfig, WaitForTx};
+use iota_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx};
 use iota_types::{
     Address, Digest, Object, ObjectId, SignedTransaction, StructTag, Transaction,
     TransactionEffects, UserSignature, Version,
@@ -23,9 +23,9 @@ use crate::{
     },
 };
 
-/// How long [`ClientMethods::wait_for_tx`] polls before giving up.
+/// How long [`TransactionBuilderClient::wait_for_tx`] polls before giving up.
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
-/// Interval between polls in [`ClientMethods::wait_for_tx`].
+/// Interval between polls in [`TransactionBuilderClient::wait_for_tx`].
 const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Returns `true` if the error represents a "not found" response from the
@@ -39,7 +39,7 @@ fn is_not_found(err: &Error) -> bool {
     }
 }
 
-impl ClientMethods for Client {
+impl TransactionBuilderClient for Client {
     type Error = crate::api::Error;
     type DryRunResult = SimulatedTransaction;
 

--- a/crates/iota-sdk-transaction-builder/src/builder/client.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client.rs
@@ -36,14 +36,14 @@ pub enum WaitForTx {
 }
 
 /// One page of objects plus an optional cursor for the next page. See
-/// [`ClientMethods::objects`].
+/// [`TransactionBuilderClient::objects`].
 #[derive(Clone, Debug)]
 pub struct ObjectsPage {
     /// The objects in this page.
     pub data: Vec<Object>,
     /// Opaque continuation cursor for fetching the next page; `None` when no
     /// further pages exist. Pass it back as the `cursor` argument to
-    /// [`ClientMethods::objects`] to advance.
+    /// [`TransactionBuilderClient::objects`] to advance.
     pub next_cursor: Option<Vec<u8>>,
 }
 
@@ -58,7 +58,7 @@ pub struct ProtocolConfig {
 
 /// A trait which defines methods needed from the client for the Transaction
 /// Builder.
-pub trait ClientMethods {
+pub trait TransactionBuilderClient {
     /// The error type for this client.
     type Error: 'static + std::error::Error + Send + Sync;
     /// The result of a dry run.
@@ -142,7 +142,7 @@ pub trait ClientMethods {
     ) -> impl std::future::Future<Output = Result<(), Self::Error>>;
 }
 
-impl<T: ClientMethods> ClientMethods for &T {
+impl<T: TransactionBuilderClient> TransactionBuilderClient for &T {
     type Error = T::Error;
     type DryRunResult = T::DryRunResult;
 
@@ -224,7 +224,7 @@ impl<T: ClientMethods> ClientMethods for &T {
     }
 }
 
-impl<T: ClientMethods> ClientMethods for std::sync::Arc<T> {
+impl<T: TransactionBuilderClient> TransactionBuilderClient for std::sync::Arc<T> {
     type Error = T::Error;
     type DryRunResult = T::DryRunResult;
 
@@ -315,7 +315,7 @@ pub(crate) mod test_client {
         StructTag, Transaction, TransactionEffects, UserSignature, Version,
     };
 
-    use super::{ClientMethods, WaitForTx};
+    use super::{TransactionBuilderClient, WaitForTx};
     use crate::ObjectsPage;
 
     /// Balance, in NANOS, of every fabricated coin. Large enough to cover any
@@ -340,8 +340,8 @@ pub(crate) mod test_client {
         Object::new(ObjectData::Struct(move_struct), owner, Digest::ZERO, 0)
     }
 
-    /// A test client that implements [`ClientMethods`] by fabricating objects
-    /// on demand.
+    /// A test client that implements [`TransactionBuilderClient`] by
+    /// fabricating objects on demand.
     ///
     /// It is useful for building transactions in tests, examples, and doc tests
     /// where a live network connection is not available. Object lookups resolve
@@ -350,7 +350,7 @@ pub(crate) mod test_client {
     /// selection always finds a single funded coin. This is enough to drive
     /// [`finish`](crate::TransactionBuilder::finish) to completion, but the
     /// resulting transaction references made-up objects and cannot be executed
-    /// — [`execute_tx`](ClientMethods::execute_tx) returns an error.
+    /// — [`execute_tx`](TransactionBuilderClient::execute_tx) returns an error.
     #[derive(Clone, Copy, Debug, Default)]
     pub struct TestClient;
 
@@ -359,7 +359,7 @@ pub(crate) mod test_client {
     #[error("TestClientError: {0}")]
     pub struct TestClientError(pub String);
 
-    impl ClientMethods for TestClient {
+    impl TransactionBuilderClient for TestClient {
         type Error = TestClientError;
         type DryRunResult = ();
 

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -18,7 +18,7 @@ use reqwest::Url;
 use serde::Serialize;
 
 use crate::{
-    ClientMethods, PTBArgument, SharedMut, WaitForTx,
+    PTBArgument, SharedMut, TransactionBuilderClient, WaitForTx,
     builder::{
         assigned_results::{AssignedResult, AssignedResults},
         gas_station::GasStationData,
@@ -34,7 +34,7 @@ use crate::{
 };
 
 mod assigned_results;
-pub(crate) mod client_methods;
+pub(crate) mod client;
 pub(crate) mod gas_station;
 pub mod move_authenticator;
 /// Argument types for PTBs
@@ -50,9 +50,9 @@ const MAX_GAS_PAYMENT_OBJECTS_KEY: &str = "max_gas_payment_objects";
 /// Fallback cap on `gas_payment.objects.len()` used when the protocol-config
 /// value is unavailable (`max_gas_payment_objects` is 256 exclusive at the
 /// time of writing, so 255 inclusive). Auto gas selection fetches the live
-/// value via [`ClientMethods::protocol_config`] and falls back to this if the
-/// implementation does not expose protocol config or the value cannot be
-/// parsed.
+/// value via [`TransactionBuilderClient::protocol_config`] and falls back to
+/// this if the implementation does not expose protocol config or the value
+/// cannot be parsed.
 const DEFAULT_MAX_GAS_PAYMENT_OBJECTS: usize = 255;
 
 /// A transaction builder which can be used to construct [`Transaction`]s.
@@ -1015,7 +1015,7 @@ impl<C, L> TransactionBuilder<C, L> {
     }
 }
 
-impl<C: ClientMethods, L> TransactionBuilder<C, L> {
+impl<C: TransactionBuilderClient, L> TransactionBuilder<C, L> {
     /// Add gas coins that will be consumed. If no gas coins are provided, the
     /// client will set a default list owned by the sender.
     ///
@@ -1413,7 +1413,7 @@ impl TransactionBuilder<(), Publish> {
     }
 }
 
-impl<C: ClientMethods> TransactionBuilder<C, Publish> {
+impl<C: TransactionBuilderClient> TransactionBuilder<C, Publish> {
     /// Get the package ID from the UpgradeCap so that it can be used for future
     /// commands.
     pub fn package_id(&mut self, name: impl AssignedResult) -> &mut TransactionBuilder<C> {

--- a/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
@@ -11,7 +11,8 @@ use iota_types::{
 };
 
 use crate::{
-    ClientMethods, PTBArgumentList, error::Error, types::MoveTypes, unresolved::InputKind,
+    PTBArgumentList, TransactionBuilderClient, error::Error, types::MoveTypes,
+    unresolved::InputKind,
 };
 
 /// A function call to authorize a transaction via move.
@@ -56,7 +57,10 @@ impl MoveAuthenticatorBuilder {
 
     /// Resolve this move authenticator builder into a [`MoveAuthenticator`]
     /// which can be used to execute the given transaction.
-    pub async fn finish(self, client: impl ClientMethods) -> Result<MoveAuthenticator, Error> {
+    pub async fn finish(
+        self,
+        client: impl TransactionBuilderClient,
+    ) -> Result<MoveAuthenticator, Error> {
         let account = client
             .object(self.account_id, None)
             .await

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -15,7 +15,7 @@
 //! ## Online vs. Offline Builder
 //!
 //! The Transaction Builder can be used with or without a client implementing
-//! [ClientMethods]. When one is provided via the
+//! [TransactionBuilderClient]. When one is provided via the
 //! [with_client](TransactionBuilder::with_client) method, the resulting builder
 //! will use it to find and validate provided IDs.
 //!
@@ -285,11 +285,11 @@ pub mod types;
 pub mod unresolved;
 
 #[cfg(feature = "test-client")]
-pub use self::builder::client_methods::test_client::{TestClient, TestClientError};
+pub use self::builder::client::test_client::{TestClient, TestClientError};
 pub use self::{
     builder::{
         TransactionBuilder,
-        client_methods::{ClientMethods, ObjectsPage, ProtocolConfig, WaitForTx},
+        client::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx},
         move_authenticator::MoveAuthenticatorBuilder,
         ptb_arguments::{PTBArgument, PTBArgumentList, Receiving, Shared, SharedMut, assigned},
         signer::TransactionSigner,


### PR DESCRIPTION
## Summary

Renames the `ClientMethods` trait to `TransactionBuilderClient`. The old name was generic and didn't convey the trait's purpose — it defines the set of client operations the transaction builder depends on, so the new name says exactly that. The defining file in `iota-sdk-transaction-builder` moves to `builder/client.rs`, and the per-client `impl` files in the GraphQL, gRPC, and FFI crates move to `transaction_builder_client.rs` to match.

Pure rename — no behavioral change.

## Test plan

- `make test`
- `make clippy`