### PR TITLE
refactor: use fastcrypto for ed25519, secp256r1 and secp256k1 crypto

### DIFF
--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -29,13 +29,14 @@ default = []
 ed25519 = ["dep:fastcrypto", "dep:rand_core"]
 secp256r1 = ["dep:fastcrypto", "dep:rand_core"]
 passkey = ["secp256r1", "dep:sha2"]
-secp256k1 = ["dep:k256", "dep:rand_core", "signature/std"]
+secp256k1 = ["dep:fastcrypto", "dep:rand_core"]
 bech32 = ["dep:bech32", "signature/std"]
-# PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519-dalek and p256
-# are pulled in purely as encoders/decoders here; the actual signing and
+# PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519-dalek, p256 and
+# k256 are pulled in purely as encoders/decoders here; the actual signing and
 # verification always go through fastcrypto.
 pem = [
   "dep:ed25519-dalek",
+  "dep:k256",
   "dep:p256",
   "dep:pem-rfc7468",
   "dep:pkcs8",
@@ -60,9 +61,9 @@ bip39 = { version = "2.0.0", features = ["rand"], optional = true }
 blst = { version = "0.3.13", optional = true }
 # ed25519 PKCS#8/PEM codec (see the `pem` feature)
 ed25519-dalek = { version = "2.1.1", optional = true }
-# ed25519 and secp256r1 signing/verification backend
+# ed25519, secp256r1 and secp256k1 signing/verification backend
 fastcrypto = { version = "=0.1.11", optional = true }
-# secp256k1 support
+# secp256k1 PKCS#8/PEM codec (see the `pem` feature)
 k256 = { version = "0.13.4", default-features = false, features = ["ecdsa"], optional = true }
 # secp256r1 PKCS#8/PEM codec (see the `pem` feature)
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"], optional = true }

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -26,10 +26,10 @@ rustdoc-args = [
 
 [features]
 default = []
-ed25519 = ["dep:fastcrypto", "dep:rand_core"]
-secp256r1 = ["dep:fastcrypto", "dep:rand_core"]
+ed25519 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
+secp256r1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 passkey = ["secp256r1", "dep:sha2"]
-secp256k1 = ["dep:fastcrypto", "dep:rand_core"]
+secp256k1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 bech32 = ["dep:bech32", "signature/std"]
 # PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519-dalek, p256 and
 # k256 are pulled in purely as encoders/decoders here; the actual signing and
@@ -78,6 +78,7 @@ sha2 = { version = "0.10.8", optional = true }
 signature = "2.2"
 slip10_ed25519 = { version = "0.1.3", optional = true }
 thiserror.workspace = true
+zeroize = { version = "1.8", features = ["derive"], optional = true }
 
 # internal dependencies
 iota-types = { workspace = true, features = ["hash", "serde"] }

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -31,17 +31,18 @@ secp256r1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 passkey = ["secp256r1", "dep:sha2"]
 secp256k1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 bech32 = ["dep:bech32", "signature/std"]
-# PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519-dalek, p256 and
+# PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519, p256 and
 # k256 are pulled in purely as encoders/decoders here; the actual signing and
 # verification always go through fastcrypto.
 pem = [
-  "dep:ed25519-dalek",
+  "dep:ed25519",
   "dep:k256",
   "dep:p256",
   "dep:pem-rfc7468",
   "dep:pkcs8",
-  "ed25519-dalek?/pem",
-  "ed25519-dalek?/pkcs8",
+  "ed25519?/pem",
+  "ed25519?/pkcs8",
+  "ed25519?/zeroize",
   "k256?/pem",
   "k256?/pkcs8",
   "p256?/pem",
@@ -60,7 +61,7 @@ bip39 = { version = "2.0.0", features = ["rand"], optional = true }
 # bls12381 support
 blst = { version = "0.3.13", optional = true }
 # ed25519 PKCS#8/PEM codec (see the `pem` feature)
-ed25519-dalek = { version = "2.1.1", optional = true }
+ed25519 = { version = "2.2", optional = true }
 # ed25519, secp256r1 and secp256k1 signing/verification backend
 fastcrypto = { version = "=0.1.11", optional = true }
 # secp256k1 PKCS#8/PEM codec (see the `pem` feature)

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -26,12 +26,17 @@ rustdoc-args = [
 
 [features]
 default = []
-ed25519 = ["dep:ed25519-dalek", "dep:rand_core"]
-secp256r1 = ["dep:p256", "dep:rand_core"]
+ed25519 = ["dep:fastcrypto", "dep:rand_core"]
+secp256r1 = ["dep:fastcrypto", "dep:rand_core"]
 passkey = ["secp256r1", "dep:sha2"]
 secp256k1 = ["dep:k256", "dep:rand_core", "signature/std"]
 bech32 = ["dep:bech32", "signature/std"]
+# PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519-dalek and p256
+# are pulled in purely as encoders/decoders here; the actual signing and
+# verification always go through fastcrypto.
 pem = [
+  "dep:ed25519-dalek",
+  "dep:p256",
   "dep:pem-rfc7468",
   "dep:pkcs8",
   "ed25519-dalek?/pem",
@@ -53,11 +58,13 @@ bip32 = { version = "0.5.3", optional = true }
 bip39 = { version = "2.0.0", features = ["rand"], optional = true }
 # bls12381 support
 blst = { version = "0.3.13", optional = true }
-# ed25519 support
+# ed25519 PKCS#8/PEM codec (see the `pem` feature)
 ed25519-dalek = { version = "2.1.1", optional = true }
+# ed25519 and secp256r1 signing/verification backend
+fastcrypto = { version = "0.1.10", optional = true }
 # secp256k1 support
 k256 = { version = "0.13.4", default-features = false, features = ["ecdsa"], optional = true }
-# secp256r1 support
+# secp256r1 PKCS#8/PEM codec (see the `pem` feature)
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "std"], optional = true }
 # pkcs8 der and pem support
 pem-rfc7468 = { version = "0.7", optional = true, features = ["std"] }
@@ -73,6 +80,10 @@ thiserror.workspace = true
 
 # internal dependencies
 iota-types = { workspace = true, features = ["hash", "serde"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# On wasm32 fastcrypto needs getrandom's "js" backend, enabled by its "wasm" feature.
+fastcrypto = { version = "0.1.10", optional = true, features = ["wasm"] }
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -89,7 +89,7 @@ impl Ed25519PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use ed25519_dalek::pkcs8::EncodePrivateKey;
 
-        self.as_dalek()
+        self.to_dalek()
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -110,7 +110,7 @@ impl Ed25519PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.as_dalek()
+        self.to_dalek()
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
@@ -125,7 +125,7 @@ impl Ed25519PrivateKey {
     /// PKCS#8/PEM codec. Don't sign with the returned key — use this type's
     /// `Signer` impl (`try_sign`) instead, so signing goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn as_dalek(&self) -> ed25519_dalek::SigningKey {
+    fn to_dalek(&self) -> ed25519_dalek::SigningKey {
         ed25519_dalek::SigningKey::from_bytes(&self.0)
     }
 }
@@ -271,7 +271,7 @@ impl Ed25519VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.as_dalek()?
+        self.to_dalek()?
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -292,7 +292,7 @@ impl Ed25519VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.as_dalek()?
+        self.to_dalek()?
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
@@ -309,7 +309,7 @@ impl Ed25519VerifyingKey {
     /// PKCS#8/PEM codec. Don't verify with the returned key — use this type's
     /// `Verifier` impl instead, so verification goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn as_dalek(&self) -> Result<ed25519_dalek::VerifyingKey, SignatureError> {
+    fn to_dalek(&self) -> Result<ed25519_dalek::VerifyingKey, SignatureError> {
         ed25519_dalek::VerifyingKey::from_bytes(
             self.0
                 .as_ref()

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -207,7 +207,7 @@ impl Signer<Ed25519Signature> for Ed25519PrivateKey {
             signature
                 .as_ref()
                 .try_into()
-                .expect("ed25519 signature is 64 bytes"),
+                .expect("ed25519 signature must be 64 bytes"),
         ))
     }
 }
@@ -252,7 +252,7 @@ impl Ed25519VerifyingKey {
             self.0
                 .as_ref()
                 .try_into()
-                .expect("ed25519 public key is 32 bytes"),
+                .expect("ed25519 public key must be 32 bytes"),
         )
     }
 
@@ -314,7 +314,7 @@ impl Ed25519VerifyingKey {
             self.0
                 .as_ref()
                 .try_into()
-                .expect("ed25519 public key is 32 bytes"),
+                .expect("ed25519 public key must be 32 bytes"),
         )
         .map_err(SignatureError::from_source)
     }

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -2,6 +2,13 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::{
+    ed25519::{
+        Ed25519KeyPair, Ed25519PublicKey as FcEd25519PublicKey,
+        Ed25519Signature as FcEd25519Signature,
+    },
+    traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
+};
 use iota_types::{
     Ed25519PublicKey, Ed25519Signature, SignatureScheme, SimpleSignature, UserSignature,
 };
@@ -9,7 +16,7 @@ use iota_types::{
 use crate::{SignatureError, Signer, Verifier};
 
 #[derive(Clone, Eq, PartialEq)]
-pub struct Ed25519PrivateKey(ed25519_dalek::SigningKey);
+pub struct Ed25519PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Ed25519PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -37,16 +44,20 @@ impl Ed25519PrivateKey {
     pub const LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
-        Self(bytes.into())
+        Self(bytes)
     }
 
     pub fn scheme(&self) -> SignatureScheme {
         SignatureScheme::Ed25519
     }
 
+    /// Reconstruct the fastcrypto keypair, which performs all signing.
+    fn keypair(&self) -> Ed25519KeyPair {
+        Ed25519KeyPair::from_bytes(&self.0).expect("any 32 bytes are a valid ed25519 seed")
+    }
+
     pub fn verifying_key(&self) -> Ed25519VerifyingKey {
-        let verifying_key = self.0.verifying_key();
-        Ed25519VerifyingKey(verifying_key)
+        Ed25519VerifyingKey(self.keypair().public().clone())
     }
 
     pub fn public_key(&self) -> Ed25519PublicKey {
@@ -59,7 +70,7 @@ impl Ed25519PrivateKey {
     {
         let mut buf: [u8; Self::LENGTH] = [0; Self::LENGTH];
         rng.fill_bytes(&mut buf);
-        Self(buf.into())
+        Self::new(buf)
     }
 
     #[cfg(feature = "pem")]
@@ -68,7 +79,7 @@ impl Ed25519PrivateKey {
     /// format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         ed25519_dalek::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
-            .map(Self)
+            .map(Self::from_dalek)
             .map_err(SignatureError::from_source)
     }
 
@@ -78,7 +89,7 @@ impl Ed25519PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use ed25519_dalek::pkcs8::EncodePrivateKey;
 
-        self.0
+        self.as_dalek()
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -89,7 +100,7 @@ impl Ed25519PrivateKey {
     /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         ed25519_dalek::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
-            .map(Self)
+            .map(Self::from_dalek)
             .map_err(SignatureError::from_source)
     }
 
@@ -99,7 +110,7 @@ impl Ed25519PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.0
+        self.as_dalek()
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
@@ -107,7 +118,14 @@ impl Ed25519PrivateKey {
 
     #[cfg(feature = "pem")]
     pub(crate) fn from_dalek(private_key: ed25519_dalek::SigningKey) -> Self {
-        Self(private_key)
+        Self::new(private_key.to_bytes())
+    }
+
+    /// Re-expose the raw private key through ed25519-dalek, used only as a
+    /// PKCS#8/PEM codec (signing itself always goes through fastcrypto).
+    #[cfg(feature = "pem")]
+    fn as_dalek(&self) -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&self.0)
     }
 }
 
@@ -117,7 +135,7 @@ impl crate::ToFromBytes for Ed25519PrivateKey {
 
     /// Return the raw 32-byte private key
     fn to_bytes(&self) -> Self::ByteArray {
-        self.0.to_bytes()
+        self.0
     }
 
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
@@ -183,9 +201,13 @@ impl crate::FromMnemonic for Ed25519PrivateKey {
 
 impl Signer<Ed25519Signature> for Ed25519PrivateKey {
     fn try_sign(&self, msg: &[u8]) -> Result<Ed25519Signature, SignatureError> {
-        self.0
-            .try_sign(msg)
-            .map(|signature| Ed25519Signature::new(signature.to_bytes()))
+        let signature: FcEd25519Signature = self.keypair().sign(msg);
+        Ok(Ed25519Signature::new(
+            signature
+                .as_ref()
+                .try_into()
+                .expect("ed25519 signature is 64 bytes"),
+        ))
     }
 }
 
@@ -206,16 +228,31 @@ impl Signer<UserSignature> for Ed25519PrivateKey {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct Ed25519VerifyingKey(ed25519_dalek::VerifyingKey);
+#[derive(Clone, Eq, PartialEq)]
+pub struct Ed25519VerifyingKey(FcEd25519PublicKey);
+
+impl std::fmt::Debug for Ed25519VerifyingKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Ed25519VerifyingKey")
+            .field(&self.0.as_ref())
+            .finish()
+    }
+}
 
 impl Ed25519VerifyingKey {
     pub fn new(public_key: &Ed25519PublicKey) -> Result<Self, SignatureError> {
-        ed25519_dalek::VerifyingKey::from_bytes(public_key.inner()).map(Self)
+        FcEd25519PublicKey::from_bytes(public_key.inner())
+            .map(Self)
+            .map_err(SignatureError::from_source)
     }
 
     pub fn public_key(&self) -> Ed25519PublicKey {
-        Ed25519PublicKey::new(self.0.to_bytes())
+        Ed25519PublicKey::new(
+            self.0
+                .as_ref()
+                .try_into()
+                .expect("ed25519 public key is 32 bytes"),
+        )
     }
 
     #[cfg(feature = "pem")]
@@ -223,7 +260,7 @@ impl Ed25519VerifyingKey {
     /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         ed25519_dalek::pkcs8::DecodePublicKey::from_public_key_der(bytes)
-            .map(Self)
+            .map(Self::from_dalek)
             .map_err(SignatureError::from_source)
     }
 
@@ -233,7 +270,7 @@ impl Ed25519VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.as_dalek()?
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -244,7 +281,7 @@ impl Ed25519VerifyingKey {
     /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         ed25519_dalek::pkcs8::DecodePublicKey::from_public_key_pem(s)
-            .map(Self)
+            .map(Self::from_dalek)
             .map_err(SignatureError::from_source)
     }
 
@@ -254,21 +291,41 @@ impl Ed25519VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.as_dalek()?
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
 
     #[cfg(feature = "pem")]
     pub(crate) fn from_dalek(verifying_key: ed25519_dalek::VerifyingKey) -> Self {
-        Self(verifying_key)
+        Self(
+            FcEd25519PublicKey::from_bytes(verifying_key.as_bytes())
+                .expect("ed25519-dalek public key is a valid ed25519 point"),
+        )
+    }
+
+    /// Re-expose the public key through ed25519-dalek, used only as a
+    /// PKCS#8/PEM codec (verification itself always goes through
+    /// fastcrypto).
+    #[cfg(feature = "pem")]
+    fn as_dalek(&self) -> Result<ed25519_dalek::VerifyingKey, SignatureError> {
+        ed25519_dalek::VerifyingKey::from_bytes(
+            self.0
+                .as_ref()
+                .try_into()
+                .expect("ed25519 public key is 32 bytes"),
+        )
+        .map_err(SignatureError::from_source)
     }
 }
 
 impl Verifier<Ed25519Signature> for Ed25519VerifyingKey {
     fn verify(&self, message: &[u8], signature: &Ed25519Signature) -> Result<(), SignatureError> {
-        let signature = ed25519_dalek::Signature::from_bytes(signature.inner());
-        self.0.verify_strict(message, &signature)
+        let signature = FcEd25519Signature::from_bytes(signature.inner())
+            .map_err(SignatureError::from_source)?;
+        self.0
+            .verify(message, &signature)
+            .map_err(SignatureError::from_source)
     }
 }
 
@@ -282,7 +339,7 @@ impl Verifier<SimpleSignature> for Ed25519VerifyingKey {
             return Err(SignatureError::from_source("not an ed25519 signature"));
         };
 
-        if public_key.inner() != self.0.as_bytes() {
+        if public_key.inner().as_slice() != self.0.as_ref() {
             return Err(SignatureError::from_source(
                 "public_key in signature does not match",
             ));

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -53,7 +53,7 @@ impl Ed25519PrivateKey {
 
     /// Reconstruct the fastcrypto keypair, which performs all signing.
     fn keypair(&self) -> Ed25519KeyPair {
-        Ed25519KeyPair::from_bytes(&self.0).expect("validated Ed25519KeyPair on construction")
+        Ed25519KeyPair::from_bytes(&self.0).expect("validated on construction")
     }
 
     pub fn verifying_key(&self) -> Ed25519VerifyingKey {

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -53,7 +53,7 @@ impl Ed25519PrivateKey {
 
     /// Reconstruct the fastcrypto keypair, which performs all signing.
     fn keypair(&self) -> Ed25519KeyPair {
-        Ed25519KeyPair::from_bytes(&self.0).expect("any 32 bytes are a valid ed25519 seed")
+        Ed25519KeyPair::from_bytes(&self.0).expect("validated Ed25519KeyPair on construction")
     }
 
     pub fn verifying_key(&self) -> Ed25519VerifyingKey {
@@ -78,18 +78,18 @@ impl Ed25519PrivateKey {
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
-        ed25519_dalek::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
-            .map(Self::from_dalek)
+        pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
             .map_err(SignatureError::from_source)
+            .and_then(Self::from_pkcs8)
     }
 
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Serialize this private key as DER-encoded PKCS#8
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
-        use ed25519_dalek::pkcs8::EncodePrivateKey;
+        use pkcs8::EncodePrivateKey;
 
-        self.to_dalek()
+        self.to_pkcs8()
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -99,9 +99,9 @@ impl Ed25519PrivateKey {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
-        ed25519_dalek::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
-            .map(Self::from_dalek)
+        pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
             .map_err(SignatureError::from_source)
+            .and_then(Self::from_pkcs8)
     }
 
     #[cfg(feature = "pem")]
@@ -110,23 +110,37 @@ impl Ed25519PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.to_dalek()
+        self.to_pkcs8()
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
     }
 
+    /// Rejects PKCS#8 v2 documents whose embedded public key does not match
+    /// the private key.
     #[cfg(feature = "pem")]
-    pub(crate) fn from_dalek(private_key: ed25519_dalek::SigningKey) -> Self {
-        Self::new(private_key.to_bytes())
+    pub(crate) fn from_pkcs8(
+        keypair_bytes: ed25519::pkcs8::KeypairBytes,
+    ) -> Result<Self, SignatureError> {
+        let private_key = Self::new(keypair_bytes.secret_key);
+        if let Some(public_key) = &keypair_bytes.public_key
+            && public_key.as_ref() != private_key.public_key().inner()
+        {
+            return Err(SignatureError::from_source(
+                "PKCS#8 embedded public key does not match the private key",
+            ));
+        }
+        Ok(private_key)
     }
 
-    /// Re-expose the raw private key through ed25519-dalek, used only as a
-    /// PKCS#8/PEM codec. Don't sign with the returned key — use this type's
-    /// `Signer` impl (`try_sign`) instead, so signing goes through fastcrypto.
+    /// Re-expose the raw private key as PKCS#8 v2 key material (with the
+    /// public key embedded), used only as a PEM/DER codec.
     #[cfg(feature = "pem")]
-    fn to_dalek(&self) -> ed25519_dalek::SigningKey {
-        ed25519_dalek::SigningKey::from_bytes(&self.0)
+    fn to_pkcs8(&self) -> ed25519::pkcs8::KeypairBytes {
+        ed25519::pkcs8::KeypairBytes {
+            secret_key: self.0,
+            public_key: Some(ed25519::pkcs8::PublicKeyBytes(*self.public_key().inner())),
+        }
     }
 }
 
@@ -260,9 +274,9 @@ impl Ed25519VerifyingKey {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
-        ed25519_dalek::pkcs8::DecodePublicKey::from_public_key_der(bytes)
-            .map(Self::from_dalek)
+        pkcs8::DecodePublicKey::from_public_key_der(bytes)
             .map_err(SignatureError::from_source)
+            .and_then(Self::from_pkcs8)
     }
 
     #[cfg(feature = "pem")]
@@ -271,7 +285,7 @@ impl Ed25519VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_dalek()?
+        self.to_pkcs8()
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -281,9 +295,9 @@ impl Ed25519VerifyingKey {
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
-        ed25519_dalek::pkcs8::DecodePublicKey::from_public_key_pem(s)
-            .map(Self::from_dalek)
+        pkcs8::DecodePublicKey::from_public_key_pem(s)
             .map_err(SignatureError::from_source)
+            .and_then(Self::from_pkcs8)
     }
 
     #[cfg(feature = "pem")]
@@ -292,31 +306,31 @@ impl Ed25519VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_dalek()?
+        self.to_pkcs8()
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
 
+    /// Validates that the raw PKCS#8 key material is a valid ed25519 point.
     #[cfg(feature = "pem")]
-    pub(crate) fn from_dalek(verifying_key: ed25519_dalek::VerifyingKey) -> Self {
-        Self(
-            FcEd25519PublicKey::from_bytes(verifying_key.as_bytes())
-                .expect("ed25519-dalek public key is a valid ed25519 point"),
-        )
+    pub(crate) fn from_pkcs8(
+        public_key: ed25519::pkcs8::PublicKeyBytes,
+    ) -> Result<Self, SignatureError> {
+        FcEd25519PublicKey::from_bytes(public_key.as_ref())
+            .map(Self)
+            .map_err(SignatureError::from_source)
     }
 
-    /// Re-expose the public key through ed25519-dalek, used only as a
-    /// PKCS#8/PEM codec. Don't verify with the returned key — use this type's
-    /// `Verifier` impl instead, so verification goes through fastcrypto.
+    /// Re-expose the public key as PKCS#8 key material, used only as a PEM/DER
+    /// codec.
     #[cfg(feature = "pem")]
-    fn to_dalek(&self) -> Result<ed25519_dalek::VerifyingKey, SignatureError> {
-        ed25519_dalek::VerifyingKey::from_bytes(
+    fn to_pkcs8(&self) -> ed25519::pkcs8::PublicKeyBytes {
+        ed25519::pkcs8::PublicKeyBytes(
             self.0
                 .as_ref()
                 .try_into()
                 .expect("ed25519 public key must be 32 bytes"),
         )
-        .map_err(SignatureError::from_source)
     }
 }
 

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -15,7 +15,7 @@ use iota_types::{
 
 use crate::{SignatureError, Signer, Verifier};
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct Ed25519PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Ed25519PrivateKey {

--- a/crates/iota-sdk-crypto/src/multisig.rs
+++ b/crates/iota-sdk-crypto/src/multisig.rs
@@ -433,7 +433,7 @@ mod tests {
         (
             Ed25519PrivateKey::new([1u8; 32]),
             Secp256k1PrivateKey::new([2u8; 32]).unwrap(),
-            Secp256r1PrivateKey::new([3u8; 32]),
+            Secp256r1PrivateKey::new([3u8; 32]).unwrap(),
         )
     }
 

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -2,19 +2,22 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::{
+    secp256k1::{
+        Secp256k1KeyPair, Secp256k1PublicKey as FcSecp256k1PublicKey,
+        Secp256k1Signature as FcSecp256k1Signature,
+    },
+    traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
+};
 use iota_types::{
     Secp256k1PublicKey, Secp256k1Signature, SignatureScheme, SimpleSignature, UserSignature,
-};
-use k256::{
-    ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::group::GroupEncoding,
 };
 use signature::{Signer, Verifier};
 
 use crate::SignatureError;
 
 #[derive(Clone, Eq, PartialEq)]
-pub struct Secp256k1PrivateKey(SigningKey);
+pub struct Secp256k1PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Secp256k1PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -44,27 +47,48 @@ impl Secp256k1PrivateKey {
     pub const LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Result<Self, SignatureError> {
-        SigningKey::from_bytes(&bytes.into()).map(Self)
+        // Validate that the bytes form a well-formed secp256k1 private key.
+        Secp256k1KeyPair::from_bytes(&bytes).map_err(SignatureError::from_source)?;
+        Ok(Self(bytes))
     }
 
     pub fn scheme(&self) -> SignatureScheme {
         SignatureScheme::Secp256k1
     }
 
+    /// Reconstruct the fastcrypto keypair, which performs all signing.
+    fn keypair(&self) -> Secp256k1KeyPair {
+        Secp256k1KeyPair::from_bytes(&self.0).expect("validated on construction")
+    }
+
     pub fn verifying_key(&self) -> Secp256k1VerifyingKey {
-        let verifying_key = self.0.verifying_key();
-        Secp256k1VerifyingKey(*verifying_key)
+        Secp256k1VerifyingKey(self.keypair().public().clone())
     }
 
     pub fn public_key(&self) -> Secp256k1PublicKey {
-        Secp256k1PublicKey::new(self.0.verifying_key().as_ref().to_bytes().into())
+        Secp256k1PublicKey::new(
+            self.keypair()
+                .public()
+                .as_ref()
+                .try_into()
+                .expect("secp256k1 public key is 33 bytes"),
+        )
     }
 
     pub fn generate<R>(mut rng: R) -> Self
     where
         R: rand_core::RngCore + rand_core::CryptoRng,
     {
-        Self(SigningKey::random(&mut rng))
+        // Almost every 32-byte value is a valid secp256k1 private key, but a
+        // few (zero, or values at/above the curve order) are not. Draw fresh
+        // bytes until we get a valid key; in practice this never repeats.
+        loop {
+            let mut buf: [u8; Self::LENGTH] = [0; Self::LENGTH];
+            rng.fill_bytes(&mut buf);
+            if let Ok(key) = Self::new(buf) {
+                return key;
+            }
+        }
     }
 
     #[cfg(feature = "pem")]
@@ -73,7 +97,7 @@ impl Secp256k1PrivateKey {
     /// format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
-            .map(Self)
+            .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
@@ -83,7 +107,7 @@ impl Secp256k1PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use k256::pkcs8::EncodePrivateKey;
 
-        self.0
+        self.to_k256()?
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -94,7 +118,7 @@ impl Secp256k1PrivateKey {
     /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
-            .map(Self)
+            .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
@@ -104,15 +128,24 @@ impl Secp256k1PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.0
+        self.to_k256()?
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
     }
 
     #[cfg(feature = "pem")]
-    pub(crate) fn from_k256(private_key: SigningKey) -> Self {
-        Self(private_key)
+    pub(crate) fn from_k256(private_key: k256::ecdsa::SigningKey) -> Self {
+        // A k256 SigningKey is by construction a valid secp256k1 scalar.
+        Self(private_key.to_bytes().into())
+    }
+
+    /// Re-expose the raw private key through k256, used only as a PKCS#8/PEM
+    /// codec. Don't sign with the returned key — use this type's `Signer` impl
+    /// (`try_sign`) instead, so signing goes through fastcrypto.
+    #[cfg(feature = "pem")]
+    fn to_k256(&self) -> Result<k256::ecdsa::SigningKey, SignatureError> {
+        k256::ecdsa::SigningKey::from_slice(&self.0).map_err(SignatureError::from_source)
     }
 }
 
@@ -122,7 +155,7 @@ impl crate::ToFromBytes for Secp256k1PrivateKey {
 
     /// Return the raw 32-byte private key
     fn to_bytes(&self) -> Self::ByteArray {
-        self.0.to_bytes().into()
+        self.0
     }
 
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
@@ -186,8 +219,14 @@ impl crate::FromMnemonic for Secp256k1PrivateKey {
 
 impl Signer<Secp256k1Signature> for Secp256k1PrivateKey {
     fn try_sign(&self, message: &[u8]) -> Result<Secp256k1Signature, SignatureError> {
-        let signature: k256::ecdsa::Signature = self.0.try_sign(message)?;
-        Ok(Secp256k1Signature::new(signature.to_bytes().into()))
+        // fastcrypto signs with SHA-256 and normalizes the signature to low-S.
+        let signature: FcSecp256k1Signature = self.keypair().sign(message);
+        Ok(Secp256k1Signature::new(
+            signature
+                .as_ref()
+                .try_into()
+                .expect("secp256k1 signature is 64 bytes"),
+        ))
     }
 }
 
@@ -209,15 +248,22 @@ impl Signer<UserSignature> for Secp256k1PrivateKey {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Secp256k1VerifyingKey(VerifyingKey);
+pub struct Secp256k1VerifyingKey(FcSecp256k1PublicKey);
 
 impl Secp256k1VerifyingKey {
     pub fn new(public_key: &Secp256k1PublicKey) -> Result<Self, SignatureError> {
-        VerifyingKey::try_from(public_key.inner().as_ref()).map(Self)
+        FcSecp256k1PublicKey::from_bytes(public_key.inner().as_ref())
+            .map(Self)
+            .map_err(SignatureError::from_source)
     }
 
     pub fn public_key(&self) -> Secp256k1PublicKey {
-        Secp256k1PublicKey::new(self.0.as_ref().to_bytes().into())
+        Secp256k1PublicKey::new(
+            self.0
+                .as_ref()
+                .try_into()
+                .expect("secp256k1 public key is 33 bytes"),
+        )
     }
 
     #[cfg(feature = "pem")]
@@ -225,7 +271,7 @@ impl Secp256k1VerifyingKey {
     /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePublicKey::from_public_key_der(bytes)
-            .map(Self)
+            .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
@@ -235,7 +281,7 @@ impl Secp256k1VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.to_k256()?
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -246,7 +292,7 @@ impl Secp256k1VerifyingKey {
     /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePublicKey::from_public_key_pem(s)
-            .map(Self)
+            .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
@@ -256,21 +302,38 @@ impl Secp256k1VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.to_k256()?
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
 
     #[cfg(feature = "pem")]
-    pub(crate) fn from_k256(verifying_key: VerifyingKey) -> Self {
-        Self(verifying_key)
+    pub(crate) fn from_k256(verifying_key: k256::ecdsa::VerifyingKey) -> Self {
+        let compressed = verifying_key.to_encoded_point(true);
+        Self(
+            FcSecp256k1PublicKey::from_bytes(compressed.as_bytes())
+                .expect("k256 public key is a valid secp256k1 point"),
+        )
+    }
+
+    /// Re-expose the public key through k256, used only as a PKCS#8/PEM codec.
+    /// Don't verify with the returned key — use this type's `Verifier` impl
+    /// instead, so verification goes through fastcrypto.
+    #[cfg(feature = "pem")]
+    fn to_k256(&self) -> Result<k256::ecdsa::VerifyingKey, SignatureError> {
+        k256::ecdsa::VerifyingKey::from_sec1_bytes(self.0.as_ref())
+            .map_err(SignatureError::from_source)
     }
 }
 
 impl Verifier<Secp256k1Signature> for Secp256k1VerifyingKey {
     fn verify(&self, message: &[u8], signature: &Secp256k1Signature) -> Result<(), SignatureError> {
-        let signature = k256::ecdsa::Signature::from_bytes(signature.inner().into())?;
-        self.0.verify(message, &signature)
+        // fastcrypto hashes with SHA-256 and rejects high-S (malleable) signatures.
+        let signature = FcSecp256k1Signature::from_bytes(signature.inner())
+            .map_err(SignatureError::from_source)?;
+        self.0
+            .verify(message, &signature)
+            .map_err(SignatureError::from_source)
     }
 }
 
@@ -388,5 +451,61 @@ mod tests {
         let external_sig = "AVFAWGjuD8+xUoc6jMC0lKqMtT+4ukln7vz+8Nuv+EbYKl47jwzOWn39maDsqu81kezLPgLzz6o/AfSE0M9+jVwClcrtiuyUggEt/6CEZi8+JQ+NS9TmOhPBZV2X1KjhGCw=";
         let b64 = sig.to_base64();
         assert_eq!(external_sig, b64);
+    }
+
+    // The secp256k1 order n. A signature `(r, s)` has a malleable counterpart
+    // `(r, n - s)`; fastcrypto (libsecp256k1) only accepts the low-S form.
+    const SECP256K1_ORDER: [u8; 32] = [
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48, 0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36,
+        0x41, 0x41,
+    ];
+
+    // Big-endian 256-bit subtraction `a - b`.
+    fn sub_be(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
+        let mut result = [0u8; 32];
+        let mut borrow = 0i16;
+        for i in (0..32).rev() {
+            let mut diff = a[i] as i16 - b[i] as i16 - borrow;
+            if diff < 0 {
+                diff += 256;
+                borrow = 1;
+            } else {
+                borrow = 0;
+            }
+            result[i] = diff as u8;
+        }
+        result
+    }
+
+    #[test]
+    fn verify_rejects_high_s() {
+        let key = [
+            172, 12, 96, 180, 207, 143, 111, 151, 81, 57, 242, 89, 74, 5, 150, 51, 56, 111, 245,
+            150, 182, 30, 149, 178, 29, 255, 188, 27, 48, 241, 151, 193,
+        ];
+        let signer = Secp256k1PrivateKey::new(key).unwrap();
+        let verifying_key = signer.verifying_key();
+
+        let message = b"hello";
+        // fastcrypto produces a low-S signature, which verifies.
+        let sig: Secp256k1Signature = signer.try_sign(message.as_slice()).unwrap();
+        verifying_key.verify(message, &sig).unwrap();
+
+        // Malleate to the equivalent high-S signature `(r, n - s)`.
+        let bytes = sig.inner();
+        let mut r = [0u8; 32];
+        let mut s = [0u8; 32];
+        r.copy_from_slice(&bytes[..32]);
+        s.copy_from_slice(&bytes[32..]);
+        let high_s = sub_be(&SECP256K1_ORDER, &s);
+
+        let mut malleated = [0u8; 64];
+        malleated[..32].copy_from_slice(&r);
+        malleated[32..].copy_from_slice(&high_s);
+        let malleated = Secp256k1Signature::new(malleated);
+
+        // The high-S variant must be rejected even though it is algebraically valid.
+        verifying_key.verify(message, &malleated).unwrap_err();
     }
 }

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -71,7 +71,7 @@ impl Secp256k1PrivateKey {
                 .public()
                 .as_ref()
                 .try_into()
-                .expect("secp256k1 public key is 33 bytes"),
+                .expect("secp256k1 public key must be 33 bytes"),
         )
     }
 
@@ -225,7 +225,7 @@ impl Signer<Secp256k1Signature> for Secp256k1PrivateKey {
             signature
                 .as_ref()
                 .try_into()
-                .expect("secp256k1 signature is 64 bytes"),
+                .expect("secp256k1 signature must be 64 bytes"),
         ))
     }
 }
@@ -262,7 +262,7 @@ impl Secp256k1VerifyingKey {
             self.0
                 .as_ref()
                 .try_into()
-                .expect("secp256k1 public key is 33 bytes"),
+                .expect("secp256k1 public key must be 33 bytes"),
         )
     }
 

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -16,7 +16,7 @@ use signature::{Signer, Verifier};
 
 use crate::SignatureError;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct Secp256k1PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Secp256k1PrivateKey {

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -107,7 +107,7 @@ impl Secp256k1PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use k256::pkcs8::EncodePrivateKey;
 
-        self.to_k256()?
+        self.to_k256()
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -128,7 +128,7 @@ impl Secp256k1PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.to_k256()?
+        self.to_k256()
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
@@ -144,8 +144,8 @@ impl Secp256k1PrivateKey {
     /// codec. Don't sign with the returned key — use this type's `Signer` impl
     /// (`try_sign`) instead, so signing goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn to_k256(&self) -> Result<k256::ecdsa::SigningKey, SignatureError> {
-        k256::ecdsa::SigningKey::from_slice(&self.0).map_err(SignatureError::from_source)
+    fn to_k256(&self) -> k256::ecdsa::SigningKey {
+        k256::ecdsa::SigningKey::from_slice(&self.0).expect("validated on construction")
     }
 }
 
@@ -281,7 +281,7 @@ impl Secp256k1VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_k256()?
+        self.to_k256()
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -302,7 +302,7 @@ impl Secp256k1VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_k256()?
+        self.to_k256()
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
@@ -320,9 +320,9 @@ impl Secp256k1VerifyingKey {
     /// Don't verify with the returned key — use this type's `Verifier` impl
     /// instead, so verification goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn to_k256(&self) -> Result<k256::ecdsa::VerifyingKey, SignatureError> {
+    fn to_k256(&self) -> k256::ecdsa::VerifyingKey {
         k256::ecdsa::VerifyingKey::from_sec1_bytes(self.0.as_ref())
-            .map_err(SignatureError::from_source)
+            .expect("validated on construction")
     }
 }
 

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -219,7 +219,6 @@ impl crate::FromMnemonic for Secp256k1PrivateKey {
 
 impl Signer<Secp256k1Signature> for Secp256k1PrivateKey {
     fn try_sign(&self, message: &[u8]) -> Result<Secp256k1Signature, SignatureError> {
-        // fastcrypto signs with SHA-256 and normalizes the signature to low-S.
         let signature: FcSecp256k1Signature = self.keypair().sign(message);
         Ok(Secp256k1Signature::new(
             signature

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -47,7 +47,7 @@ impl Secp256k1PrivateKey {
     pub const LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Result<Self, SignatureError> {
-        // Validate that the bytes form a well-formed secp256k1 private key.
+        // Validate that the bytes represent a well-formed secp256k1 private key.
         Secp256k1KeyPair::from_bytes(&bytes).map_err(SignatureError::from_source)?;
         Ok(Self(bytes))
     }
@@ -328,7 +328,6 @@ impl Secp256k1VerifyingKey {
 
 impl Verifier<Secp256k1Signature> for Secp256k1VerifyingKey {
     fn verify(&self, message: &[u8], signature: &Secp256k1Signature) -> Result<(), SignatureError> {
-        // fastcrypto hashes with SHA-256 and rejects high-S (malleable) signatures.
         let signature = FcSecp256k1Signature::from_bytes(signature.inner())
             .map_err(SignatureError::from_source)?;
         self.0

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -35,7 +35,9 @@ impl proptest::arbitrary::Arbitrary for Secp256r1PrivateKey {
         use proptest::strategy::Strategy;
 
         proptest::arbitrary::any::<[u8; Self::LENGTH]>()
-            .prop_map(Self::new)
+            .prop_filter_map("invalid secp256r1 private key", |bytes| {
+                Self::new(bytes).ok()
+            })
             .boxed()
     }
 }
@@ -44,10 +46,10 @@ impl Secp256r1PrivateKey {
     /// The length of an secp256r1 private key in bytes.
     pub const LENGTH: usize = 32;
 
-    pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
+    pub fn new(bytes: [u8; Self::LENGTH]) -> Result<Self, SignatureError> {
         // Validate that the bytes represent a well-formed secp256r1 private key.
-        Secp256r1KeyPair::from_bytes(&bytes).expect("invalid secp256r1 private key");
-        Self(bytes)
+        Secp256r1KeyPair::from_bytes(&bytes).map_err(SignatureError::from_source)?;
+        Ok(Self(bytes))
     }
 
     pub fn scheme(&self) -> SignatureScheme {
@@ -77,9 +79,16 @@ impl Secp256r1PrivateKey {
     where
         R: rand_core::RngCore + rand_core::CryptoRng,
     {
-        let mut buf: [u8; Self::LENGTH] = [0; Self::LENGTH];
-        rng.fill_bytes(&mut buf);
-        Self::new(buf)
+        // Almost every 32-byte value is a valid secp256r1 private key, but a
+        // few (zero, or values at/above the curve order) are not. Draw fresh
+        // bytes until we get a valid key; in practice this never repeats.
+        loop {
+            let mut buf: [u8; Self::LENGTH] = [0; Self::LENGTH];
+            rng.fill_bytes(&mut buf);
+            if let Ok(key) = Self::new(buf) {
+                return key;
+            }
+        }
     }
 
     #[cfg(feature = "pem")]
@@ -127,7 +136,8 @@ impl Secp256r1PrivateKey {
 
     #[cfg(feature = "pem")]
     pub(crate) fn from_p256(private_key: p256::ecdsa::SigningKey) -> Self {
-        Self::new(private_key.to_bytes().into())
+        // A p256 SigningKey is by construction a valid secp256r1 scalar.
+        Self(private_key.to_bytes().into())
     }
 
     /// Re-expose the raw private key through p256, used only as a PKCS#8/PEM
@@ -158,13 +168,7 @@ impl crate::ToFromBytes for Secp256r1PrivateKey {
 
         let mut arr = [0u8; Self::LENGTH];
         arr.copy_from_slice(bytes);
-
-        // Reject scalars that aren't a well-formed secp256r1 private key (e.g.
-        // all-zeros or >= the curve order) rather than panicking in `new`.
-        Secp256r1KeyPair::from_bytes(&arr).map_err(|e| {
-            crate::PrivateKeyError::InvalidScheme(format!("invalid secp256r1 private key: {e}"))
-        })?;
-        Ok(Self(arr))
+        Self::new(arr).map_err(|e| crate::PrivateKeyError::InvalidScheme(e.to_string()))
     }
 }
 
@@ -438,7 +442,7 @@ mod tests {
             167, 44, 116, 0, 51, 221, 254, 179, 210, 44, 93, 196, 125, 155, 85, 94, 29, 41, 13, 60,
             59, 132, 69, 84, 176, 217, 77, 49, 25, 113, 118, 125,
         ];
-        let signer = Secp256r1PrivateKey::new(key);
+        let signer = Secp256r1PrivateKey::new(key).unwrap();
 
         let message = PersonalMessage(b"hello".into());
         let sig = signer.sign_personal_message(&message).unwrap();

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -98,7 +98,7 @@ impl Secp256r1PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use p256::pkcs8::EncodePrivateKey;
 
-        self.to_p256()?
+        self.to_p256()
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -119,7 +119,7 @@ impl Secp256r1PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.to_p256()?
+        self.to_p256()
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
@@ -134,8 +134,8 @@ impl Secp256r1PrivateKey {
     /// codec. Don't sign with the returned key — use this type's `Signer` impl
     /// (`try_sign`) instead, so signing goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn to_p256(&self) -> Result<p256::ecdsa::SigningKey, SignatureError> {
-        p256::ecdsa::SigningKey::from_slice(&self.0).map_err(SignatureError::from_source)
+    fn to_p256(&self) -> p256::ecdsa::SigningKey {
+        p256::ecdsa::SigningKey::from_slice(&self.0).expect("validated on construction")
     }
 }
 
@@ -277,7 +277,7 @@ impl Secp256r1VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_p256()?
+        self.to_p256()
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -298,7 +298,7 @@ impl Secp256r1VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.to_p256()?
+        self.to_p256()
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
@@ -316,9 +316,9 @@ impl Secp256r1VerifyingKey {
     /// Don't verify with the returned key — use this type's `Verifier` impl
     /// instead, so verification goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn to_p256(&self) -> Result<p256::ecdsa::VerifyingKey, SignatureError> {
+    fn to_p256(&self) -> p256::ecdsa::VerifyingKey {
         p256::ecdsa::VerifyingKey::from_sec1_bytes(self.0.as_ref())
-            .map_err(SignatureError::from_source)
+            .expect("validated on construction")
     }
 }
 

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -98,7 +98,7 @@ impl Secp256r1PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use p256::pkcs8::EncodePrivateKey;
 
-        self.as_p256()?
+        self.to_p256()?
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -119,7 +119,7 @@ impl Secp256r1PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.as_p256()?
+        self.to_p256()?
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
@@ -134,7 +134,7 @@ impl Secp256r1PrivateKey {
     /// codec. Don't sign with the returned key — use this type's `Signer` impl
     /// (`try_sign`) instead, so signing goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn as_p256(&self) -> Result<p256::ecdsa::SigningKey, SignatureError> {
+    fn to_p256(&self) -> Result<p256::ecdsa::SigningKey, SignatureError> {
         p256::ecdsa::SigningKey::from_slice(&self.0).map_err(SignatureError::from_source)
     }
 }
@@ -158,7 +158,13 @@ impl crate::ToFromBytes for Secp256r1PrivateKey {
 
         let mut arr = [0u8; Self::LENGTH];
         arr.copy_from_slice(bytes);
-        Ok(Self::new(arr))
+
+        // Reject scalars that aren't a well-formed secp256r1 private key (e.g.
+        // all-zeros or >= the curve order) rather than panicking in `new`.
+        Secp256r1KeyPair::from_bytes(&arr).map_err(|e| {
+            crate::PrivateKeyError::InvalidScheme(format!("invalid secp256r1 private key: {e}"))
+        })?;
+        Ok(Self(arr))
     }
 }
 
@@ -271,7 +277,7 @@ impl Secp256r1VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.as_p256()?
+        self.to_p256()?
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -292,7 +298,7 @@ impl Secp256r1VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.as_p256()?
+        self.to_p256()?
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
@@ -310,7 +316,7 @@ impl Secp256r1VerifyingKey {
     /// Don't verify with the returned key — use this type's `Verifier` impl
     /// instead, so verification goes through fastcrypto.
     #[cfg(feature = "pem")]
-    fn as_p256(&self) -> Result<p256::ecdsa::VerifyingKey, SignatureError> {
+    fn to_p256(&self) -> Result<p256::ecdsa::VerifyingKey, SignatureError> {
         p256::ecdsa::VerifyingKey::from_sec1_bytes(self.0.as_ref())
             .map_err(SignatureError::from_source)
     }
@@ -440,5 +446,15 @@ mod tests {
         let external_sig = "AlqWPdkIE2bZAUquKv2Tdh9i+Ih+rVSQXH/YsgvwkmeOJR0YLjL/kadivoPtiQkvZBQ1ZI8eDZxe8SaLniwoT88Dh+/vAuGf1UrouFTdefpBEWn3apy8x3EexN5c5ESzGDc=";
         let b64 = sig.to_base64();
         assert_eq!(external_sig, b64);
+    }
+
+    #[test]
+    fn from_bytes_rejects_invalid_scalar() {
+        use crate::ToFromBytes;
+
+        // The all-zeros scalar is not a valid secp256r1 private key; `from_bytes`
+        // must surface this as an error rather than panicking.
+        let err = Secp256r1PrivateKey::from_bytes([0u8; Secp256r1PrivateKey::LENGTH]);
+        assert!(err.is_err());
     }
 }

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -219,7 +219,6 @@ impl crate::FromMnemonic for Secp256r1PrivateKey {
 
 impl Signer<Secp256r1Signature> for Secp256r1PrivateKey {
     fn try_sign(&self, message: &[u8]) -> Result<Secp256r1Signature, SignatureError> {
-        // fastcrypto signs with SHA-256 and normalizes the signature to low-S.
         let signature: FcSecp256r1Signature = self.keypair().sign(message);
         Ok(Secp256r1Signature::new(
             signature

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -16,7 +16,7 @@ use signature::{Signer, Verifier};
 
 use crate::SignatureError;
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct Secp256r1PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Secp256r1PrivateKey {

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -2,19 +2,22 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
+use fastcrypto::{
+    secp256r1::{
+        Secp256r1KeyPair, Secp256r1PublicKey as FcSecp256r1PublicKey,
+        Secp256r1Signature as FcSecp256r1Signature,
+    },
+    traits::{KeyPair as _, Signer as _, ToFromBytes as _, VerifyingKey as _},
+};
 use iota_types::{
     Secp256r1PublicKey, Secp256r1Signature, SignatureScheme, SimpleSignature, UserSignature,
-};
-use p256::{
-    ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::group::GroupEncoding,
 };
 use signature::{Signer, Verifier};
 
 use crate::SignatureError;
 
 #[derive(Clone, Eq, PartialEq)]
-pub struct Secp256r1PrivateKey(SigningKey);
+pub struct Secp256r1PrivateKey([u8; Self::LENGTH]);
 
 impl std::fmt::Debug for Secp256r1PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -42,20 +45,32 @@ impl Secp256r1PrivateKey {
     pub const LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
-        Self(SigningKey::from_bytes(&bytes.into()).unwrap())
+        // Validate that the bytes form a well-formed secp256r1 private key.
+        Secp256r1KeyPair::from_bytes(&bytes).expect("invalid secp256r1 private key");
+        Self(bytes)
     }
 
     pub fn scheme(&self) -> SignatureScheme {
         SignatureScheme::Secp256r1
     }
 
+    /// Reconstruct the fastcrypto keypair, which performs all signing.
+    fn keypair(&self) -> Secp256r1KeyPair {
+        Secp256r1KeyPair::from_bytes(&self.0).expect("validated on construction")
+    }
+
     pub fn verifying_key(&self) -> Secp256r1VerifyingKey {
-        let verifying_key = self.0.verifying_key();
-        Secp256r1VerifyingKey(*verifying_key)
+        Secp256r1VerifyingKey(self.keypair().public().clone())
     }
 
     pub fn public_key(&self) -> Secp256r1PublicKey {
-        Secp256r1PublicKey::new(self.0.verifying_key().as_ref().to_bytes().into())
+        Secp256r1PublicKey::new(
+            self.keypair()
+                .public()
+                .as_ref()
+                .try_into()
+                .expect("secp256r1 public key is 33 bytes"),
+        )
     }
 
     pub fn generate<R>(mut rng: R) -> Self
@@ -73,7 +88,7 @@ impl Secp256r1PrivateKey {
     /// format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
-            .map(Self)
+            .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
@@ -83,7 +98,7 @@ impl Secp256r1PrivateKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use p256::pkcs8::EncodePrivateKey;
 
-        self.0
+        self.as_p256()?
             .to_pkcs8_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.as_bytes().to_owned())
@@ -94,7 +109,7 @@ impl Secp256r1PrivateKey {
     /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
-            .map(Self)
+            .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
@@ -104,15 +119,22 @@ impl Secp256r1PrivateKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
-        self.0
+        self.as_p256()?
             .to_pkcs8_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
             .map(|pem| (*pem).to_owned())
     }
 
     #[cfg(feature = "pem")]
-    pub(crate) fn from_p256(private_key: SigningKey) -> Self {
-        Self(private_key)
+    pub(crate) fn from_p256(private_key: p256::ecdsa::SigningKey) -> Self {
+        Self::new(private_key.to_bytes().into())
+    }
+
+    /// Re-expose the raw private key through p256, used only as a PKCS#8/PEM
+    /// codec (signing itself always goes through fastcrypto).
+    #[cfg(feature = "pem")]
+    fn as_p256(&self) -> Result<p256::ecdsa::SigningKey, SignatureError> {
+        p256::ecdsa::SigningKey::from_slice(&self.0).map_err(SignatureError::from_source)
     }
 }
 
@@ -122,7 +144,7 @@ impl crate::ToFromBytes for Secp256r1PrivateKey {
 
     /// Return the raw 32-byte private key
     fn to_bytes(&self) -> Self::ByteArray {
-        self.0.to_bytes().into()
+        self.0
     }
 
     fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, Self::Error> {
@@ -186,8 +208,14 @@ impl crate::FromMnemonic for Secp256r1PrivateKey {
 
 impl Signer<Secp256r1Signature> for Secp256r1PrivateKey {
     fn try_sign(&self, message: &[u8]) -> Result<Secp256r1Signature, SignatureError> {
-        let signature: p256::ecdsa::Signature = self.0.try_sign(message)?;
-        Ok(Secp256r1Signature::new(signature.to_bytes().into()))
+        // fastcrypto signs with SHA-256 and normalizes the signature to low-S.
+        let signature: FcSecp256r1Signature = self.keypair().sign(message);
+        Ok(Secp256r1Signature::new(
+            signature
+                .as_ref()
+                .try_into()
+                .expect("secp256r1 signature is 64 bytes"),
+        ))
     }
 }
 
@@ -209,15 +237,22 @@ impl Signer<UserSignature> for Secp256r1PrivateKey {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Secp256r1VerifyingKey(VerifyingKey);
+pub struct Secp256r1VerifyingKey(FcSecp256r1PublicKey);
 
 impl Secp256r1VerifyingKey {
     pub fn new(public_key: &Secp256r1PublicKey) -> Result<Self, SignatureError> {
-        VerifyingKey::try_from(public_key.inner().as_ref()).map(Self)
+        FcSecp256r1PublicKey::from_bytes(public_key.inner().as_ref())
+            .map(Self)
+            .map_err(SignatureError::from_source)
     }
 
     pub fn public_key(&self) -> Secp256r1PublicKey {
-        Secp256r1PublicKey::new(self.0.as_ref().to_bytes().into())
+        Secp256r1PublicKey::new(
+            self.0
+                .as_ref()
+                .try_into()
+                .expect("secp256r1 public key is 33 bytes"),
+        )
     }
 
     #[cfg(feature = "pem")]
@@ -225,7 +260,7 @@ impl Secp256r1VerifyingKey {
     /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePublicKey::from_public_key_der(bytes)
-            .map(Self)
+            .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
@@ -235,7 +270,7 @@ impl Secp256r1VerifyingKey {
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.as_p256()?
             .to_public_key_der()
             .map_err(SignatureError::from_source)
             .map(|der| der.into_vec())
@@ -246,7 +281,7 @@ impl Secp256r1VerifyingKey {
     /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePublicKey::from_public_key_pem(s)
-            .map(Self)
+            .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
@@ -256,21 +291,37 @@ impl Secp256r1VerifyingKey {
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 
-        self.0
+        self.as_p256()?
             .to_public_key_pem(pkcs8::LineEnding::default())
             .map_err(SignatureError::from_source)
     }
 
     #[cfg(feature = "pem")]
-    pub(crate) fn from_p256(verifying_key: VerifyingKey) -> Self {
-        Self(verifying_key)
+    pub(crate) fn from_p256(verifying_key: p256::ecdsa::VerifyingKey) -> Self {
+        let compressed = verifying_key.to_encoded_point(true);
+        Self(
+            FcSecp256r1PublicKey::from_bytes(compressed.as_bytes())
+                .expect("p256 public key is a valid secp256r1 point"),
+        )
+    }
+
+    /// Re-expose the public key through p256, used only as a PKCS#8/PEM codec
+    /// (verification itself always goes through fastcrypto).
+    #[cfg(feature = "pem")]
+    fn as_p256(&self) -> Result<p256::ecdsa::VerifyingKey, SignatureError> {
+        p256::ecdsa::VerifyingKey::from_sec1_bytes(self.0.as_ref())
+            .map_err(SignatureError::from_source)
     }
 }
 
 impl Verifier<Secp256r1Signature> for Secp256r1VerifyingKey {
     fn verify(&self, message: &[u8], signature: &Secp256r1Signature) -> Result<(), SignatureError> {
-        let signature = p256::ecdsa::Signature::from_bytes(signature.inner().into())?;
-        self.0.verify(message, &signature)
+        // fastcrypto hashes with SHA-256 and rejects high-S signatures.
+        let signature = FcSecp256r1Signature::from_bytes(signature.inner())
+            .map_err(SignatureError::from_source)?;
+        self.0
+            .verify(message, &signature)
+            .map_err(SignatureError::from_source)
     }
 }
 

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -69,7 +69,7 @@ impl Secp256r1PrivateKey {
                 .public()
                 .as_ref()
                 .try_into()
-                .expect("secp256r1 public key is 33 bytes"),
+                .expect("secp256r1 public key must be 33 bytes"),
         )
     }
 
@@ -221,7 +221,7 @@ impl Signer<Secp256r1Signature> for Secp256r1PrivateKey {
             signature
                 .as_ref()
                 .try_into()
-                .expect("secp256r1 signature is 64 bytes"),
+                .expect("secp256r1 signature must be 64 bytes"),
         ))
     }
 }
@@ -258,7 +258,7 @@ impl Secp256r1VerifyingKey {
             self.0
                 .as_ref()
                 .try_into()
-                .expect("secp256r1 public key is 33 bytes"),
+                .expect("secp256r1 public key must be 33 bytes"),
         )
     }
 

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -45,7 +45,7 @@ impl Secp256r1PrivateKey {
     pub const LENGTH: usize = 32;
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
-        // Validate that the bytes form a well-formed secp256r1 private key.
+        // Validate that the bytes represent a well-formed secp256r1 private key.
         Secp256r1KeyPair::from_bytes(&bytes).expect("invalid secp256r1 private key");
         Self(bytes)
     }
@@ -324,7 +324,6 @@ impl Secp256r1VerifyingKey {
 
 impl Verifier<Secp256r1Signature> for Secp256r1VerifyingKey {
     fn verify(&self, message: &[u8], signature: &Secp256r1Signature) -> Result<(), SignatureError> {
-        // fastcrypto hashes with SHA-256 and rejects high-S signatures.
         let signature = FcSecp256r1Signature::from_bytes(signature.inner())
             .map_err(SignatureError::from_source)?;
         self.0

--- a/crates/iota-sdk-crypto/src/simple.rs
+++ b/crates/iota-sdk-crypto/src/simple.rs
@@ -233,11 +233,11 @@ mod keypair {
                 .map_err(SignatureError::from_source)?
             {
                 #[cfg(feature = "ed25519")]
-                (ed25519_dalek::pkcs8::ALGORITHM_OID, None) => private_key
+                (ed25519::pkcs8::ALGORITHM_OID, None) => private_key
                     .try_into()
-                    .map(crate::ed25519::Ed25519PrivateKey::from_dalek)
-                    .map(InnerKeypair::Ed25519)
-                    .map_err(SignatureError::from_source),
+                    .map_err(SignatureError::from_source)
+                    .and_then(crate::ed25519::Ed25519PrivateKey::from_pkcs8)
+                    .map(InnerKeypair::Ed25519),
                 #[cfg(feature = "secp256r1")]
                 (
                     p256::elliptic_curve::ALGORITHM_OID,
@@ -416,11 +416,11 @@ mod keypair {
                 .map_err(SignatureError::from_source)?
             {
                 #[cfg(feature = "ed25519")]
-                (ed25519_dalek::pkcs8::ALGORITHM_OID, None) => public_key
+                (ed25519::pkcs8::ALGORITHM_OID, None) => public_key
                     .try_into()
-                    .map(crate::ed25519::Ed25519VerifyingKey::from_dalek)
-                    .map(InnerVerifyingKey::Ed25519)
-                    .map_err(SignatureError::from_source),
+                    .map_err(SignatureError::from_source)
+                    .and_then(crate::ed25519::Ed25519VerifyingKey::from_pkcs8)
+                    .map(InnerVerifyingKey::Ed25519),
                 #[cfg(feature = "secp256r1")]
                 (
                     p256::elliptic_curve::ALGORITHM_OID,

--- a/crates/iota-sdk-crypto/src/simple.rs
+++ b/crates/iota-sdk-crypto/src/simple.rs
@@ -207,11 +207,9 @@ mod keypair {
                     }
                     let mut arr = [0u8; crate::secp256r1::Secp256r1PrivateKey::LENGTH];
                     arr.copy_from_slice(key_bytes);
-                    Ok(Self {
-                        inner: InnerKeypair::Secp256r1(crate::secp256r1::Secp256r1PrivateKey::new(
-                            arr,
-                        )),
-                    })
+                    crate::secp256r1::Secp256r1PrivateKey::new(arr)
+                        .map(InnerKeypair::Secp256r1)
+                        .map(|inner| Self { inner })
                 }
                 _ => Err(SignatureError::from_source(
                     "unsupported signature scheme for SimpleKeypair",

--- a/crates/iota-sdk-ffi/src/crypto/secp256r1.rs
+++ b/crates/iota-sdk-ffi/src/crypto/secp256r1.rs
@@ -27,7 +27,7 @@ impl Secp256r1PrivateKey {
             bytes.try_into().map_err(|v: Vec<u8>| {
                 SdkFfiError::custom(format!("expected bytes of length 32, found {}", v.len()))
             })?,
-        )))
+        )?))
     }
 
     pub fn scheme(&self) -> SignatureScheme {


### PR DESCRIPTION
## Why

Consolidate the SDK's crypto on `fastcrypto` (pinned `=0.1.11`, the same implementation the node uses) instead of a separate `ed25519-dalek` / `p256` / `k256` backend.

## What

- ed25519, secp256r1 and secp256k1 signing/verification now go through `fastcrypto`.
- `ed25519`, `p256` and `k256` are kept only as PKCS#8/PEM codecs behind the `pem` feature (fastcrypto has no PKCS#8 support).
- `fastcrypto`'s `wasm` feature is target-gated so `wasm32` still builds.

### Behavioral changes (now matching the node)

- **secp256r1**: low-S on sign, rejects high-S on verify (WebAuthn/passkey high-S signatures are now rejected).
- **secp256k1**: rejects malleable high-S signatures on verify (previously accepted by `k256`); signing output is unchanged (SHA-256, low-S).
- **ed25519**: ed25519-consensus verification instead of dalek `verify_strict`.

## Test plan

- `cargo test --all-features` → 30/30 (incl. ed25519/secp256r1/secp256k1 & passkey signing fixtures, the secp256k1 high-S rejection test, PEM round-trips)
- clippy `-D warnings`, `wasm32` check (ed25519 + secp256r1 + secp256k1), all feature combos, downstream crates build

Companion monorepo change: iotaledger/iota#12133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

