### PR TITLE
chore(graphql): remove WRAPPED_OR_DELETED from ObjectKind

### DIFF
--- a/crates/iota-sdk-graphql-client-build/schema.graphql
+++ b/crates/iota-sdk-graphql-client-build/schema.graphql
@@ -586,8 +586,6 @@ type Coin implements IMoveObject & IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -801,8 +799,6 @@ type CoinMetadata implements IMoveObject & IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -1696,8 +1692,6 @@ interface IObject {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -2355,8 +2349,6 @@ type MoveObject implements IMoveObject & IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -2600,8 +2592,6 @@ type MovePackage implements IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -3100,8 +3090,6 @@ type NameRegistration implements IMoveObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -3325,8 +3313,6 @@ type Object implements IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """
@@ -3569,11 +3555,6 @@ enum ObjectKind {
   The object is fetched from the index.
   """
   INDEXED
-  """
-  The object is deleted or wrapped and only partial information can be
-  loaded from the indexer.
-  """
-  WRAPPED_OR_DELETED
 }
 
 """
@@ -4589,8 +4570,6 @@ type StakedIota implements IMoveObject & IObject & IOwner {
   contents of a genesis or system package upgrade transaction.
   - INDEXED: The object is retrieved from the off-chain index and
   represents the most recent or historical state of the object.
-  - WRAPPED_OR_DELETED: The object is deleted or wrapped and only partial
-  information can be loaded.
   """
   status: ObjectKind!
   """


### PR DESCRIPTION
## Why

Sync the bundled GraphQL schema with upstream, which dropped the `WRAPPED_OR_DELETED` variant from `ObjectKind` (and its references in object `status` field docs).

## What

Removes the `WRAPPED_OR_DELETED` enum value and the corresponding doc lines from `iota-sdk-graphql-client-build/schema.graphql`. No Rust code references the variant, and `cargo check -p iota-sdk-graphql-client` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)