### PR TITLE
feat(ffi): expose missing StructTag constructors and predicates

### DIFF
--- a/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
@@ -116,6 +116,36 @@ impl StructTag {
             .collect()
     }
 
+    /// Returns whether the type (excluding the type params) is the same as
+    /// another struct tag.
+    pub fn is_same_type_as(&self, other: &StructTag) -> bool {
+        self.0.is_same_type_as(&other.0)
+    }
+
+    /// Checks if this is an IOTA balance type
+    /// (`0x2::balance::Balance<0x2::iota::IOTA>`)
+    pub fn is_gas_balance(&self) -> bool {
+        self.0.is_gas_balance()
+    }
+
+    /// Checks if this is a timelocked coin balance `TimeLock<Balance<T>>`
+    pub fn is_timelocked_balance(&self) -> bool {
+        self.0.is_timelocked_balance()
+    }
+
+    /// Creates a new timelocked IOTA balance struct tag
+    /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
+    #[uniffi::constructor]
+    pub fn new_timelocked_gas_balance() -> Self {
+        Self(iota_sdk::types::StructTag::new_timelocked_gas_balance())
+    }
+
+    /// Checks if this is a timelocked IOTA balance type
+    /// (`0x2::timelock::TimeLock<0x2::balance::Balance<0x2::iota::IOTA>>`)
+    pub fn is_timelocked_gas_balance(&self) -> bool {
+        self.0.is_timelocked_gas_balance()
+    }
+
     /// Returns the string representation of this struct tag using the
     /// canonical display, with or without a `0x` prefix.
     pub fn to_canonical_string(&self, with_prefix: bool) -> String {

--- a/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
+++ b/crates/iota-sdk-ffi/src/types/move_core/struct_tag.rs
@@ -204,6 +204,8 @@ export_struct_tag_from_type_tag_ctors!(
     ConfigSetting,
     DynamicObjectFieldWrapper,
     Coin,
+    RegulatedCoinMetadata,
+    DenyCapV1,
     TimeLock,
     Option,
     TransferReceiving,


### PR DESCRIPTION
## Why

`iota-sdk-types` exposes several `StructTag` constructors/predicates that the FFI never re-exported, leaving them unreachable from the language bindings.

## What

- Add the generic-on-chain `coin::RegulatedCoinMetadata` and `coin::DenyCapV1` ctors to `export_struct_tag_from_type_tag_ctors!` — the macro-list gap from #1188.
- Expose the remaining hand-written helpers: `is_same_type_as`, `is_gas_balance`, `is_timelocked_balance`, and the `new_timelocked_gas_balance` / `is_timelocked_gas_balance` pair.

The FFI `StructTag` surface now matches core, except `type_params_mut` (`&mut` return, not expressible via uniffi) and `into_parts` (tuple return, already covered by `address()` / `module()` / `name()` / `type_args()`).

Purely additive. Verified the bindings regenerate with all the new methods.

Closes #1188

https://claude.ai/code/session_01NjieFyT2R5NbChfEPCrfcv