### PR TITLE
chore: install prebuilt cargo-udeps in CI

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -95,8 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Install nightly cargo-udeps
-        run: cargo +nightly install cargo-udeps
+      - name: Install cargo-udeps
+        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        with:
+          tool: cargo-udeps
       - name: Run Cargo Udeps
         run: cargo +nightly udeps ${{ matrix.flags }}
 


### PR DESCRIPTION
The `Check Unused Dependencies` jobs fail on every PR because `cargo +nightly install cargo-udeps` no longer compiles on the latest nightly: its `cargo-credential` dependency hits an E0119 coherence conflict with an old `time` crate.

Fetch a prebuilt binary via `taiki-e/install-action` instead (already used for cargo-hack), pinned to the v2.81.10 release commit. This is also faster than building from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)