### PR TITLE
fix: surface GraphQL errors instead of panicking on partial responses

### DIFF
--- a/crates/iota-sdk-graphql-client/src/client.rs
+++ b/crates/iota-sdk-graphql-client/src/client.rs
@@ -22,13 +22,19 @@ pub(crate) static USER_AGENT: &str =
     concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 /// Helper function to convert a GraphQL response to a Result.
+///
+/// A GraphQL response may carry `errors` together with (possibly partial)
+/// `data` — for example when a request exceeds the server's max page size, the
+/// failing field is set to `null` in `data` and the reason is reported in
+/// `errors`. In that case the errors take precedence, so any populated `errors`
+/// list is surfaced as a query error rather than being treated as a
+/// success. A response with neither `data` nor `errors` is reported as an empty
+/// response error instead of panicking.
 pub(crate) fn response_to_err<T>(response: GraphQlResponse<T>) -> Result<T, Error> {
     match (response.data, response.errors) {
-        (Some(data), None) => Ok(data),
-        (None, Some(errors)) => Err(Error::graphql_error(errors)),
-        _ => unreachable!(
-            "Either data or errors must be present in a GraphQL response, but not both"
-        ),
+        (_, Some(errors)) if !errors.is_empty() => Err(Error::graphql_error(errors)),
+        (Some(data), _) => Ok(data),
+        (None, _) => Err(Error::empty_response_error()),
     }
 }
 
@@ -188,6 +194,8 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::test_utils::test_client;
 
@@ -204,6 +212,42 @@ mod tests {
 
         assert!(client.set_rpc_server("localhost:9125/graphql").is_ok());
         assert!(client.set_rpc_server("9125/graphql").is_err());
+    }
+
+    // A response carrying both partial `data` and a populated `errors` list
+    // (e.g. an oversized page request) must surface the errors instead of
+    // panicking on the unreachable arm.
+    #[test]
+    fn test_response_to_err_data_and_errors() {
+        let response: GraphQlResponse<serde_json::Value> = serde_json::from_value(json!({
+            "data": { "epoch": null },
+            "errors": [{ "message": "Page size 75 exceeds the max page size of 50" }],
+        }))
+        .unwrap();
+
+        let err = response_to_err(response).unwrap_err();
+        assert!(err.graphql_errors().is_some());
+    }
+
+    #[test]
+    fn test_response_to_err_data_only() {
+        let response: GraphQlResponse<serde_json::Value> =
+            serde_json::from_value(json!({ "data": { "epoch": 1 } })).unwrap();
+
+        let data = response_to_err(response).unwrap();
+        assert_eq!(data, json!({ "epoch": 1 }));
+    }
+
+    #[test]
+    fn test_response_to_err_errors_only() {
+        let response: GraphQlResponse<serde_json::Value> = serde_json::from_value(json!({
+            "data": null,
+            "errors": [{ "message": "boom" }],
+        }))
+        .unwrap();
+
+        let err = response_to_err(response).unwrap_err();
+        assert!(err.graphql_errors().is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

Fixes #1215. A page size above the server's max (50) made the wasm module trap with `RuntimeError: unreachable` — a Rust panic crossing the FFI boundary with no message.

The root cause is in `iota-sdk-graphql-client`: a GraphQL response can carry **both** partial `data` and `errors` (an oversized-page request nulls the failing field in `data` and reports the reason in `errors`). `response_to_err` only handled the data-xor-errors cases and hit `unreachable!()` otherwise.

## What

`response_to_err` now handles all combinations: a populated `errors` list takes precedence and is returned as a query error, and a response with neither field falls back to an empty-response error instead of panicking. JS callers now get a proper `SdkFfiError` (e.g. "Page size 75 exceeds the max page size of 50"). Fixing it in the client means native targets benefit too.

## Test plan

Added unit tests for the data+errors, data-only, and errors-only cases. `cargo test`, clippy, and nightly fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019wFK1Xpjzxi6khMvz6PhRD)_