### PR TITLE
fix: apply PaginationFilter direction default in wasm bindings

### DIFF
--- a/bindings/wasm/scripts/fix-generated-typescript.mjs
+++ b/bindings/wasm/scripts/fix-generated-typescript.mjs
@@ -40,6 +40,27 @@ fixed = fixed.replace(
   'from "./wasm-bindgen/index_bg.js"'
 );
 
+// Restore the default for `PaginationFilter.direction`.
+// uniffi record metadata can only encode literal defaults (numbers, strings,
+// bools, None, Some(...), []), never an enum variant, so the `#[default]`
+// `Direction::Forward` on the Rust field cannot be carried into the bindings.
+// As a result ubrn emits `direction` as a required field and omits it from the
+// record's `defaults()`. In TypeScript that surfaces as a type error, but in
+// plain JS the field is silently `undefined`, the enum converter lowers it to a
+// garbage ordinal, and the next call panics ("Invalid Direction enum value").
+// Upgrading does not help: uniffi's bare `#[uniffi(default)]` keyword exists
+// (>=0.30) but ubrn deliberately renders an enum type-default as `undefined`
+// ("no canonical first variant"), reproducing the same bug. So we inject the
+// Rust-side default here, which also makes `direction` optional in `.new({...})`
+// to match the Rust API. Idempotent: skipped if already set.
+fixed = fixed.replace(
+  /(export const PaginationFilter = \(\(\) => \{[\s\S]*?const defaults = \(\) => \(\{)([\s\S]*?)(\}\);)/,
+  (full, head, body, tail) =>
+    /[\s{,]direction\s*:/.test(body)
+      ? full
+      : `${head}\n        direction: Direction.Forward,${body}${tail}`
+);
+
 if (source !== fixed) {
   writeFileSync(bindingsFile, fixed);
   console.log('Normalized generated TypeScript bindings.');


### PR DESCRIPTION
Constructing `PaginationFilter` in JS without `direction` left the field `undefined`; the enum converter lowered it to a garbage ordinal and the next call panicked (`Invalid Direction enum value: 65536`).

uniffi record metadata can't encode an enum-variant default, so ubrn omits `direction` from the generated `defaults()`. This injects the Rust-side default (`Direction.Forward`) into the `PaginationFilter` factory in `fix-generated-typescript.mjs`, so omitting `direction` now matches the Rust API and the field becomes optional in `.new({…})`. The patch is idempotent.

Upgrading the toolchain doesn't fix it: the latest `uniffi-bindgen-react-native` still renders an enum type-default as `undefined`, reproducing the same bug.

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbXPUrsd7PuttHeHCyNMa5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbXPUrsd7PuttHeHCyNMa5)_