### PR TITLE
release: bump `iota-wasm-sdk` version to `3.0.0-alpha.1`

### DIFF
--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -1,0 +1,3 @@
+## [3.0.0-alpha.1] - 2026-06-16
+
+Initial Release


### PR DESCRIPTION
Initial release of `iota-wasm-sdk` at `3.0.0-alpha.1`, aligning with the `iota-sdk` and `iota-python-sdk` 3.x line.

Created manually rather than via the `Pre-publish` workflow. `bindings/wasm/package.json` is already at `3.0.0-alpha.1` on `develop`, so the only change is a minimal initial CHANGELOG entry. The branch name `release/iota-wasm-sdk/3.0.0-alpha.1` drives the tag: on merge, `release.yml` creates a draft GitHub release tagged `iota-wasm-sdk-v3.0.0-alpha.1`. Publishing that draft creates the git tag and triggers the npm publish.

---
_Generated by [Claude Code](https://claude.ai/code/session_018FvCrU2fxcroatA77J6YcN)_