### PR TITLE
chore: pin rust nightly

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           tool: cargo-udeps
       - name: Run Cargo Udeps
-        run: cargo +nightly udeps ${{ matrix.flags }}
+        run: cargo +nightly-2026-06-29 udeps ${{ matrix.flags }}
 
   proto-build:
     if: (!github.event.pull_request.draft || contains(github.event.pull_request.body, '[run-ci]'))

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
 
       - name: Install latest nightly
-        run: rustup toolchain install nightly --component rustfmt --allow-downgrade
+        run: rustup toolchain install nightly-2026-06-29 --component rustfmt --allow-downgrade
 
       - name: rustfmt
         run: make check-fmt

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ check-features: ## Check feature flags for crates
 
 .PHONY: check-fmt
 check-fmt: ## Check code formatting
-	cargo +nightly fmt -- --check
+	cargo +nightly-2026-06-29 fmt -- --check
 
 .PHONY: fmt
 fmt: ## Format code
-	cargo +nightly fmt
+	cargo +nightly-2026-06-29 fmt
 
 .PHONY: fetch-compiled-packages
 fetch-compiled-packages: ## Fetch the compiled Move packages if missing or out of date (used by `make test`)


### PR DESCRIPTION
CI has been getting a lot of `Segmentation fault` recently, e.g. https://github.com/iotaledger/iota-rust-sdk/actions/runs/28787977547/job/85359220280?pr=1240.
Pinning to an older version should avoid that unstability.