### PR TITLE
chore: fix flaky coins_stream test

### DIFF
--- a/crates/iota-sdk-graphql-client/src/api/coins.rs
+++ b/crates/iota-sdk-graphql-client/src/api/coins.rs
@@ -155,10 +155,6 @@ mod tests {
         };
         let key = Ed25519PublicKey::generate(rand::thread_rng());
         let address = key.derive_address();
-        // Wait until the funding transactions are finalized so the coins are
-        // available in the indexer before we stream them. `request_and_wait`
-        // alone only confirms the faucet transfer on the node, not that the
-        // coins have been indexed for GraphQL queries.
         faucet
             .request_and_wait_for_finalized(address, &client)
             .await

--- a/crates/iota-sdk-graphql-client/src/api/coins.rs
+++ b/crates/iota-sdk-graphql-client/src/api/coins.rs
@@ -155,30 +155,48 @@ mod tests {
         };
         let key = Ed25519PublicKey::generate(rand::thread_rng());
         let address = key.derive_address();
-        faucet.request_and_wait(address).await.unwrap();
+        // Wait until the funding transactions are finalized so the coins are
+        // available in the indexer before we stream them. `request_and_wait`
+        // alone only confirms the faucet transfer on the node, not that the
+        // coins have been indexed for GraphQL queries.
+        faucet
+            .request_and_wait_for_finalized(address, &client)
+            .await
+            .unwrap();
 
         const MAX_RETRIES: u32 = 10;
         const RETRY_DELAY: time::Duration = time::Duration::from_secs(1);
 
+        // Retry until the expected number of coins is streamed. Indexer lag can
+        // return a successful but incomplete page, so retry on a low count as
+        // well as on a stream error, re-counting from scratch each attempt.
         let mut num_coins = 0;
         for attempt in 0..MAX_RETRIES {
+            num_coins = 0;
             let mut stream = client.coins_stream(address, None, Direction::default());
-
+            let mut errored = false;
             while let Some(result) = stream.next().await {
                 match result {
                     Ok(_) => num_coins += 1,
                     Err(_) => {
-                        if attempt < MAX_RETRIES - 1 {
-                            time::sleep(RETRY_DELAY).await;
-                            num_coins = 0;
-                            break;
-                        }
+                        errored = true;
+                        break;
                     }
                 }
             }
+
+            if !errored && num_coins >= NUM_COINS_FROM_FAUCET {
+                break;
+            }
+            if attempt < MAX_RETRIES - 1 {
+                time::sleep(RETRY_DELAY).await;
+            }
         }
 
-        assert!(num_coins >= NUM_COINS_FROM_FAUCET);
+        assert!(
+            num_coins >= NUM_COINS_FROM_FAUCET,
+            "expected at least {NUM_COINS_FROM_FAUCET} coins for {address}, got {num_coins}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

`api::coins::tests::test_coins_stream` fails intermittently in CI on `assert!(num_coins >= NUM_COINS_FROM_FAUCET)`.

The root cause is test synchronization, not an indexer/client bug:

- The test funded an address with `request_and_wait`, which only confirms the faucet transfer landed **on the node** — not that the coins were **indexed** for GraphQL queries. `coins_stream` queries the indexer, which ingests checkpoints asynchronously, so it could return a *successful but incomplete* page (often 0 coins).
- The retry loop only retried on a stream **error**, never on a low count, and the delay lived inside the error branch. So under indexer lag all 10 attempts ran back-to-back with no delay, and `num_coins` was never reset per attempt.

## What

- Fund via `request_and_wait_for_finalized`, which waits for the funding transactions to be finalized (in an indexed checkpoint) before streaming.
- Retry on an insufficient count as well as on error, re-counting from scratch each attempt, with the delay applied between attempts.
- Include observed vs. expected count in the assert message.

## Test plan

Requires a running localnet (`make test-with-localnet`). Verified the crate + test target compile (`cargo check --tests -p iota-sdk-graphql-client`) and formatting is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQiHjiMiVinJBWLDiNtDjx)_