### PR TITLE
fix: pass explicit npm dist-tag when publishing WASM package

### DIFF
--- a/.github/workflows/wasm_publish.yml
+++ b/.github/workflows/wasm_publish.yml
@@ -100,14 +100,26 @@ jobs:
           echo "Publishing version $version"
           npm version "$version" --no-git-tag-version --allow-same-version
 
+      - name: Determine npm dist-tag
+        working-directory: package
+        # npm >= 11.6 refuses to publish a prerelease version without an
+        # explicit --tag, so prereleases are published under `next` instead of
+        # the implicit `latest`.
+        run: |
+          version=$(npm pkg get version | tr -d '"')
+          case "$version" in
+            *-*) echo "NPM_DIST_TAG=next" >> "$GITHUB_ENV" ;;
+            *) echo "NPM_DIST_TAG=latest" >> "$GITHUB_ENV" ;;
+          esac
+
       - name: Publish to npm (dry-run)
         if: github.event_name == 'workflow_dispatch' && inputs.test_publish == true
         working-directory: package
-        run: npm publish --access public --ignore-scripts --dry-run
+        run: npm publish --access public --ignore-scripts --tag "$NPM_DIST_TAG" --dry-run
 
       - name: Publish to npm
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.test_publish == false)
         working-directory: package
         # Authenticates via npm OIDC trusted publishing (no NPM_TOKEN). The repo
         # is public, so --provenance attaches a verifiable build attestation.
-        run: npm publish --access public --ignore-scripts --provenance
+        run: npm publish --access public --ignore-scripts --tag "$NPM_DIST_TAG" --provenance

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iotaledger/iota-rust-sdk"
+    "url": "git+https://github.com/iotaledger/iota-rust-sdk.git"
   },
   "type": "module",
   "main": "dist/iota-sdk.js",


### PR DESCRIPTION
npm >= 11.6 refuses to publish a prerelease version without an explicit `--tag`, which broke the publish workflow for `3.0.0-alpha.1` (dry-run and real publish alike). The workflow now derives the dist-tag from the package version (prerelease → `next`, otherwise `latest`) and passes it to `npm publish`. Also normalizes `repository.url` in `package.json` to silence an npm publish warning.

Test plan: dry-run dispatch on this branch — https://github.com/iotaledger/iota-rust-sdk/actions/runs/27337452224

https://claude.ai/code/session_01Gv2K4YTJkRnNeiHUfUv1xm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv2K4YTJkRnNeiHUfUv1xm)_