### PR TITLE
fix: expose CoinMetadata.supply as a native integer in bindings

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/api/coins.rs
+++ b/crates/iota-sdk-ffi/src/graphql/api/coins.rs
@@ -60,13 +60,13 @@ impl GraphQLClient {
 
     /// Get the coin metadata for the coin type.
     pub async fn coin_metadata(&self, coin_type: &str) -> Result<Option<CoinMetadata>> {
-        Ok(self
-            .0
+        self.0
             .read()
             .await
             .coin_metadata(coin_type)
             .await?
-            .map(Into::into))
+            .map(CoinMetadata::try_from)
+            .transpose()
     }
 
     /// Get total supply for the coin type.

--- a/crates/iota-sdk-ffi/src/graphql/query_types.rs
+++ b/crates/iota-sdk-ffi/src/graphql/query_types.rs
@@ -15,23 +15,20 @@ use iota_sdk::graphql_client::{
     },
 };
 
-use crate::types::{
-    address::Address,
-    move_core::TypeTag,
-    object::ObjectId,
-    transaction::{SignedTransaction, TransactionEffects},
+use crate::{
+    error::SdkFfiError,
+    types::{
+        address::Address,
+        move_core::TypeTag,
+        object::ObjectId,
+        transaction::{SignedTransaction, TransactionEffects},
+    },
 };
 
 uniffi::custom_type!(Base64, String, {
     remote,
     lower: |val| val.0,
     try_lift: |s| Ok(Base64(s)),
-});
-
-uniffi::custom_type!(BigInt, String, {
-    remote,
-    lower: |val| val.0,
-    try_lift: |s| Ok(BigInt(s)),
 });
 
 #[derive(uniffi::Record)]
@@ -968,23 +965,30 @@ pub struct CoinMetadata {
     pub symbol: Option<String>,
     /// The overall quantity of tokens that will be issued.
     #[uniffi(default = None)]
-    pub supply: Option<BigInt>,
+    pub supply: Option<u64>,
     /// Version of the token.
     pub version: u64,
 }
 
-impl From<iota_sdk::graphql_client::query_types::CoinMetadata> for CoinMetadata {
-    fn from(value: iota_sdk::graphql_client::query_types::CoinMetadata) -> Self {
-        Self {
+impl TryFrom<iota_sdk::graphql_client::query_types::CoinMetadata> for CoinMetadata {
+    type Error = SdkFfiError;
+
+    fn try_from(
+        value: iota_sdk::graphql_client::query_types::CoinMetadata,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
             address: Arc::new(value.address.into()),
             decimals: value.decimals,
             description: value.description,
             icon_url: value.icon_url,
             name: value.name,
             symbol: value.symbol,
-            supply: value.supply,
+            // The GraphQL `BigInt` scalar carries the supply as a decimal
+            // string; on-chain a coin's supply is a `u64`, so parse it into one
+            // to expose a native integer (e.g. `bigint` in TS) to bindings.
+            supply: value.supply.map(u64::try_from).transpose()?,
             version: value.version,
-        }
+        })
     }
 }
 
@@ -997,7 +1001,7 @@ impl From<CoinMetadata> for iota_sdk::graphql_client::query_types::CoinMetadata 
             icon_url: value.icon_url,
             name: value.name,
             symbol: value.symbol,
-            supply: value.supply,
+            supply: value.supply.map(|supply| BigInt(supply.to_string())),
             version: value.version,
         }
     }


### PR DESCRIPTION
Fixes #1212.

`CoinMetadata.supply` used the uniffi custom `BigInt` type, which lowers to a **string**. So the generated bindings declared the field as `BigInt` while the runtime value was a decimal string, and it diverged from `total_supply()`, which returns a native `u64` (`bigint` in TS, `ULong` in Kotlin, …).

A coin's on-chain supply is a `u64` (the GraphQL client already parses it into one for `total_supply()`), so this exposes `supply` as `Option<u64>`. It's now a real integer across **all** bindings — matching its declaration and `total_supply()`. The `graphql → ffi` conversion becomes fallible (the `BigInt` string → `u64` parse), and the now-unused `BigInt` custom-type registration is removed.

> [!NOTE]
> Behavioral change: the runtime type of `supply` goes from a string to a native integer in every binding. Acceptable since there are no external consumers yet.

### Test plan
- `cargo check`, `clippy -Dwarnings`, and `cargo test -p iota-sdk-ffi` pass; nightly `rustfmt --check` clean.
- Generated the Kotlin/Python/Swift bindings locally and confirmed `supply` renders as `kotlin.ULong?` / `Optional[int]` / `UInt64?` — consistent with `total_supply()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKknNs3PwbZUBmYeHa6T1r

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKknNs3PwbZUBmYeHa6T1r)_