### PR TITLE
fix: accept optional 0x prefix in FFI hex_decode

### DIFF
--- a/crates/iota-sdk-ffi/src/lib.rs
+++ b/crates/iota-sdk-ffi/src/lib.rs
@@ -38,8 +38,21 @@ pub fn hex_encode(input: &[u8]) -> String {
 
 #[uniffi::export]
 pub fn hex_decode(input: String) -> crate::error::Result<Vec<u8>> {
+    let input = input.strip_prefix("0x").unwrap_or(&input);
     Ok(hex::decode(input)?)
 }
 
 crate::export_primitive_types_bcs_conversion!(u8, u16, u32, u64, i8, i16, i32, i64, bool, String);
 crate::export_primitive_types_json_conversion!(u8, u16, u32, u64, i8, i16, i32, i64, bool, String);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_decode_accepts_optional_0x_prefix() {
+        let expected = vec![0xde, 0xad, 0xbe, 0xef];
+        assert_eq!(hex_decode("deadbeef".to_owned()).unwrap(), expected);
+        assert_eq!(hex_decode("0xdeadbeef".to_owned()).unwrap(), expected);
+    }
+}


### PR DESCRIPTION
## Why

`hexDecode("0x…")` threw `Invalid character 'x'`, forcing callers to strip the prefix manually — awkward given `0x`-prefixed hex is the dominant on-chain format. (Ergonomic nit noted in #1213.)

## What

`hex_decode` in `iota-sdk-ffi` now strips an optional leading `0x` before decoding. Added a unit test covering both prefixed and unprefixed input.

[run-ci]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DeyuE6Qx9ADpchRPTqSdf

---
_Generated by [Claude Code](https://claude.ai/code/session_012DeyuE6Qx9ADpchRPTqSdf)_