### PR TITLE
fix: forward pagination arguments in the checkpoints GraphQL query

### DIFF
--- a/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
+++ b/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
@@ -149,6 +149,30 @@ impl Client {
 mod tests {
     use crate::{PaginationFilter, test_utils::test_client};
 
+    /// Guards #1210: the `checkpoints` field must forward its pagination
+    /// arguments. Without them the server returns its default page and every
+    /// `PaginationFilter` (direction, limit, cursor) is silently ignored.
+    #[test]
+    fn checkpoints_query_forwards_pagination_arguments() {
+        use cynic::QueryBuilder;
+
+        use crate::query_types::{CheckpointsArgs, CheckpointsQuery};
+
+        let operation = CheckpointsQuery::build(CheckpointsArgs {
+            first: Some(10),
+            after: None,
+            last: None,
+            before: None,
+        });
+        for arg in ["first:", "after:", "last:", "before:"] {
+            assert!(
+                operation.query.contains(arg),
+                "checkpoints query is missing the `{arg}` argument:\n{}",
+                operation.query
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_checkpoint_query() {
         let client = test_client();

--- a/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
+++ b/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
@@ -149,9 +149,6 @@ impl Client {
 mod tests {
     use crate::{PaginationFilter, test_utils::test_client};
 
-    /// Guards #1210: the `checkpoints` field must forward its pagination
-    /// arguments. Without them the server returns its default page and every
-    /// `PaginationFilter` (direction, limit, cursor) is silently ignored.
     #[test]
     fn checkpoints_query_forwards_pagination_arguments() {
         use cynic::QueryBuilder;

--- a/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
@@ -41,6 +41,7 @@ pub struct CheckpointTotalTx {
 #[derive(cynic::QueryFragment, Debug)]
 #[cynic(schema = "rpc", graphql_type = "Query", variables = "CheckpointsArgs")]
 pub struct CheckpointsQuery {
+    #[arguments(first: $first, after: $after, last: $last, before: $before)]
     pub checkpoints: CheckpointConnection,
 }
 


### PR DESCRIPTION
## Why

`GraphQlClient.checkpoints(paginationFilter)` ignored its filter entirely — any `direction`/`limit`/`cursor` returned the same default page (#1210).

Root cause is Rust-side, not the bindings: the cynic `CheckpointsQuery` declared `variables = "CheckpointsArgs"` but never attached `#[arguments(...)]` to the `checkpoints` connection field, so the generated GraphQL omitted `first/after/last/before`. The Rust GraphQL client had the same bug; the wasm bindings just surfaced it.

## What

- Attach `#[arguments(first: $first, after: $after, last: $last, before: $before)]` to the `checkpoints` field (matches `objects.graphql` and the sibling `CheckpointQuery`).
- Add an offline regression test asserting the generated query forwards the pagination arguments — the previous network test only checked "returns data" with the default filter, so it never caught this.

## Test plan

- New test `checkpoints_query_forwards_pagination_arguments` passes; confirmed it fails if the `#[arguments]` is removed.
- End-to-end against mainnet via the wasm bindings (reporter's exact repro):
  - Before: `checkpoints({direction: Backward, limit: 40})` → 20 items (default page).
  - After: → **40** items, newest sequence numbers; `{Forward, limit: 5}` → **5** items. Filter honored.
- `cargo clippy` (all targets) + `cargo +nightly fmt --check` clean.

Closes #1210
