### PR TITLE
fix: unbreak feature-powerset check, tests, and tx examples

### DIFF
--- a/crates/iota-sdk-graphql-client/src/api/transactions.rs
+++ b/crates/iota-sdk-graphql-client/src/api/transactions.rs
@@ -374,7 +374,7 @@ mod tests {
 
         client
             .transaction_data_effects(
-                TransactionDigest::from_base58("CY14gCcLcVuSMN9Hq7Ya6vEhBAzSzciNw47togWXJAZ8")
+                TransactionDigest::from_base58("FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj")
                     .unwrap(),
             )
             .await
@@ -390,7 +390,7 @@ mod tests {
             .transactions_data_effects(
                 TransactionsFilter {
                     transaction_ids: Some(vec![
-                        "CY14gCcLcVuSMN9Hq7Ya6vEhBAzSzciNw47togWXJAZ8".to_string(),
+                        "FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj".to_string(),
                     ]),
                     ..Default::default()
                 },

--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "serde")]
 use std::hash::{Hash, Hasher};
 
 use crate::{Address, Input, ObjectReference, TypeTag, transaction::SharedObjectReference};

--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -183,7 +183,7 @@ mod tests {
     use base64ct::{Base64, Encoding};
 
     use super::*;
-    use crate::{Digest, ObjectId, SignatureScheme, StructTag, Version};
+    use crate::{ObjectDigest, ObjectId, SignatureScheme, StructTag, Version};
 
     #[cfg(feature = "proptest")]
     #[test_strategy::proptest]
@@ -200,7 +200,7 @@ mod tests {
             ObjectReference {
                 object_id: ObjectId::ZERO,
                 version: Version::default(),
-                digest: Digest::MIN,
+                digest: ObjectDigest::MIN,
             },
         )
         .into()
@@ -250,7 +250,7 @@ mod tests {
             Input::Receiving(ObjectReference {
                 object_id: ObjectId::ZERO,
                 version: Version::default(),
-                digest: Digest::MIN,
+                digest: ObjectDigest::MIN,
             }),
         ];
 
@@ -344,7 +344,11 @@ mod tests {
     /// owned / receiving / mutable-shared inputs.
     fn synthetic_fixtures() -> Vec<SyntheticFixture> {
         let owned = |b: u8, v: u64| {
-            ObjectReference::new(ObjectId::new([b; 32]), Version::from_u64(v), Digest::MIN)
+            ObjectReference::new(
+                ObjectId::new([b; 32]),
+                Version::from_u64(v),
+                ObjectDigest::MIN,
+            )
         };
         let shared = |b: u8, v: u64, mutable: bool| {
             SharedObjectReference::new(ObjectId::new([b; 32]), Version::from_u64(v), mutable)
@@ -353,7 +357,7 @@ mod tests {
             Input::Receiving(ObjectReference::new(
                 ObjectId::new([b; 32]),
                 Version::from_u64(v),
-                Digest::MIN,
+                ObjectDigest::MIN,
             ))
         };
 

--- a/crates/iota-sdk/examples/get_transaction.rs
+++ b/crates/iota-sdk/examples/get_transaction.rs
@@ -9,7 +9,7 @@ use iota_sdk::{
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
-    let digest = TransactionDigest::from_base58("3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh")?;
+    let digest = TransactionDigest::from_base58("FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj")?;
 
     let signed_transaction = client.transaction(digest).await?.expect("tx not found");
     println!("Signed Transaction: {signed_transaction:#?}\n");


### PR DESCRIPTION
## Why

Three independent breakages were keeping CI red:

- **`feature-powerset` check** — `std::hash::{Hash, Hasher}` in `move_authenticator.rs` is only used by the serde-gated `impl Hash`, so `cargo check --no-default-features` failed under `-D warnings`. Gated the import behind `serde`, matching `passkey.rs`.
- **`examples` + `tests-with-network`** — testnet pruned the transaction the `get_transaction` example and the graphql-client `transaction_data_effects` tests referenced. Repointed them at a current testnet tx (cherry-picked from #1029).
- **`tests` / `lint`** — the digest newtype split (#1232) changed `ObjectReference` to hold an `ObjectDigest` but didn't update the `MoveAuthenticator` test fixtures, which still built bare `Digest::MIN`. Switched them to `ObjectDigest::MIN` (byte-identical, so the frozen wire/digest fixtures are unchanged).

## Test plan

- `cargo test -p iota-sdk-types --all-features` — 324 passing, incl. the frozen fixtures.
- `cargo clippy -p iota-sdk-types --all-targets --all-features -- -D warnings` — clean.
- `cargo check --no-default-features` across the feature powerset — clean.
- `cargo +nightly fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmcB2BU5TQTD9LMGk1BdQP