### PR TITLE
fix(workflows): drop RUSTFLAGS=-Dwarnings from wasm publish

### DIFF
--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: read
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   build:
     name: Build WASM bindings


### PR DESCRIPTION
The workflow-level `RUSTFLAGS: -Dwarnings` leaked into the from-source build of the third-party ubrn helper binary (`npx ubrn build` on first use), turning an upstream unused-import warning into a hard error — this broke the first publish dry run. Lints on our own code are already enforced by the PR CI workflows, so the publish workflow doesn't need the flag.