### PR TITLE
feat(grpc): improve client API with typed per-endpoint read masks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ strum = "0.27.2"
 syn = { version = "2", features = ["full"] }
 test-strategy = "0.4.0"
 thiserror = "2.0"
-tokio = "1.40.0"
+tokio = "1.52.3"
 tonic = "0.14"
 tracing = "0.1"
 variadics_please = "1.1"

--- a/crates/iota-sdk-ffi/Cargo.toml
+++ b/crates/iota-sdk-ffi/Cargo.toml
@@ -44,6 +44,7 @@ rand.workspace = true
 roaring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tokio = { workspace = true, features = ["time", "sync"] }
 # wasm-unstable-single-threaded relaxes Send+Sync checks on wasm32 targets only
 uniffi = { version = "0.31", features = ["cli", "tokio", "wasm-unstable-single-threaded", "scaffolding-ffi-buffer-fns"] }
 

--- a/crates/iota-sdk-graphql-client/Cargo.toml
+++ b/crates/iota-sdk-graphql-client/Cargo.toml
@@ -51,7 +51,7 @@ iota-types = { workspace = true, features = ["serde", "rand", "hash"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [build-dependencies]
 iota-graphql-client-build.workspace = true

--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -6,9 +6,7 @@
 use std::borrow::Cow;
 
 pub use iota_grpc_types::{
-    field::{FieldMask, FieldMaskUtil},
-    field_mask_normalize,
-    google::rpc::Status as RpcStatus,
+    field::FieldMask, field_mask_normalize, google::rpc::Status as RpcStatus,
     proto::TryFromProtoError,
 };
 use iota_grpc_types::{
@@ -201,14 +199,6 @@ impl From<FieldMask> for ReadMask<'_> {
     fn from(mask: FieldMask) -> Self {
         Self(Cow::Owned(field_mask_normalize(&mask.paths.join(","))))
     }
-}
-
-/// Build a field mask with a custom value or default.
-///
-/// This is a convenience helper that handles the common pattern of using
-/// a user-provided field mask or falling back to a default.
-pub fn field_mask_with_default(custom: Option<&str>, default: &str) -> FieldMask {
-    FieldMask::from_str(custom.unwrap_or(default))
 }
 
 /// Safely convert a `usize` to `u32`, saturating at `u32::MAX` instead of

--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -146,20 +146,18 @@ pub type Result<T> = std::result::Result<T, Error>;
 // Field Masks
 // =============================================================================
 
-/// A read mask that can be passed to client methods.
+/// A low-level read mask string.
 ///
-/// Construct from field path constants defined in
-/// [`read_mask_fields`](crate::read_mask_fields):
+/// Most callers should use the scoped per-endpoint mask types in
+/// [`read_mask_fields`](crate::read_mask_fields)
+/// (e.g. [`ObjectReadMask`](crate::read_mask_fields::ObjectReadMask)) which
+/// are passed directly to the client methods. This type is the underlying
+/// string holder, useful when composing masks by hand:
 ///
 /// ```
-/// use iota_sdk_grpc_client::{ReadMask, read_mask_fields::TransactionField};
+/// use iota_sdk_grpc_client::ReadMask;
 ///
-/// // Single field
-/// let mask = ReadMask::from(TransactionField::EFFECTS);
-/// assert_eq!(mask.as_str(), "effects");
-///
-/// // Multiple fields
-/// let mask = ReadMask::from(&[TransactionField::EFFECTS, TransactionField::CHECKPOINT]);
+/// let mask = ReadMask::from("effects,checkpoint");
 /// assert_eq!(mask.as_str(), "effects,checkpoint");
 /// ```
 #[derive(Clone, Debug)]
@@ -209,11 +207,8 @@ impl From<FieldMask> for ReadMask<'_> {
 ///
 /// This is a convenience helper that handles the common pattern of using
 /// a user-provided field mask or falling back to a default.
-pub fn field_mask_with_default(custom: Option<ReadMask<'_>>, default: &str) -> FieldMask {
-    match custom {
-        Some(mask) => FieldMask::from_str(mask.as_str()),
-        None => FieldMask::from_str(default),
-    }
+pub fn field_mask_with_default(custom: Option<&str>, default: &str) -> FieldMask {
+    FieldMask::from_str(custom.unwrap_or(default))
 }
 
 /// Safely convert a `usize` to `u32`, saturating at `u32::MAX` instead of
@@ -351,9 +346,12 @@ pub struct Page<T> {
 ///
 /// - `$query_name` — name of the generated builder struct
 /// - `$service_client_type` — the tonic service client type
-/// - `$item_type` — the item type in the response vec
+/// - `$item_type` — the item type exposed by the builder
 /// - `$rpc_method` — the RPC method name on the service client
 /// - `$items_field` — the field name on the response containing the items vec
+/// - `map_item` (optional) — a fallible `fn(&ProtoItem) -> Result<$item_type>`
+///   applied to each response element. When omitted, items are passed through
+///   unchanged (so `$item_type` must be the response field's element type).
 ///
 /// # Example
 ///
@@ -368,7 +366,23 @@ pub struct Page<T> {
 ///     }
 /// }
 /// ```
+///
+/// With a per-item conversion:
+///
+/// ```ignore
+/// define_list_query! {
+///     pub struct GetCoinsQuery {
+///         service_client: StateServiceClient<InterceptedChannel>,
+///         request: ListOwnedObjectsRequest,
+///         item: Coin,
+///         rpc_method: list_owned_objects,
+///         items_field: objects,
+///         map_item: object_to_coin, // fn(&Object) -> Result<Coin>
+///     }
+/// }
+/// ```
 macro_rules! define_list_query {
+    // Pass-through variant: `$item_type` is the response element type.
     (
         $(#[$meta:meta])*
         pub struct $query_name:ident {
@@ -377,6 +391,59 @@ macro_rules! define_list_query {
             item: $item_type:ty,
             rpc_method: $rpc_method:ident,
             items_field: $items_field:ident,
+        }
+    ) => {
+        $crate::api::define_list_query! {
+            @impl
+            $(#[$meta])*
+            pub struct $query_name {
+                service_client: $service_client_type,
+                request: $request_type,
+                item: $item_type,
+                rpc_method: $rpc_method,
+                items_field: $items_field,
+                map_item: |item| $crate::api::Result::Ok(item),
+            }
+        }
+    };
+
+    // Conversion variant: each response element is mapped through `$map_item`,
+    // a fallible `fn(&ProtoItem) -> Result<$item_type>`.
+    (
+        $(#[$meta:meta])*
+        pub struct $query_name:ident {
+            service_client: $service_client_type:ty,
+            request: $request_type:ty,
+            item: $item_type:ty,
+            rpc_method: $rpc_method:ident,
+            items_field: $items_field:ident,
+            map_item: $map_item:expr,
+        }
+    ) => {
+        $crate::api::define_list_query! {
+            @impl
+            $(#[$meta])*
+            pub struct $query_name {
+                service_client: $service_client_type,
+                request: $request_type,
+                item: $item_type,
+                rpc_method: $rpc_method,
+                items_field: $items_field,
+                map_item: |item| $map_item(&item),
+            }
+        }
+    };
+
+    (
+        @impl
+        $(#[$meta:meta])*
+        pub struct $query_name:ident {
+            service_client: $service_client_type:ty,
+            request: $request_type:ty,
+            item: $item_type:ty,
+            rpc_method: $rpc_method:ident,
+            items_field: $items_field:ident,
+            map_item: $map_item:expr,
         }
     ) => {
         $(#[$meta])*
@@ -413,7 +480,7 @@ macro_rules! define_list_query {
                 limit: impl Into<Option<u32>>,
             ) -> $crate::api::Result<$crate::api::MetadataEnvelope<Vec<$item_type>>> {
                 let limit = limit.into();
-                let mut all_items = Vec::new();
+                let mut all_items: Vec<$item_type> = Vec::new();
                 let mut next_page_token = self.page_token;
                 let mut result_metadata = None;
                 let mut service_client = self.service_client;
@@ -454,7 +521,10 @@ macro_rules! define_list_query {
                         result_metadata = Some(metadata);
                     }
 
-                    all_items.extend(body.$items_field);
+                    let map_item = $map_item;
+                    for item in body.$items_field {
+                        all_items.push(map_item(item)?);
+                    }
 
                     match body.next_page_token {
                         Some(token) => next_page_token = Some(token),
@@ -502,9 +572,16 @@ macro_rules! define_list_query {
                     let (body, metadata) =
                         $crate::api::MetadataEnvelope::from(response).into_parts();
 
+                    let map_item = $map_item;
+                    let items = body
+                        .$items_field
+                        .into_iter()
+                        .map(map_item)
+                        .collect::<$crate::api::Result<Vec<$item_type>>>()?;
+
                     Ok($crate::api::MetadataEnvelope::new(
                         $crate::api::Page {
-                            items: body.$items_field,
+                            items,
                             next_page_token: body.next_page_token,
                         },
                         metadata,

--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -3,10 +3,13 @@
 
 //! High-level API for transaction execution.
 
-use iota_grpc_types::v1::{
-    signatures::{UserSignature as ProtoUserSignature, UserSignatures},
-    transaction::ExecutedTransaction,
-    transaction_execution_service::{ExecuteTransactionItem, ExecuteTransactionsRequest},
+use iota_grpc_types::{
+    read_mask_fields::TransactionReadMask,
+    v1::{
+        signatures::{UserSignature as ProtoUserSignature, UserSignatures},
+        transaction::ExecutedTransaction,
+        transaction_execution_service::{ExecuteTransactionItem, ExecuteTransactionsRequest},
+    },
 };
 use iota_types::SignedTransaction;
 
@@ -14,7 +17,7 @@ use crate::{
     Client,
     api::{
         EXECUTE_TRANSACTIONS_READ_MASK, Error, MetadataEnvelope, ProtoResult, ProtocolError,
-        ReadMask, Result, build_proto_transaction, field_mask_with_default,
+        Result, build_proto_transaction, field_mask_with_default,
     },
 };
 
@@ -31,14 +34,11 @@ impl Client {
     /// - `result.input_objects()` - Get input objects (if requested)
     /// - `result.output_objects()` - Get output objects (if requested)
     ///
-    /// # Read Mask
-    ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns. If `None`, uses [`EXECUTE_TRANSACTIONS_READ_MASK`] which
-    /// includes effects, events, and input/output objects.
-    ///
-    /// Use [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// constants with [`ReadMask::from`] for field selection.
+    /// The optional `read_mask` controls which fields the server returns; pass
+    /// `None` for the default mask [`EXECUTE_TRANSACTIONS_READ_MASK`] (effects,
+    /// events, and input/output objects). Pass a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Checkpoint Inclusion
     ///
@@ -53,14 +53,11 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::SignedTransaction;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     ///
     /// let signed_tx: SignedTransaction = todo!();
-    ///
-    /// // Execute transaction - returns proto type
     /// let result = client.execute_transaction(signed_tx, None, None).await?;
     ///
-    /// // Lazy conversion - only deserialize what you need
     /// let effects = result.body().effects()?.effects()?;
     /// println!("Status: {:?}", effects.as_v1().status);
     ///
@@ -74,8 +71,8 @@ impl Client {
     pub async fn execute_transaction(
         &self,
         signed_transaction: SignedTransaction,
-        read_mask: Option<ReadMask<'_>>,
-        checkpoint_inclusion_timeout_ms: Option<u64>,
+        read_mask: impl Into<Option<TransactionReadMask>>,
+        checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
     ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
         self.execute_transactions(
             vec![signed_transaction],
@@ -83,11 +80,7 @@ impl Client {
             checkpoint_inclusion_timeout_ms,
         )
         .await?
-        .try_map(|results| {
-            results.into_iter().next().ok_or_else(|| {
-                Error::Protocol(ProtocolError::EmptyResponseField("transaction_results"))
-            })?
-        })
+        .try_map(extract_single_execution_result)
     }
 
     /// Execute a batch of signed transactions.
@@ -99,15 +92,11 @@ impl Client {
     /// input. Each element is either the successfully executed transaction or
     /// the per-item error returned by the server.
     ///
-    /// # Read Mask
-    ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns for each `ExecutedTransaction`. If `None`, uses
-    /// [`EXECUTE_TRANSACTIONS_READ_MASK`] which includes effects, events, and
-    /// input/output objects.
-    ///
-    /// Use [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// constants with [`ReadMask::from`] for field selection.
+    /// The optional `read_mask` controls which fields the server returns for
+    /// each `ExecutedTransaction`; pass `None` for the default mask
+    /// [`EXECUTE_TRANSACTIONS_READ_MASK`]. Pass a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Checkpoint Inclusion
     ///
@@ -124,9 +113,11 @@ impl Client {
     pub async fn execute_transactions(
         &self,
         transactions: Vec<SignedTransaction>,
-        read_mask: Option<ReadMask<'_>>,
-        checkpoint_inclusion_timeout_ms: Option<u64>,
+        read_mask: impl Into<Option<TransactionReadMask>>,
+        checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
+        let read_mask = read_mask.into();
+        let checkpoint_inclusion_timeout_ms = checkpoint_inclusion_timeout_ms.into();
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
         }
@@ -139,7 +130,7 @@ impl Client {
         let mut request = ExecuteTransactionsRequest::default()
             .with_transactions(items)
             .with_read_mask(field_mask_with_default(
-                read_mask,
+                read_mask.as_ref().map(|m| m.as_str()),
                 EXECUTE_TRANSACTIONS_READ_MASK,
             ));
 
@@ -159,6 +150,15 @@ impl Client {
                 .collect())
         })
     }
+}
+
+fn extract_single_execution_result(
+    results: Vec<Result<ExecutedTransaction>>,
+) -> Result<ExecutedTransaction> {
+    results
+        .into_iter()
+        .next()
+        .ok_or_else(|| Error::Protocol(ProtocolError::EmptyResponseField("transaction_results")))?
 }
 
 /// Convert a `SignedTransaction` into a proto `ExecuteTransactionItem`.

--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -4,7 +4,7 @@
 //! High-level API for transaction execution.
 
 use iota_grpc_types::{
-    read_mask_fields::TransactionReadMask,
+    read_mask_fields::{IntoReadMask, TransactionReadMask},
     v1::{
         signatures::{UserSignature as ProtoUserSignature, UserSignatures},
         transaction::ExecutedTransaction,
@@ -15,10 +15,7 @@ use iota_types::SignedTransaction;
 
 use crate::{
     Client,
-    api::{
-        EXECUTE_TRANSACTIONS_READ_MASK, Error, MetadataEnvelope, ProtoResult, ProtocolError,
-        Result, build_proto_transaction, field_mask_with_default,
-    },
+    api::{Error, MetadataEnvelope, ProtoResult, ProtocolError, Result, build_proto_transaction},
 };
 
 impl Client {
@@ -34,9 +31,8 @@ impl Client {
     /// - `result.input_objects()` - Get input objects (if requested)
     /// - `result.output_objects()` - Get output objects (if requested)
     ///
-    /// The optional `read_mask` controls which fields the server returns; pass
-    /// `None` for the default mask [`EXECUTE_TRANSACTIONS_READ_MASK`] (effects,
-    /// events, and input/output objects). Pass a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `TransactionReadMask::default()` for the default mask. Pass a
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -51,12 +47,15 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::TransactionReadMask;
     /// # use iota_types::SignedTransaction;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
     /// let signed_tx: SignedTransaction = todo!();
-    /// let result = client.execute_transaction(signed_tx, None, None).await?;
+    /// let result = client
+    ///     .execute_transaction(signed_tx, None, TransactionReadMask::default())
+    ///     .await?;
     ///
     /// let effects = result.body().effects()?.effects()?;
     /// println!("Status: {:?}", effects.as_v1().status);
@@ -71,13 +70,13 @@ impl Client {
     pub async fn execute_transaction(
         &self,
         signed_transaction: SignedTransaction,
-        read_mask: impl Into<Option<TransactionReadMask>>,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
+        read_mask: impl IntoReadMask<TransactionReadMask>,
     ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
         self.execute_transactions(
             vec![signed_transaction],
-            read_mask,
             checkpoint_inclusion_timeout_ms,
+            read_mask,
         )
         .await?
         .try_map(extract_single_execution_result)
@@ -92,9 +91,9 @@ impl Client {
     /// input. Each element is either the successfully executed transaction or
     /// the per-item error returned by the server.
     ///
-    /// The optional `read_mask` controls which fields the server returns for
-    /// each `ExecutedTransaction`; pass `None` for the default mask
-    /// [`EXECUTE_TRANSACTIONS_READ_MASK`]. Pass a
+    /// The `read_mask` controls which fields the server returns for each
+    /// `ExecutedTransaction`; use `TransactionReadMask::default()` for the
+    /// default mask. Pass a
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -113,10 +112,10 @@ impl Client {
     pub async fn execute_transactions(
         &self,
         transactions: Vec<SignedTransaction>,
-        read_mask: impl Into<Option<TransactionReadMask>>,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
+        read_mask: impl IntoReadMask<TransactionReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
-        let read_mask = read_mask.into();
+        let read_mask = read_mask.into_read_mask();
         let checkpoint_inclusion_timeout_ms = checkpoint_inclusion_timeout_ms.into();
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
@@ -129,10 +128,7 @@ impl Client {
 
         let mut request = ExecuteTransactionsRequest::default()
             .with_transactions(items)
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                EXECUTE_TRANSACTIONS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         if let Some(timeout_ms) = checkpoint_inclusion_timeout_ms {
             request = request.with_checkpoint_inclusion_timeout_ms(timeout_ms);

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -3,16 +3,19 @@
 
 //! High-level API for transaction simulation.
 
-use iota_grpc_types::v1::transaction_execution_service::{
-    SimulateTransactionItem, SimulateTransactionsRequest, SimulatedTransaction,
-    simulate_transaction_item::TransactionCheckModes,
+use iota_grpc_types::{
+    read_mask_fields::SimulateReadMask,
+    v1::transaction_execution_service::{
+        SimulateTransactionItem, SimulateTransactionsRequest, SimulatedTransaction,
+        simulate_transaction_item::TransactionCheckModes,
+    },
 };
 use iota_types::Transaction;
 
 use crate::{
     Client,
     api::{
-        Error, MetadataEnvelope, ProtoResult, ProtocolError, ReadMask, Result,
+        Error, MetadataEnvelope, ProtoResult, ProtocolError, Result,
         SIMULATE_TRANSACTIONS_READ_MASK, build_proto_transaction, field_mask_with_default,
     },
 };
@@ -37,7 +40,6 @@ impl Client {
     /// - `transaction`: The transaction to simulate
     /// - `skip_checks`: Set to true for relaxed Move VM checks (useful for
     ///   debugging and development)
-    /// - `read_mask`: Optional field mask to control which fields are returned
     ///
     /// Returns [`SimulatedTransaction`] which contains:
     /// - `executed_transaction()` - Access to the simulated ExecutedTransaction
@@ -52,29 +54,17 @@ impl Client {
     /// - `result.executed_transaction()?.output_objects()` - Get output objects
     ///   (if requested)
     ///
-    /// # Read Mask
-    ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns. If `None`, uses [`SIMULATE_TRANSACTIONS_READ_MASK`] which
-    /// includes effects, events, and input/output objects.
-    ///
-    /// Use [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField)
-    /// constants with [`ReadMask::from`] for field selection.
-    ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::Transaction;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     ///
     /// let tx: Transaction = todo!();
-    ///
-    /// // Simulate transaction - returns proto type
     /// let result = client.simulate_transaction(tx, false, None).await?;
     ///
-    /// // Lazy conversion - only deserialize what you need
     /// let executed_tx = result.body().executed_transaction()?;
     /// let effects = executed_tx.effects()?.effects()?;
     /// println!("Simulation status: {:?}", effects.as_v1().status);
@@ -84,11 +74,16 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// The optional `read_mask` controls which fields the server returns; pass
+    /// `None` for the default mask, or a
+    /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
+    /// any slice/array/vec of fields — conversion is automatic.
     pub async fn simulate_transaction(
         &self,
         transaction: Transaction,
         skip_checks: bool,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: impl Into<Option<SimulateReadMask>>,
     ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
         self.simulate_transactions(
             vec![SimulateTransactionInput {
@@ -98,11 +93,7 @@ impl Client {
             read_mask,
         )
         .await?
-        .try_map(|results| {
-            results.into_iter().next().ok_or_else(|| {
-                Error::Protocol(ProtocolError::EmptyResponseField("transaction_results"))
-            })?
-        })
+        .try_map(extract_single_simulation_result)
     }
 
     /// Simulate a batch of transactions without executing them.
@@ -114,6 +105,12 @@ impl Client {
     /// input. Each element is either the successfully simulated transaction or
     /// the per-item error returned by the server.
     ///
+    /// The optional `read_mask` controls which fields the server returns for
+    /// each `SimulatedTransaction`; pass `None` for the default mask
+    /// [`SIMULATE_TRANSACTIONS_READ_MASK`]. Pass a
+    /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
+    /// any slice/array/vec of fields — conversion is automatic.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `transactions` is empty.
@@ -122,8 +119,9 @@ impl Client {
     pub async fn simulate_transactions(
         &self,
         transactions: Vec<SimulateTransactionInput>,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: impl Into<Option<SimulateReadMask>>,
     ) -> Result<MetadataEnvelope<Vec<Result<SimulatedTransaction>>>> {
+        let read_mask = read_mask.into();
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
         }
@@ -136,7 +134,7 @@ impl Client {
         let request = SimulateTransactionsRequest::default()
             .with_transactions(items)
             .with_read_mask(field_mask_with_default(
-                read_mask,
+                read_mask.as_ref().map(|m| m.as_str()),
                 SIMULATE_TRANSACTIONS_READ_MASK,
             ));
 
@@ -152,6 +150,15 @@ impl Client {
                 .collect())
         })
     }
+}
+
+fn extract_single_simulation_result(
+    results: Vec<Result<SimulatedTransaction>>,
+) -> Result<SimulatedTransaction> {
+    results
+        .into_iter()
+        .next()
+        .ok_or_else(|| Error::Protocol(ProtocolError::EmptyResponseField("transaction_results")))?
 }
 
 /// Convert a transaction and options into a proto `SimulateTransactionItem`.

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -4,7 +4,7 @@
 //! High-level API for transaction simulation.
 
 use iota_grpc_types::{
-    read_mask_fields::SimulateReadMask,
+    read_mask_fields::{IntoReadMask, SimulateReadMask},
     v1::transaction_execution_service::{
         SimulateTransactionItem, SimulateTransactionsRequest, SimulatedTransaction,
         simulate_transaction_item::TransactionCheckModes,
@@ -14,10 +14,7 @@ use iota_types::Transaction;
 
 use crate::{
     Client,
-    api::{
-        Error, MetadataEnvelope, ProtoResult, ProtocolError, Result,
-        SIMULATE_TRANSACTIONS_READ_MASK, build_proto_transaction, field_mask_with_default,
-    },
+    api::{Error, MetadataEnvelope, ProtoResult, ProtocolError, Result, build_proto_transaction},
 };
 
 /// A single transaction with simulation options for use in batch simulation.
@@ -58,12 +55,15 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::SimulateReadMask;
     /// # use iota_types::Transaction;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
     /// let tx: Transaction = todo!();
-    /// let result = client.simulate_transaction(tx, false, None).await?;
+    /// let result = client
+    ///     .simulate_transaction(tx, false, SimulateReadMask::default())
+    ///     .await?;
     ///
     /// let executed_tx = result.body().executed_transaction()?;
     /// let effects = executed_tx.effects()?.effects()?;
@@ -75,15 +75,15 @@ impl Client {
     /// # }
     /// ```
     ///
-    /// The optional `read_mask` controls which fields the server returns; pass
-    /// `None` for the default mask, or a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `SimulateReadMask::default()` for the default mask. Pass a
     /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
     /// any slice/array/vec of fields — conversion is automatic.
     pub async fn simulate_transaction(
         &self,
         transaction: Transaction,
         skip_checks: bool,
-        read_mask: impl Into<Option<SimulateReadMask>>,
+        read_mask: impl IntoReadMask<SimulateReadMask>,
     ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
         self.simulate_transactions(
             vec![SimulateTransactionInput {
@@ -105,9 +105,9 @@ impl Client {
     /// input. Each element is either the successfully simulated transaction or
     /// the per-item error returned by the server.
     ///
-    /// The optional `read_mask` controls which fields the server returns for
-    /// each `SimulatedTransaction`; pass `None` for the default mask
-    /// [`SIMULATE_TRANSACTIONS_READ_MASK`]. Pass a
+    /// The `read_mask` controls which fields the server returns for each
+    /// `SimulatedTransaction`; use `SimulateReadMask::default()` for the
+    /// default mask. Pass a
     /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
     /// any slice/array/vec of fields — conversion is automatic.
     ///
@@ -119,9 +119,9 @@ impl Client {
     pub async fn simulate_transactions(
         &self,
         transactions: Vec<SimulateTransactionInput>,
-        read_mask: impl Into<Option<SimulateReadMask>>,
+        read_mask: impl IntoReadMask<SimulateReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<SimulatedTransaction>>>> {
-        let read_mask = read_mask.into();
+        let read_mask = read_mask.into_read_mask();
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
         }
@@ -133,10 +133,7 @@ impl Client {
 
         let request = SimulateTransactionsRequest::default()
             .with_transactions(items)
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                SIMULATE_TRANSACTIONS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         let response = self
             .execution_service_client()

--- a/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
@@ -5,9 +5,9 @@
 //!
 //! # Read Mask
 //!
-//! All checkpoint query methods accept an optional `read_mask` to control
-//! which data is included in the response. Pass `None` for the default mask,
-//! or a
+//! All checkpoint query methods accept a `read_mask` to control which data is
+//! included in the response. Pass `CheckpointResponseReadMask::default()` for
+//! the default mask, or a
 //! [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
 //! (or any slice/array/vec of fields) — conversion is automatic.
 
@@ -15,7 +15,7 @@ use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
 use iota_grpc_types::{
-    read_mask_fields::CheckpointResponseReadMask,
+    read_mask_fields::{CheckpointResponseReadMask, IntoReadMask},
     v1::{
         checkpoint, event, filter as grpc_filter,
         ledger_service::{
@@ -30,9 +30,8 @@ use iota_types::{CheckpointDigest, CheckpointSequenceNumber};
 use crate::{
     Client, Error,
     api::{
-        CheckpointResponse, CheckpointStreamError, CheckpointStreamItem, GET_CHECKPOINT_READ_MASK,
-        MetadataEnvelope, ProtocolError, Result, TryFromProtoError, field_mask_with_default,
-        saturating_usize_to_u32,
+        CheckpointResponse, CheckpointStreamError, CheckpointStreamItem, MetadataEnvelope,
+        ProtocolError, Result, TryFromProtoError, saturating_usize_to_u32,
     },
 };
 
@@ -40,39 +39,42 @@ impl Client {
     /// Get the latest checkpoint.
     ///
     /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; pass `None` for the default field mask
-    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
+    /// default field mask. Pass a
     /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
-    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
+    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
-    /// let checkpoint = client.get_checkpoint_latest(None, None, None).await?;
+    /// let checkpoint = client
+    ///     .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
+    ///     .await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_checkpoint_latest(
         &self,
-        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        read_mask: impl IntoReadMask<CheckpointResponseReadMask>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::Latest(true),
-            read_mask.into(),
             transactions_filter.into(),
             events_filter.into(),
+            read_mask.into_read_mask(),
         )
         .await
     }
@@ -80,26 +82,27 @@ impl Client {
     /// Get checkpoint by sequence number.
     ///
     /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; pass `None` for the default field mask
-    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
+    /// default field mask. Pass a
     /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
     /// * `sequence_number` - The checkpoint sequence number to fetch
-    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
+    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let checkpoint = client
-    ///     .get_checkpoint_by_sequence_number(100, None, None, None)
+    ///     .get_checkpoint_by_sequence_number(100, None, None, CheckpointResponseReadMask::default())
     ///     .await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
@@ -108,15 +111,15 @@ impl Client {
     pub async fn get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        read_mask: impl IntoReadMask<CheckpointResponseReadMask>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::SequenceNumber(sequence_number),
-            read_mask.into(),
             transactions_filter.into(),
             events_filter.into(),
+            read_mask.into_read_mask(),
         )
         .await
     }
@@ -124,28 +127,29 @@ impl Client {
     /// Get checkpoint by digest.
     ///
     /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; pass `None` for the default field mask
-    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
+    /// default field mask. Pass a
     /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
     /// * `digest` - The checkpoint digest to fetch
-    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
+    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use iota_types::CheckpointDigest;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let digest: CheckpointDigest = todo!();
     /// let checkpoint = client
-    ///     .get_checkpoint_by_digest(digest, None, None, None)
+    ///     .get_checkpoint_by_digest(digest, None, None, CheckpointResponseReadMask::default())
     ///     .await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
@@ -154,15 +158,15 @@ impl Client {
     pub async fn get_checkpoint_by_digest(
         &self,
         digest: CheckpointDigest,
-        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        read_mask: impl IntoReadMask<CheckpointResponseReadMask>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::Digest(digest.into()),
-            read_mask.into(),
             transactions_filter.into(),
             events_filter.into(),
+            read_mask.into_read_mask(),
         )
         .await
     }
@@ -171,9 +175,9 @@ impl Client {
     async fn get_checkpoint_internal(
         &self,
         checkpoint_id: get_checkpoint_request::CheckpointId,
-        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
+        read_mask: CheckpointResponseReadMask,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         let mut request = match checkpoint_id {
             get_checkpoint_request::CheckpointId::Latest(val) => {
@@ -191,10 +195,7 @@ impl Client {
                 )));
             }
         }
-        .with_read_mask(field_mask_with_default(
-            read_mask.as_ref().map(|m| m.as_str()),
-            GET_CHECKPOINT_READ_MASK,
-        ));
+        .with_read_mask(read_mask);
 
         if let Some(tf) = transactions_filter {
             request = request.with_transactions_filter(tf);
@@ -241,8 +242,9 @@ impl Client {
     /// To skip non-matching checkpoints entirely, use
     /// [`stream_checkpoints_filtered`](Self::stream_checkpoints_filtered).
     ///
-    /// The optional `read_mask` controls which fields the server returns; pass
-    /// `None` for the default field mask [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `CheckpointResponseReadMask::default()` for the default field mask.
+    /// Pass a
     /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -256,19 +258,26 @@ impl Client {
     ///   starts from the latest checkpoint.
     /// * `end_sequence_number` - Optional ending checkpoint. If `None`, streams
     ///   indefinitely.
-    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
+    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let mut stream = client
-    ///     .stream_checkpoints(Some(0), Some(10), None, None, None)
+    ///     .stream_checkpoints(
+    ///         Some(0),
+    ///         Some(10),
+    ///         None,
+    ///         None,
+    ///         CheckpointResponseReadMask::default(),
+    ///     )
     ///     .await?;
     ///
     /// while let Some(checkpoint) = stream.body_mut().next().await {
@@ -282,39 +291,39 @@ impl Client {
         &self,
         start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
         end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
-        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        read_mask: impl IntoReadMask<CheckpointResponseReadMask>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
     {
-        self.stream_checkpoints_unfiltered(
+        self.stream_checkpoints_internal(
             start_sequence_number.into(),
             end_sequence_number.into(),
-            read_mask.into(),
             transactions_filter.into(),
             events_filter.into(),
+            read_mask.into_read_mask(),
         )
         .await
     }
 
-    async fn stream_checkpoints_unfiltered(
+    async fn stream_checkpoints_internal(
         &self,
         start_sequence_number: Option<CheckpointSequenceNumber>,
         end_sequence_number: Option<CheckpointSequenceNumber>,
-        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
+        read_mask: CheckpointResponseReadMask,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
     {
         let envelope = self
             .stream_checkpoints_raw(
                 start_sequence_number,
                 end_sequence_number,
-                read_mask,
                 transactions_filter,
                 events_filter,
                 false,
                 None,
+                read_mask,
             )
             .await?;
 
@@ -353,8 +362,9 @@ impl Client {
     ///
     /// At least one of `transactions_filter` or `events_filter` must be set.
     ///
-    /// The optional `read_mask` controls which fields the server returns; pass
-    /// `None` for the default field mask [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `CheckpointResponseReadMask::default()` for the default field mask.
+    /// Pass a
     /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -364,16 +374,17 @@ impl Client {
     ///   starts from the latest checkpoint.
     /// * `end_sequence_number` - Optional ending checkpoint. If `None`, streams
     ///   indefinitely.
-    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     /// * `progress_interval_ms` - Optional progress message interval in
     ///   milliseconds. Defaults to 2000ms. Minimum 500ms.
+    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::{Client, CheckpointStreamItem};
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use iota_grpc_types::v1::filter as grpc_filter;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -381,7 +392,14 @@ impl Client {
     /// // At least one filter is required
     /// let tx_filter = grpc_filter::TransactionFilter::default();
     /// let mut stream = client
-    ///     .stream_checkpoints_filtered(Some(0), None, None, Some(tx_filter), None, None)
+    ///     .stream_checkpoints_filtered(
+    ///         Some(0),
+    ///         None,
+    ///         Some(tx_filter),
+    ///         None,
+    ///         None,
+    ///         CheckpointResponseReadMask::default(),
+    ///     )
     ///     .await?;
     ///
     /// while let Some(item) = stream.body_mut().next().await {
@@ -400,48 +418,43 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    #[allow(clippy::too_many_arguments)]
     pub async fn stream_checkpoints_filtered(
         &self,
         start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
         end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
-        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
         progress_interval_ms: impl Into<Option<u32>>,
+        read_mask: impl IntoReadMask<CheckpointResponseReadMask>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
     {
         self.stream_checkpoints_raw(
             start_sequence_number.into(),
             end_sequence_number.into(),
-            read_mask.into(),
             transactions_filter.into(),
             events_filter.into(),
             true,
             progress_interval_ms.into(),
+            read_mask.into_read_mask(),
         )
         .await
     }
 
     /// Internal helper that builds the stream request and returns the raw
     /// [`CheckpointStreamItem`] stream.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn stream_checkpoints_raw(
         &self,
         start_sequence_number: Option<CheckpointSequenceNumber>,
         end_sequence_number: Option<CheckpointSequenceNumber>,
-        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
         filter_checkpoints: bool,
         progress_interval_ms: Option<u32>,
+        read_mask: CheckpointResponseReadMask,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
     {
-        let mut request =
-            StreamCheckpointsRequest::default().with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                GET_CHECKPOINT_READ_MASK,
-            ));
+        let mut request = StreamCheckpointsRequest::default().with_read_mask(read_mask);
 
         if let Some(start) = start_sequence_number {
             request = request.with_start_sequence_number(start);

--- a/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
@@ -6,22 +6,24 @@
 //! # Read Mask
 //!
 //! All checkpoint query methods accept an optional `read_mask` to control
-//! which data is included in the response.
-//!
-//! Use [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-//! constants with [`ReadMask::from`](crate::ReadMask::from) for field
-//! selection.
+//! which data is included in the response. Pass `None` for the default mask,
+//! or a
+//! [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+//! (or any slice/array/vec of fields) — conversion is automatic.
 
 use std::pin::Pin;
 
 use futures::{Stream, StreamExt};
-use iota_grpc_types::v1::{
-    checkpoint, event, filter as grpc_filter,
-    ledger_service::{
-        GetCheckpointRequest, StreamCheckpointsRequest, checkpoint_data, get_checkpoint_request,
+use iota_grpc_types::{
+    read_mask_fields::CheckpointResponseReadMask,
+    v1::{
+        checkpoint, event, filter as grpc_filter,
+        ledger_service::{
+            GetCheckpointRequest, StreamCheckpointsRequest, checkpoint_data, get_checkpoint_request,
+        },
+        signatures::ValidatorAggregatedSignature as ProtoValidatorAggregatedSignature,
+        transaction::ExecutedTransaction,
     },
-    signatures::ValidatorAggregatedSignature as ProtoValidatorAggregatedSignature,
-    transaction::ExecutedTransaction,
 };
 use iota_types::{CheckpointDigest, CheckpointSequenceNumber};
 
@@ -29,23 +31,23 @@ use crate::{
     Client, Error,
     api::{
         CheckpointResponse, CheckpointStreamError, CheckpointStreamItem, GET_CHECKPOINT_READ_MASK,
-        MetadataEnvelope, ProtocolError, ReadMask, Result, TryFromProtoError,
-        field_mask_with_default, saturating_usize_to_u32,
+        MetadataEnvelope, ProtocolError, Result, TryFromProtoError, field_mask_with_default,
+        saturating_usize_to_u32,
     },
 };
 
 impl Client {
     /// Get the latest checkpoint.
     ///
-    /// This retrieves the checkpoint including summary, contents,
-    /// transactions, and events based on the provided read mask.
+    /// Returns the checkpoint with fields populated according to the
+    /// `read_mask`; pass `None` for the default field mask
+    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
-    ///   See [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    ///   for all available fields.
+    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     ///
@@ -54,7 +56,7 @@ impl Client {
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let checkpoint = client.get_checkpoint_latest(None, None, None).await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
@@ -62,31 +64,31 @@ impl Client {
     /// ```
     pub async fn get_checkpoint_latest(
         &self,
-        read_mask: Option<ReadMask<'_>>,
-        transactions_filter: Option<grpc_filter::TransactionFilter>,
-        events_filter: Option<grpc_filter::EventFilter>,
+        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::Latest(true),
-            read_mask,
-            transactions_filter,
-            events_filter,
+            read_mask.into(),
+            transactions_filter.into(),
+            events_filter.into(),
         )
         .await
     }
 
     /// Get checkpoint by sequence number.
     ///
-    /// This retrieves the checkpoint including summary, contents,
-    /// transactions, and events based on the provided read mask.
+    /// Returns the checkpoint with fields populated according to the
+    /// `read_mask`; pass `None` for the default field mask
+    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
     /// * `sequence_number` - The checkpoint sequence number to fetch
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
-    ///   See [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    ///   for all available fields.
+    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     ///
@@ -95,7 +97,7 @@ impl Client {
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let checkpoint = client
     ///     .get_checkpoint_by_sequence_number(100, None, None, None)
     ///     .await?;
@@ -106,31 +108,31 @@ impl Client {
     pub async fn get_checkpoint_by_sequence_number(
         &self,
         sequence_number: CheckpointSequenceNumber,
-        read_mask: Option<ReadMask<'_>>,
-        transactions_filter: Option<grpc_filter::TransactionFilter>,
-        events_filter: Option<grpc_filter::EventFilter>,
+        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::SequenceNumber(sequence_number),
-            read_mask,
-            transactions_filter,
-            events_filter,
+            read_mask.into(),
+            transactions_filter.into(),
+            events_filter.into(),
         )
         .await
     }
 
     /// Get checkpoint by digest.
     ///
-    /// This retrieves the checkpoint including summary, contents,
-    /// transactions, and events based on the provided read mask.
+    /// Returns the checkpoint with fields populated according to the
+    /// `read_mask`; pass `None` for the default field mask
+    /// [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
     ///
     /// # Parameters
     ///
     /// * `digest` - The checkpoint digest to fetch
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
-    ///   See [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    ///   for all available fields.
+    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     ///
@@ -140,7 +142,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::CheckpointDigest;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let digest: CheckpointDigest = todo!();
     /// let checkpoint = client
     ///     .get_checkpoint_by_digest(digest, None, None, None)
@@ -152,15 +154,15 @@ impl Client {
     pub async fn get_checkpoint_by_digest(
         &self,
         digest: CheckpointDigest,
-        read_mask: Option<ReadMask<'_>>,
-        transactions_filter: Option<grpc_filter::TransactionFilter>,
-        events_filter: Option<grpc_filter::EventFilter>,
+        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
         self.get_checkpoint_internal(
             get_checkpoint_request::CheckpointId::Digest(digest.into()),
-            read_mask,
-            transactions_filter,
-            events_filter,
+            read_mask.into(),
+            transactions_filter.into(),
+            events_filter.into(),
         )
         .await
     }
@@ -169,7 +171,7 @@ impl Client {
     async fn get_checkpoint_internal(
         &self,
         checkpoint_id: get_checkpoint_request::CheckpointId,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<CheckpointResponse>> {
@@ -189,7 +191,10 @@ impl Client {
                 )));
             }
         }
-        .with_read_mask(field_mask_with_default(read_mask, GET_CHECKPOINT_READ_MASK));
+        .with_read_mask(field_mask_with_default(
+            read_mask.as_ref().map(|m| m.as_str()),
+            GET_CHECKPOINT_READ_MASK,
+        ));
 
         if let Some(tf) = transactions_filter {
             request = request.with_transactions_filter(tf);
@@ -236,6 +241,11 @@ impl Client {
     /// To skip non-matching checkpoints entirely, use
     /// [`stream_checkpoints_filtered`](Self::stream_checkpoints_filtered).
     ///
+    /// The optional `read_mask` controls which fields the server returns; pass
+    /// `None` for the default field mask [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
     /// **Note:** The metadata in the returned [`MetadataEnvelope`] is captured
     /// from the initial gRPC response headers when the stream is opened. It is
     /// **not** updated as subsequent checkpoint data arrives.
@@ -246,10 +256,7 @@ impl Client {
     ///   starts from the latest checkpoint.
     /// * `end_sequence_number` - Optional ending checkpoint. If `None`, streams
     ///   indefinitely.
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
-    ///   See [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    ///   for all available fields.
+    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     ///
@@ -259,7 +266,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let mut stream = client
     ///     .stream_checkpoints(Some(0), Some(10), None, None, None)
     ///     .await?;
@@ -273,9 +280,28 @@ impl Client {
     /// ```
     pub async fn stream_checkpoints(
         &self,
+        start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+    ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
+    {
+        self.stream_checkpoints_unfiltered(
+            start_sequence_number.into(),
+            end_sequence_number.into(),
+            read_mask.into(),
+            transactions_filter.into(),
+            events_filter.into(),
+        )
+        .await
+    }
+
+    async fn stream_checkpoints_unfiltered(
+        &self,
         start_sequence_number: Option<CheckpointSequenceNumber>,
         end_sequence_number: Option<CheckpointSequenceNumber>,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
@@ -327,16 +353,18 @@ impl Client {
     ///
     /// At least one of `transactions_filter` or `events_filter` must be set.
     ///
+    /// The optional `read_mask` controls which fields the server returns; pass
+    /// `None` for the default field mask [`GET_CHECKPOINT_READ_MASK`]. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
     /// # Parameters
     ///
     /// * `start_sequence_number` - Optional starting checkpoint. If `None`,
     ///   starts from the latest checkpoint.
     /// * `end_sequence_number` - Optional ending checkpoint. If `None`, streams
     ///   indefinitely.
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`crate::api::GET_CHECKPOINT_READ_MASK`] as default.
-    ///   See [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    ///   for all available fields.
+    /// * `read_mask` - Optional field mask; `None` uses the default
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
     /// * `progress_interval_ms` - Optional progress message interval in
@@ -349,7 +377,7 @@ impl Client {
     /// # use iota_grpc_types::v1::filter as grpc_filter;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// // At least one filter is required
     /// let tx_filter = grpc_filter::TransactionFilter::default();
     /// let mut stream = client
@@ -372,24 +400,25 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub async fn stream_checkpoints_filtered(
         &self,
-        start_sequence_number: Option<CheckpointSequenceNumber>,
-        end_sequence_number: Option<CheckpointSequenceNumber>,
-        read_mask: Option<ReadMask<'_>>,
-        transactions_filter: Option<grpc_filter::TransactionFilter>,
-        events_filter: Option<grpc_filter::EventFilter>,
-        progress_interval_ms: Option<u32>,
+        start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        read_mask: impl Into<Option<CheckpointResponseReadMask>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        progress_interval_ms: impl Into<Option<u32>>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
     {
         self.stream_checkpoints_raw(
-            start_sequence_number,
-            end_sequence_number,
-            read_mask,
-            transactions_filter,
-            events_filter,
+            start_sequence_number.into(),
+            end_sequence_number.into(),
+            read_mask.into(),
+            transactions_filter.into(),
+            events_filter.into(),
             true,
-            progress_interval_ms,
+            progress_interval_ms.into(),
         )
         .await
     }
@@ -401,15 +430,18 @@ impl Client {
         &self,
         start_sequence_number: Option<CheckpointSequenceNumber>,
         end_sequence_number: Option<CheckpointSequenceNumber>,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: Option<CheckpointResponseReadMask>,
         transactions_filter: Option<grpc_filter::TransactionFilter>,
         events_filter: Option<grpc_filter::EventFilter>,
         filter_checkpoints: bool,
         progress_interval_ms: Option<u32>,
     ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
     {
-        let mut request = StreamCheckpointsRequest::default()
-            .with_read_mask(field_mask_with_default(read_mask, GET_CHECKPOINT_READ_MASK));
+        let mut request =
+            StreamCheckpointsRequest::default().with_read_mask(field_mask_with_default(
+                read_mask.as_ref().map(|m| m.as_str()),
+                GET_CHECKPOINT_READ_MASK,
+            ));
 
         if let Some(start) = start_sequence_number {
             request = request.with_start_sequence_number(start);

--- a/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
@@ -5,14 +5,14 @@
 
 use iota_grpc_types::{
     field::FieldMask,
+    read_mask_fields::EpochReadMask,
     v1::{epoch::Epoch, ledger_service::GetEpochRequest},
 };
 
 use crate::{
     Client,
     api::{
-        GET_EPOCH_READ_MASK, MetadataEnvelope, ReadMask, Result, TryFromProtoError,
-        field_mask_with_default,
+        GET_EPOCH_READ_MASK, MetadataEnvelope, Result, TryFromProtoError, field_mask_with_default,
     },
 };
 
@@ -20,95 +20,86 @@ impl Client {
     /// Get epoch information.
     ///
     /// Returns the [`Epoch`] proto type with fields populated according to the
-    /// `read_mask`.
-    ///
-    /// # Parameters
-    ///
-    /// * `epoch` - The epoch to query. If `None`, returns the current epoch.
-    /// * `read_mask` - Optional field mask specifying which fields to include.
-    ///   If `None`, uses [`GET_EPOCH_READ_MASK`].
-    ///
-    /// # Read Mask
-    ///
-    /// Use [`EpochField`](iota_grpc_types::read_mask_fields::EpochField)
-    /// constants with [`ReadMask::from`] for field selection. For individual
-    /// protocol config map entries, use
+    /// `read_mask`; pass `None` for the default field mask
+    /// [`GET_EPOCH_READ_MASK`]. Pass an
+    /// [`EpochReadMask`](iota_grpc_types::read_mask_fields::EpochReadMask)
+    /// built from an
+    /// [`EpochField`](iota_grpc_types::read_mask_fields::EpochField) or any
+    /// slice/array/vec of fields. For individual protocol config map entries,
+    /// use
     /// [`EpochField::feature_flag`](iota_grpc_types::read_mask_fields::EpochField::feature_flag)
     /// and
     /// [`EpochField::attribute`](iota_grpc_types::read_mask_fields::EpochField::attribute).
     ///
+    /// # Parameters
+    ///
+    /// * `epoch` - The epoch to query. If `None`, returns the current epoch.
+    /// * `read_mask` - Optional field mask; `None` uses the default.
+    ///
     /// # Example
     ///
     /// ```no_run
-    /// # use iota_sdk_grpc_client::{Client, ReadMask};
-    /// # use iota_sdk_grpc_client::read_mask_fields::EpochField;
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{EpochField, EpochReadMask};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     ///
-    /// // Get current epoch with default fields
+    /// // Current epoch with the default mask.
     /// let epoch = client.get_epoch(None, None).await?;
     /// println!("Epoch: {:?}", epoch.body().epoch);
     ///
-    /// // Get specific epoch with custom fields
+    /// // Specific epoch with selected fields.
     /// let epoch = client
     ///     .get_epoch(
     ///         Some(0),
-    ///         Some(ReadMask::from(&[
+    ///         EpochReadMask::from([
     ///             EpochField::EPOCH,
     ///             EpochField::REFERENCE_GAS_PRICE,
     ///             EpochField::FIRST_CHECKPOINT,
-    ///         ])),
+    ///         ]),
     ///     )
     ///     .await?;
     ///
-    /// // Get all feature flags for the current epoch
+    /// // All feature flags for the current epoch.
     /// let epoch = client
     ///     .get_epoch(
     ///         None,
-    ///         Some(ReadMask::from(EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS)),
+    ///         EpochReadMask::from(EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS),
     ///     )
     ///     .await?
     ///     .into_inner();
     /// let flags = epoch.protocol_config.unwrap().feature_flags.unwrap().flags;
     ///
-    /// // Get a single named feature flag
-    /// let flag_field = EpochField::feature_flag("enable_vdf");
-    /// let epoch = client
-    ///     .get_epoch(None, Some(ReadMask::from(flag_field.as_str())))
-    ///     .await?;
-    ///
-    /// // Get all protocol attributes for the current epoch
+    /// // A single named feature flag.
     /// let epoch = client
     ///     .get_epoch(
     ///         None,
-    ///         Some(ReadMask::from(EpochField::PROTOCOL_CONFIG_ATTRIBUTES)),
+    ///         EpochReadMask::from(EpochField::feature_flag("enable_vdf")),
     ///     )
-    ///     .await?
-    ///     .into_inner();
-    /// let attributes = epoch
-    ///     .protocol_config
-    ///     .unwrap()
-    ///     .attributes
-    ///     .unwrap()
-    ///     .attributes;
+    ///     .await?;
     ///
-    /// // Get a single named attribute
-    /// let attr_field = EpochField::attribute("max_tx_gas");
+    /// // A single named attribute.
     /// let epoch = client
-    ///     .get_epoch(None, Some(ReadMask::from(attr_field.as_str())))
+    ///     .get_epoch(
+    ///         None,
+    ///         EpochReadMask::from(EpochField::attribute("max_tx_gas")),
+    ///     )
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_epoch(
         &self,
-        epoch: Option<u64>,
-        read_mask: Option<ReadMask<'_>>,
+        epoch: impl Into<Option<u64>>,
+        read_mask: impl Into<Option<EpochReadMask>>,
     ) -> Result<MetadataEnvelope<Epoch>> {
-        let mut request = GetEpochRequest::default()
-            .with_read_mask(field_mask_with_default(read_mask, GET_EPOCH_READ_MASK));
+        let read_mask = read_mask.into();
+        let mut request = GetEpochRequest::default().with_read_mask(field_mask_with_default(
+            read_mask.as_ref().map(|m| m.as_str()),
+            GET_EPOCH_READ_MASK,
+        ));
 
-        if let Some(epoch) = epoch {
+        if let Some(epoch) = epoch.into() {
             request = request.with_epoch(epoch);
         }
 
@@ -128,7 +119,7 @@ impl Client {
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let gas_price = client.get_reference_gas_price().await?.into_inner();
     /// println!("Reference gas price: {gas_price} NANOS");
     /// # Ok(())

--- a/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
@@ -5,23 +5,21 @@
 
 use iota_grpc_types::{
     field::FieldMask,
-    read_mask_fields::EpochReadMask,
+    read_mask_fields::{EpochReadMask, IntoReadMask},
     v1::{epoch::Epoch, ledger_service::GetEpochRequest},
 };
 
 use crate::{
     Client,
-    api::{
-        GET_EPOCH_READ_MASK, MetadataEnvelope, Result, TryFromProtoError, field_mask_with_default,
-    },
+    api::{MetadataEnvelope, Result, TryFromProtoError},
 };
 
 impl Client {
     /// Get epoch information.
     ///
     /// Returns the [`Epoch`] proto type with fields populated according to the
-    /// `read_mask`; pass `None` for the default field mask
-    /// [`GET_EPOCH_READ_MASK`]. Pass an
+    /// `read_mask`; use `EpochReadMask::default()` for the default field mask.
+    /// Pass an
     /// [`EpochReadMask`](iota_grpc_types::read_mask_fields::EpochReadMask)
     /// built from an
     /// [`EpochField`](iota_grpc_types::read_mask_fields::EpochField) or any
@@ -34,7 +32,7 @@ impl Client {
     /// # Parameters
     ///
     /// * `epoch` - The epoch to query. If `None`, returns the current epoch.
-    /// * `read_mask` - Optional field mask; `None` uses the default.
+    /// * `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Example
     ///
@@ -45,7 +43,7 @@ impl Client {
     /// let client = Client::new_localnet()?;
     ///
     /// // Current epoch with the default mask.
-    /// let epoch = client.get_epoch(None, None).await?;
+    /// let epoch = client.get_epoch(None, EpochReadMask::default()).await?;
     /// println!("Epoch: {:?}", epoch.body().epoch);
     ///
     /// // Specific epoch with selected fields.
@@ -91,13 +89,10 @@ impl Client {
     pub async fn get_epoch(
         &self,
         epoch: impl Into<Option<u64>>,
-        read_mask: impl Into<Option<EpochReadMask>>,
+        read_mask: impl IntoReadMask<EpochReadMask>,
     ) -> Result<MetadataEnvelope<Epoch>> {
-        let read_mask = read_mask.into();
-        let mut request = GetEpochRequest::default().with_read_mask(field_mask_with_default(
-            read_mask.as_ref().map(|m| m.as_str()),
-            GET_EPOCH_READ_MASK,
-        ));
+        let read_mask = read_mask.into_read_mask();
+        let mut request = GetEpochRequest::default().with_read_mask(read_mask);
 
         if let Some(epoch) = epoch.into() {
             request = request.with_epoch(epoch);

--- a/crates/iota-sdk-grpc-client/src/api/ledger/health.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/health.rs
@@ -28,10 +28,10 @@ impl Client {
     ///   If `None`, the server applies its default threshold (5 seconds).
     pub async fn get_health(
         &self,
-        threshold_ms: Option<u64>,
+        threshold_ms: impl Into<Option<u64>>,
     ) -> Result<MetadataEnvelope<GetHealthResponse>> {
         let mut request = GetHealthRequest::default();
-        if let Some(ms) = threshold_ms {
+        if let Some(ms) = threshold_ms.into() {
             request = request.with_threshold_ms(ms);
         }
 

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -3,23 +3,26 @@
 
 //! High-level API for object queries.
 
-use iota_grpc_types::v1::{
-    ledger_service::{GetObjectsRequest, ObjectRequest, ObjectRequests},
-    object::Object,
-    types::ObjectReference,
+use iota_grpc_types::{
+    read_mask_fields::ObjectReadMask,
+    v1::{
+        ledger_service::{GetObjectsRequest, ObjectRequest, ObjectRequests},
+        object::Object,
+        types::ObjectReference,
+    },
 };
 use iota_types::{ObjectId, Version};
 
 use crate::{
     Client,
     api::{
-        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ProtoResult, ReadMask, Result,
-        collect_stream, field_mask_with_default, proto_object_id, saturating_usize_to_u32,
+        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ProtoResult, Result, collect_stream,
+        field_mask_with_default, proto_object_id, saturating_usize_to_u32,
     },
 };
 
 impl Client {
-    /// Get objects by their IDs and optional versions.
+    /// Get objects by their IDs.
     ///
     /// Returns proto `Object` types. Use `obj.object()` to convert to SDK
     /// type, or use `obj.object_reference()` to get the object reference.
@@ -33,30 +36,31 @@ impl Client {
     ///
     /// # Read Mask
     ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns. If `None`, uses [`GET_OBJECTS_READ_MASK`].
-    ///
-    /// Use [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField)
-    /// constants with [`ReadMask::from`] for field selection.
+    /// The `read_mask` parameter controls which fields the server returns; pass
+    /// `None` for the default mask, or an
+    /// [`ObjectReadMask`](iota_grpc_types::read_mask_fields::ObjectReadMask)
+    /// built from an
+    /// [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField) or any
+    /// slice/array/vec of fields.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// # use iota_sdk_grpc_client::{Client, ReadMask};
-    /// # use iota_sdk_grpc_client::read_mask_fields::ObjectField;
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{ObjectField, ObjectReadMask};
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let object_id: ObjectId = "0x2".parse()?;
     ///
-    /// // Get objects with default mask
-    /// let objs = client.get_objects(&[(object_id, None)], None).await?;
+    /// // Default mask
+    /// let objs = client.get_objects([object_id], None).await?;
     ///
-    /// // Get objects with field mask (only reference object ID, no BCS)
+    /// // Selected fields
     /// let objs = client
     ///     .get_objects(
-    ///         &[(object_id, None)],
-    ///         Some(ReadMask::from(ObjectField::REFERENCE_OBJECT_ID)),
+    ///         [object_id],
+    ///         ObjectReadMask::from([ObjectField::REFERENCE, ObjectField::BCS]),
     ///     )
     ///     .await?;
     ///
@@ -72,31 +76,112 @@ impl Client {
     /// ```
     pub async fn get_objects(
         &self,
-        refs: &[(ObjectId, Option<Version>)],
-        read_mask: Option<ReadMask<'_>>,
+        refs: impl IntoIterator<Item = ObjectId>,
+        read_mask: impl Into<Option<ObjectReadMask>>,
+    ) -> Result<MetadataEnvelope<Vec<Object>>> {
+        let refs = refs
+            .into_iter()
+            .map(|id| {
+                ObjectRequest::default()
+                    .with_object_ref(ObjectReference::default().with_object_id(proto_object_id(id)))
+            })
+            .collect::<Vec<_>>();
+
+        self.get_objects_internal(refs, read_mask.into()).await
+    }
+
+    /// Get objects by their IDs and optional versions.
+    ///
+    /// Returns proto `Object` types. Use `obj.object()` to convert to SDK
+    /// type, or use `obj.object_reference()` to get the object reference.
+    ///
+    /// Results are returned in the same order as the input refs.
+    /// If an object is not found, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyRequest`] if `refs` is empty.
+    ///
+    /// # Read Mask
+    ///
+    /// The `read_mask` parameter controls which fields the server returns; pass
+    /// `None` for the default mask, or an
+    /// [`ObjectReadMask`](iota_grpc_types::read_mask_fields::ObjectReadMask)
+    /// built from an
+    /// [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField) or any
+    /// slice/array/vec of fields.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{ObjectField, ObjectReadMask};
+    /// # use iota_types::ObjectId;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let object_id: ObjectId = "0x2".parse()?;
+    ///
+    /// // Default mask
+    /// let objs = client
+    ///     .get_objects_with_versions([(object_id, None)], None)
+    ///     .await?;
+    ///
+    /// // Selected fields
+    /// let objs = client
+    ///     .get_objects_with_versions(
+    ///         [(object_id, None)],
+    ///         ObjectReadMask::from(ObjectField::REFERENCE_OBJECT_ID),
+    ///     )
+    ///     .await?;
+    ///
+    /// for obj in objs.body() {
+    ///     // Convert proto object to SDK type
+    ///     let sdk_obj = obj.object()?;
+    ///     println!("Got object ID: {:?}", sdk_obj.id());
+    ///     let obj_ref = obj.object_reference()?;
+    ///     println!("Object version: {:?}", obj_ref.version());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_objects_with_versions(
+        &self,
+        refs: impl IntoIterator<Item = (ObjectId, Option<Version>)>,
+        read_mask: impl Into<Option<ObjectReadMask>>,
+    ) -> Result<MetadataEnvelope<Vec<Object>>> {
+        let refs = refs
+            .into_iter()
+            .map(|(id, version)| {
+                let mut object_ref = ObjectReference::default().with_object_id(proto_object_id(id));
+
+                if let Some(v) = version {
+                    object_ref = object_ref.with_version(v.as_u64());
+                }
+
+                ObjectRequest::default().with_object_ref(object_ref)
+            })
+            .collect::<Vec<_>>();
+
+        self.get_objects_internal(refs, read_mask.into()).await
+    }
+
+    async fn get_objects_internal(
+        &self,
+        refs: Vec<ObjectRequest>,
+        read_mask: Option<ObjectReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Object>>> {
         if refs.is_empty() {
             return Err(Error::EmptyRequest);
         }
 
-        let requests = ObjectRequests::default().with_requests(
-            refs.iter()
-                .map(|(id, version)| {
-                    let mut object_ref =
-                        ObjectReference::default().with_object_id(proto_object_id(*id));
-
-                    if let Some(v) = version {
-                        object_ref = object_ref.with_version(v.as_u64());
-                    }
-
-                    ObjectRequest::default().with_object_ref(object_ref)
-                })
-                .collect(),
-        );
+        let requests = ObjectRequests::default().with_requests(refs);
 
         let mut request = GetObjectsRequest::default()
             .with_requests(requests)
-            .with_read_mask(field_mask_with_default(read_mask, GET_OBJECTS_READ_MASK));
+            .with_read_mask(field_mask_with_default(
+                read_mask.as_ref().map(|m| m.as_str()),
+                GET_OBJECTS_READ_MASK,
+            ));
 
         if let Some(max_size) = self.max_decoding_message_size() {
             request = request.with_max_message_size_bytes(saturating_usize_to_u32(max_size));

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -4,7 +4,7 @@
 //! High-level API for object queries.
 
 use iota_grpc_types::{
-    read_mask_fields::ObjectReadMask,
+    read_mask_fields::{IntoReadMask, ObjectReadMask},
     v1::{
         ledger_service::{GetObjectsRequest, ObjectRequest, ObjectRequests},
         object::Object,
@@ -16,8 +16,8 @@ use iota_types::{ObjectId, Version};
 use crate::{
     Client,
     api::{
-        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ProtoResult, Result, collect_stream,
-        field_mask_with_default, proto_object_id, saturating_usize_to_u32,
+        Error, MetadataEnvelope, ProtoResult, Result, collect_stream, proto_object_id,
+        saturating_usize_to_u32,
     },
 };
 
@@ -36,8 +36,8 @@ impl Client {
     ///
     /// # Read Mask
     ///
-    /// The `read_mask` parameter controls which fields the server returns; pass
-    /// `None` for the default mask, or an
+    /// The `read_mask` parameter controls which fields the server returns; use
+    /// `ObjectReadMask::default()` for the default mask, or pass an
     /// [`ObjectReadMask`](iota_grpc_types::read_mask_fields::ObjectReadMask)
     /// built from an
     /// [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField) or any
@@ -54,7 +54,9 @@ impl Client {
     /// let object_id: ObjectId = "0x2".parse()?;
     ///
     /// // Default mask
-    /// let objs = client.get_objects([object_id], None).await?;
+    /// let objs = client
+    ///     .get_objects([object_id], ObjectReadMask::default())
+    ///     .await?;
     ///
     /// // Selected fields
     /// let objs = client
@@ -77,7 +79,7 @@ impl Client {
     pub async fn get_objects(
         &self,
         refs: impl IntoIterator<Item = ObjectId>,
-        read_mask: impl Into<Option<ObjectReadMask>>,
+        read_mask: impl IntoReadMask<ObjectReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Object>>> {
         let refs = refs
             .into_iter()
@@ -87,7 +89,8 @@ impl Client {
             })
             .collect::<Vec<_>>();
 
-        self.get_objects_internal(refs, read_mask.into()).await
+        self.get_objects_internal(refs, read_mask.into_read_mask())
+            .await
     }
 
     /// Get objects by their IDs and optional versions.
@@ -104,8 +107,8 @@ impl Client {
     ///
     /// # Read Mask
     ///
-    /// The `read_mask` parameter controls which fields the server returns; pass
-    /// `None` for the default mask, or an
+    /// The `read_mask` parameter controls which fields the server returns; use
+    /// `ObjectReadMask::default()` for the default mask, or pass an
     /// [`ObjectReadMask`](iota_grpc_types::read_mask_fields::ObjectReadMask)
     /// built from an
     /// [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField) or any
@@ -123,7 +126,7 @@ impl Client {
     ///
     /// // Default mask
     /// let objs = client
-    ///     .get_objects_with_versions([(object_id, None)], None)
+    ///     .get_objects_with_versions([(object_id, None)], ObjectReadMask::default())
     ///     .await?;
     ///
     /// // Selected fields
@@ -147,7 +150,7 @@ impl Client {
     pub async fn get_objects_with_versions(
         &self,
         refs: impl IntoIterator<Item = (ObjectId, Option<Version>)>,
-        read_mask: impl Into<Option<ObjectReadMask>>,
+        read_mask: impl IntoReadMask<ObjectReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Object>>> {
         let refs = refs
             .into_iter()
@@ -162,13 +165,14 @@ impl Client {
             })
             .collect::<Vec<_>>();
 
-        self.get_objects_internal(refs, read_mask.into()).await
+        self.get_objects_internal(refs, read_mask.into_read_mask())
+            .await
     }
 
     async fn get_objects_internal(
         &self,
         refs: Vec<ObjectRequest>,
-        read_mask: Option<ObjectReadMask>,
+        read_mask: ObjectReadMask,
     ) -> Result<MetadataEnvelope<Vec<Object>>> {
         if refs.is_empty() {
             return Err(Error::EmptyRequest);
@@ -178,10 +182,7 @@ impl Client {
 
         let mut request = GetObjectsRequest::default()
             .with_requests(requests)
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                GET_OBJECTS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         if let Some(max_size) = self.max_decoding_message_size() {
             request = request.with_max_message_size_bytes(saturating_usize_to_u32(max_size));

--- a/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
@@ -3,58 +3,56 @@
 
 //! High-level API for service info queries.
 
-use iota_grpc_types::v1::ledger_service::{GetServiceInfoRequest, GetServiceInfoResponse};
+use iota_grpc_types::{
+    read_mask_fields::ServiceInfoReadMask,
+    v1::ledger_service::{GetServiceInfoRequest, GetServiceInfoResponse},
+};
 
 use crate::{
     Client,
-    api::{
-        GET_SERVICE_INFO_READ_MASK, MetadataEnvelope, ReadMask, Result, field_mask_with_default,
-    },
+    api::{GET_SERVICE_INFO_READ_MASK, MetadataEnvelope, Result, field_mask_with_default},
 };
 
 impl Client {
     /// Get service info from the node.
     ///
     /// Returns the [`GetServiceInfoResponse`] proto type with fields populated
-    /// according to the `read_mask`.
-    ///
-    /// # Read Mask
-    ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns. If `None`, uses [`GET_SERVICE_INFO_READ_MASK`].
-    ///
-    /// Use [`ServiceInfoField`](iota_grpc_types::read_mask_fields::ServiceInfoField)
-    /// constants with [`ReadMask::from`] for field selection.
+    /// according to the `read_mask`; pass `None` for the default read mask
+    /// [`GET_SERVICE_INFO_READ_MASK`], or a
+    /// [`ServiceInfoReadMask`](iota_grpc_types::read_mask_fields::ServiceInfoReadMask)
+    /// built from a
+    /// [`ServiceInfoField`](iota_grpc_types::read_mask_fields::ServiceInfoField)
+    /// or any slice/array/vec of fields.
     ///
     /// # Example
     ///
     /// ```no_run
-    /// # use iota_sdk_grpc_client::{Client, ReadMask};
-    /// # use iota_sdk_grpc_client::read_mask_fields::ServiceInfoField;
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{ServiceInfoField, ServiceInfoReadMask};
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     ///
-    /// // Get service info with default fields
     /// let info = client.get_service_info(None).await?;
     /// println!("Chain ID: {:?}", info.body().chain_id);
     /// println!("Epoch: {:?}", info.body().epoch);
     ///
-    /// // Get service info with specific fields
+    /// // With a custom mask.
     /// let info = client
-    ///     .get_service_info(Some(ReadMask::from(&[
+    ///     .get_service_info(ServiceInfoReadMask::from([
     ///         ServiceInfoField::CHAIN_ID,
     ///         ServiceInfoField::EPOCH,
-    ///     ])))
+    ///     ]))
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_service_info(
         &self,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: impl Into<Option<ServiceInfoReadMask>>,
     ) -> Result<MetadataEnvelope<GetServiceInfoResponse>> {
+        let read_mask = read_mask.into();
         let request = GetServiceInfoRequest::default().with_read_mask(field_mask_with_default(
-            read_mask,
+            read_mask.as_ref().map(|m| m.as_str()),
             GET_SERVICE_INFO_READ_MASK,
         ));
 

--- a/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
@@ -4,21 +4,21 @@
 //! High-level API for service info queries.
 
 use iota_grpc_types::{
-    read_mask_fields::ServiceInfoReadMask,
+    read_mask_fields::{IntoReadMask, ServiceInfoReadMask},
     v1::ledger_service::{GetServiceInfoRequest, GetServiceInfoResponse},
 };
 
 use crate::{
     Client,
-    api::{GET_SERVICE_INFO_READ_MASK, MetadataEnvelope, Result, field_mask_with_default},
+    api::{MetadataEnvelope, Result},
 };
 
 impl Client {
     /// Get service info from the node.
     ///
     /// Returns the [`GetServiceInfoResponse`] proto type with fields populated
-    /// according to the `read_mask`; pass `None` for the default read mask
-    /// [`GET_SERVICE_INFO_READ_MASK`], or a
+    /// according to the `read_mask`; use `ServiceInfoReadMask::default()` for
+    /// the default read mask, or pass a
     /// [`ServiceInfoReadMask`](iota_grpc_types::read_mask_fields::ServiceInfoReadMask)
     /// built from a
     /// [`ServiceInfoField`](iota_grpc_types::read_mask_fields::ServiceInfoField)
@@ -32,7 +32,9 @@ impl Client {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
-    /// let info = client.get_service_info(None).await?;
+    /// let info = client
+    ///     .get_service_info(ServiceInfoReadMask::default())
+    ///     .await?;
     /// println!("Chain ID: {:?}", info.body().chain_id);
     /// println!("Epoch: {:?}", info.body().epoch);
     ///
@@ -48,13 +50,10 @@ impl Client {
     /// ```
     pub async fn get_service_info(
         &self,
-        read_mask: impl Into<Option<ServiceInfoReadMask>>,
+        read_mask: impl IntoReadMask<ServiceInfoReadMask>,
     ) -> Result<MetadataEnvelope<GetServiceInfoResponse>> {
-        let read_mask = read_mask.into();
-        let request = GetServiceInfoRequest::default().with_read_mask(field_mask_with_default(
-            read_mask.as_ref().map(|m| m.as_str()),
-            GET_SERVICE_INFO_READ_MASK,
-        ));
+        let read_mask = read_mask.into_read_mask();
+        let request = GetServiceInfoRequest::default().with_read_mask(read_mask);
 
         let mut client = self.ledger_service_client();
         let response = client.get_service_info(request).await?;

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -40,6 +40,14 @@ impl Client {
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// or any slice/array/vec of fields.
     ///
+    /// The `input_objects`, `output_objects`, `balance_changes` and
+    /// `object_changes` fields (also included by wildcard masks) require the
+    /// serving node to still have the transaction's objects. If one has been
+    /// pruned, the transaction's result is a `FAILED_PRECONDITION` error
+    /// instead of a silently incomplete answer — narrow the read mask, or
+    /// fetch objects individually via
+    /// [`get_objects`](Client::get_objects) for best-effort retrieval.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `digests` is empty.

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -4,7 +4,7 @@
 //! High-level API for transaction queries.
 
 use iota_grpc_types::{
-    read_mask_fields::TransactionReadMask,
+    read_mask_fields::{IntoReadMask, TransactionReadMask},
     v1::{
         ledger_service::{GetTransactionsRequest, TransactionRequest, TransactionRequests},
         transaction::ExecutedTransaction,
@@ -14,10 +14,7 @@ use iota_types::TransactionDigest;
 
 use crate::{
     Client,
-    api::{
-        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ProtoResult, Result, collect_stream,
-        field_mask_with_default, saturating_usize_to_u32,
-    },
+    api::{Error, MetadataEnvelope, ProtoResult, Result, collect_stream, saturating_usize_to_u32},
 };
 
 impl Client {
@@ -36,8 +33,8 @@ impl Client {
     /// Results are returned in the same order as the input digests.
     /// If a transaction is not found, an error is returned.
     ///
-    /// The optional `read_mask` controls which fields the server returns; pass
-    /// `None` for the default field mask [`GET_TRANSACTIONS_READ_MASK`], or a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `TransactionReadMask::default()` for the default field mask, or pass a
     /// [`TransactionReadMask`](iota_grpc_types::read_mask_fields::TransactionReadMask)
     /// built from a
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
@@ -58,7 +55,9 @@ impl Client {
     /// let digest: TransactionDigest = TransactionDigest::ZERO;
     ///
     /// // Default mask
-    /// let txs = client.get_transactions([digest], None).await?;
+    /// let txs = client
+    ///     .get_transactions([digest], TransactionReadMask::default())
+    ///     .await?;
     /// for tx in txs.body() {
     ///     let effects = tx.effects()?.effects()?;
     ///     println!("Status: {:?}", effects.as_v1().status);
@@ -81,20 +80,20 @@ impl Client {
     pub async fn get_transactions(
         &self,
         digests: impl IntoIterator<Item = TransactionDigest>,
-        read_mask: impl Into<Option<TransactionReadMask>>,
+        read_mask: impl IntoReadMask<TransactionReadMask>,
     ) -> Result<MetadataEnvelope<Vec<ExecutedTransaction>>> {
         let requests = digests
             .into_iter()
             .map(|d| TransactionRequest::default().with_digest(d))
             .collect::<Vec<_>>();
-        self.get_transactions_internal(requests, read_mask.into())
+        self.get_transactions_internal(requests, read_mask.into_read_mask())
             .await
     }
 
     async fn get_transactions_internal(
         &self,
         requests: Vec<TransactionRequest>,
-        read_mask: Option<TransactionReadMask>,
+        read_mask: TransactionReadMask,
     ) -> Result<MetadataEnvelope<Vec<ExecutedTransaction>>> {
         if requests.is_empty() {
             return Err(Error::EmptyRequest);
@@ -104,10 +103,7 @@ impl Client {
 
         let mut request = GetTransactionsRequest::default()
             .with_requests(requests)
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                GET_TRANSACTIONS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         if let Some(max_size) = self.max_decoding_message_size() {
             request = request.with_max_message_size_bytes(saturating_usize_to_u32(max_size));

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -3,17 +3,20 @@
 
 //! High-level API for transaction queries.
 
-use iota_grpc_types::v1::{
-    ledger_service::{GetTransactionsRequest, TransactionRequest, TransactionRequests},
-    transaction::ExecutedTransaction,
+use iota_grpc_types::{
+    read_mask_fields::TransactionReadMask,
+    v1::{
+        ledger_service::{GetTransactionsRequest, TransactionRequest, TransactionRequests},
+        transaction::ExecutedTransaction,
+    },
 };
 use iota_types::TransactionDigest;
 
 use crate::{
     Client,
     api::{
-        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ProtoResult, ReadMask, Result,
-        collect_stream, field_mask_with_default, saturating_usize_to_u32,
+        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ProtoResult, Result, collect_stream,
+        field_mask_with_default, saturating_usize_to_u32,
     },
 };
 
@@ -33,44 +36,30 @@ impl Client {
     /// Results are returned in the same order as the input digests.
     /// If a transaction is not found, an error is returned.
     ///
+    /// The optional `read_mask` controls which fields the server returns; pass
+    /// `None` for the default field mask [`GET_TRANSACTIONS_READ_MASK`], or a
+    /// [`TransactionReadMask`](iota_grpc_types::read_mask_fields::TransactionReadMask)
+    /// built from a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `digests` is empty.
     ///
-    /// # Read Mask
-    ///
-    /// The optional `read_mask` parameter controls which fields the server
-    /// returns. If `None`, uses [`GET_TRANSACTIONS_READ_MASK`].
-    ///
-    /// Use [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// constants with [`ReadMask::from`] for field selection.
-    ///
     /// # Example
     ///
     /// ```no_run
-    /// # use iota_sdk_grpc_client::{Client, ReadMask};
-    /// # use iota_sdk_grpc_client::read_mask_fields::TransactionField;
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{TransactionField, TransactionReadMask};
     /// # use iota_types::TransactionDigest;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
-    /// let digest: TransactionDigest = todo!();
+    /// let client = Client::new_localnet()?;
+    /// let digest: TransactionDigest = TransactionDigest::ZERO;
     ///
-    /// // Get transactions with default mask
-    /// let txs = client.get_transactions(&[digest], None).await?;
-    ///
-    /// // Get transactions with field mask
-    /// let txs = client
-    ///     .get_transactions(
-    ///         &[digest],
-    ///         Some(ReadMask::from(&[
-    ///             TransactionField::EFFECTS,
-    ///             TransactionField::CHECKPOINT,
-    ///         ])),
-    ///     )
-    ///     .await?;
-    ///
+    /// // Default mask
+    /// let txs = client.get_transactions([digest], None).await?;
     /// for tx in txs.body() {
-    ///     // Lazy conversion - only deserialize what you need
     ///     let effects = tx.effects()?.effects()?;
     ///     println!("Status: {:?}", effects.as_v1().status);
     ///
@@ -78,29 +67,45 @@ impl Client {
     ///     let checkpoint = tx.checkpoint_sequence_number()?;
     ///     println!("Checkpoint: {}", checkpoint);
     /// }
+    ///
+    /// // Selected fields
+    /// let txs = client
+    ///     .get_transactions(
+    ///         [digest],
+    ///         TransactionReadMask::from([TransactionField::EFFECTS, TransactionField::CHECKPOINT]),
+    ///     )
+    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_transactions(
         &self,
-        digests: &[TransactionDigest],
-        read_mask: Option<ReadMask<'_>>,
+        digests: impl IntoIterator<Item = TransactionDigest>,
+        read_mask: impl Into<Option<TransactionReadMask>>,
     ) -> Result<MetadataEnvelope<Vec<ExecutedTransaction>>> {
-        if digests.is_empty() {
+        let requests = digests
+            .into_iter()
+            .map(|d| TransactionRequest::default().with_digest(d))
+            .collect::<Vec<_>>();
+        self.get_transactions_internal(requests, read_mask.into())
+            .await
+    }
+
+    async fn get_transactions_internal(
+        &self,
+        requests: Vec<TransactionRequest>,
+        read_mask: Option<TransactionReadMask>,
+    ) -> Result<MetadataEnvelope<Vec<ExecutedTransaction>>> {
+        if requests.is_empty() {
             return Err(Error::EmptyRequest);
         }
 
-        let requests = TransactionRequests::default().with_requests(
-            digests
-                .iter()
-                .map(|d| TransactionRequest::default().with_digest(*d))
-                .collect(),
-        );
+        let requests = TransactionRequests::default().with_requests(requests);
 
         let mut request = GetTransactionsRequest::default()
             .with_requests(requests)
             .with_read_mask(field_mask_with_default(
-                read_mask,
+                read_mask.as_ref().map(|m| m.as_str()),
                 GET_TRANSACTIONS_READ_MASK,
             ));
 

--- a/crates/iota-sdk-grpc-client/src/api/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/mod.rs
@@ -212,12 +212,8 @@ impl CheckpointResponse {
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// use iota_sdk_grpc_client::CHECKPOINT_RESPONSE_CHECKPOINT_DATA;
-    ///
-    /// let client = Client::new("http://localhost:9000")?;
-    /// let cp = client
-    ///     .get_checkpoint_latest(Some(CHECKPOINT_RESPONSE_CHECKPOINT_DATA.into()), None, None)
-    ///     .await?;
+    /// let client = Client::new_localnet()?;
+    /// let cp = client.get_checkpoint_latest(None, None, None).await?;
     /// let data = cp.body().checkpoint_data()?;
     /// # Ok(())
     /// # }

--- a/crates/iota-sdk-grpc-client/src/api/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/mod.rs
@@ -17,7 +17,7 @@ pub mod state;
 pub use common::{CheckpointStreamError, Error, Page, ProtocolError, ReadMask, Result, RpcStatus};
 pub(crate) use common::{
     ProtoResult, TryFromProtoError, build_proto_transaction, collect_stream, define_list_query,
-    field_mask_with_default, proto_object_id, saturating_usize_to_u32,
+    proto_object_id, saturating_usize_to_u32,
 };
 pub use iota_grpc_types::read_masks::*;
 use iota_types::CheckpointSequenceNumber;
@@ -211,9 +211,12 @@ impl CheckpointResponse {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
-    /// let cp = client.get_checkpoint_latest(None, None, None).await?;
+    /// let cp = client
+    ///     .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
+    ///     .await?;
     /// let data = cp.body().checkpoint_data()?;
     /// # Ok(())
     /// # }

--- a/crates/iota-sdk-grpc-client/src/api/move_package/package_versions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/move_package/package_versions.rs
@@ -49,7 +49,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let package_id: ObjectId = "0x2".parse()?;
     ///
     /// let page = client.list_package_versions(package_id, None, None).await?;
@@ -65,7 +65,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let package_id: ObjectId = "0x2".parse()?;
     ///
     /// let all = client
@@ -81,8 +81,8 @@ impl Client {
     pub fn list_package_versions(
         &self,
         package_id: ObjectId,
-        page_size: Option<u32>,
-        page_token: Option<prost::bytes::Bytes>,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
     ) -> ListPackageVersionsQuery {
         let base_request =
             ListPackageVersionsRequest::default().with_package_id(proto_object_id(package_id));
@@ -91,8 +91,8 @@ impl Client {
             self.move_package_service_client(),
             base_request,
             self.max_decoding_message_size(),
-            page_size,
-            page_token,
+            page_size.into(),
+            page_token.into(),
         )
     }
 }

--- a/crates/iota-sdk-grpc-client/src/api/state/coin_info.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coin_info.rs
@@ -27,7 +27,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::StructTag;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let coin_type: StructTag = "0x2::iota::IOTA".parse()?;
     ///
     /// let response = client.get_coin_info(coin_type).await?;

--- a/crates/iota-sdk-grpc-client/src/api/state/coins.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coins.rs
@@ -69,8 +69,9 @@ impl Client {
     /// # Parameters
     ///
     /// - `owner` - The address that owns the coins.
-    /// - `coin_type` - Optional coin type filter as a [`StructTag`]. If `None`,
-    ///   lists all coin types (`0x2::coin::Coin`).
+    /// - `coin_type` - Optional coin type filter as a [`StructTag`]. The value
+    ///   must be the inner type `T` of `Coin<T>`. If `None`, lists all coin
+    ///   types (with type `0x2::coin::Coin`).
     /// - `page_size` - Optional maximum number of coins per page.
     /// - `page_token` - Optional continuation token from a previous page.
     /// - `read_mask` - Field mask controlling the returned fields.

--- a/crates/iota-sdk-grpc-client/src/api/state/coins.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coins.rs
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! High-level API for listing coins owned by an address.
+//!
+//! Wraps [`Client::list_owned_objects`](crate::Client::list_owned_objects)
+//! with a coin type filter and converts each returned proto `Object` into an
+//! [`iota_types::framework::Coin`].
+//!
+//! # Read Mask
+//!
+//! The default read mask is [`LIST_OWNED_OBJECTS_READ_MASK`]; the `bcs` field
+//! is required for the proto `Object` → SDK `Coin` conversion, so callers
+//! supplying a custom mask must include it.
+
+use iota_grpc_types::{
+    read_mask_fields::OwnedObjectReadMask,
+    v1::{
+        state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
+        types::Address as ProtoAddress,
+    },
+};
+use iota_types::{Address, Identifier, StructTag, framework::Coin};
+
+use crate::{
+    Client, InterceptedChannel,
+    api::{
+        Error, LIST_OWNED_OBJECTS_READ_MASK, Result, TryFromProtoError, define_list_query,
+        field_mask_with_default,
+    },
+};
+
+define_list_query! {
+    /// Builder for listing coins owned by an address.
+    ///
+    /// Created by [`Client::get_coins`]. Await directly for a single page
+    /// (with access to `next_page_token`), or call
+    /// [`.collect(limit)`](Self::collect) to auto-paginate.
+    pub struct GetCoinsQuery {
+        service_client: StateServiceClient<InterceptedChannel>,
+        request: ListOwnedObjectsRequest,
+        item: Coin,
+        rpc_method: list_owned_objects,
+        items_field: objects,
+        map_item: object_to_coin,
+    }
+}
+
+fn object_to_coin(obj: &iota_grpc_types::v1::object::Object) -> Result<Coin> {
+    let sdk_obj = obj.object()?;
+    Coin::try_from_object(&sdk_obj).map_err(|e| Error::from(TryFromProtoError::invalid("coin", e)))
+}
+
+impl Client {
+    /// List coins owned by an address.
+    ///
+    /// Returns a query builder. Await it directly for a single page (with
+    /// access to `next_page_token`), or call `.collect(limit)` to
+    /// auto-paginate through all results.
+    ///
+    /// Each returned [`Coin`] is converted from the underlying proto
+    /// `Object`. The `read_mask` controls which fields the server returns; pass
+    /// `None` for the default field mask [`LIST_OWNED_OBJECTS_READ_MASK`]
+    /// (which includes `bcs`, required for conversion), or an
+    /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
+    /// — it **must** include
+    /// [`OwnedObjectField::BCS`](iota_grpc_types::read_mask_fields::OwnedObjectField::BCS)
+    /// because the proto `Object` → SDK `Coin` conversion deserializes the BCS
+    /// payload.
+    ///
+    /// # Parameters
+    ///
+    /// - `owner` - The address that owns the coins.
+    /// - `coin_type` - Optional coin type filter as a [`StructTag`]. If `None`,
+    ///   lists all coin types (`0x2::coin::Coin`).
+    /// - `page_size` - Optional maximum number of coins per page.
+    /// - `page_token` - Optional continuation token from a previous page.
+    /// - `read_mask` - Optional field mask; `None` uses the default.
+    ///
+    /// # Examples
+    ///
+    /// Single page:
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_types::Address;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let owner: Address = "0x1".parse()?;
+    ///
+    /// let page = client.get_coins(owner, None, None, None, None).await?;
+    /// for coin in &page.body().items {
+    ///     println!("Coin {}: {}", coin.id(), coin.balance());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Auto-paginate:
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_types::Address;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let owner: Address = "0x1".parse()?;
+    ///
+    /// let all = client
+    ///     .get_coins(owner, None, Some(50), None, None)
+    ///     .collect(Some(500))
+    ///     .await?;
+    /// for coin in all.body() {
+    ///     println!("Coin {}: {}", coin.id(), coin.balance());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get_coins(
+        &self,
+        owner: Address,
+        coin_type: impl Into<Option<StructTag>>,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+        read_mask: impl Into<Option<OwnedObjectReadMask>>,
+    ) -> GetCoinsQuery {
+        self.get_coins_internal(
+            owner,
+            coin_type.into(),
+            page_size.into(),
+            page_token.into(),
+            read_mask.into(),
+        )
+    }
+
+    fn get_coins_internal(
+        &self,
+        owner: Address,
+        coin_type: Option<StructTag>,
+        page_size: Option<u32>,
+        page_token: Option<prost::bytes::Bytes>,
+        read_mask: Option<OwnedObjectReadMask>,
+    ) -> GetCoinsQuery {
+        // When no specific coin type is provided, query for the generic
+        // `0x2::coin::Coin` (no type params); the server returns all
+        // `Coin<T>` objects regardless of `T`.
+        let coin_type = coin_type.map(StructTag::new_coin).unwrap_or_else(|| {
+            StructTag::new(
+                Address::FRAMEWORK,
+                Identifier::COIN_MODULE,
+                Identifier::COIN,
+                Vec::new(),
+            )
+        });
+
+        let base_request = ListOwnedObjectsRequest::default()
+            .with_owner(ProtoAddress::default().with_address(Vec::from(owner)))
+            .with_object_type(coin_type.to_string())
+            .with_read_mask(field_mask_with_default(
+                read_mask.as_ref().map(|m| m.as_str()),
+                LIST_OWNED_OBJECTS_READ_MASK,
+            ));
+
+        GetCoinsQuery::new(
+            self.state_service_client(),
+            base_request,
+            self.max_decoding_message_size(),
+            page_size,
+            page_token,
+        )
+    }
+}

--- a/crates/iota-sdk-grpc-client/src/api/state/coins.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coins.rs
@@ -14,7 +14,7 @@
 //! supplying a custom mask must include it.
 
 use iota_grpc_types::{
-    read_mask_fields::OwnedObjectReadMask,
+    read_mask_fields::{IntoReadMask, OwnedObjectReadMask},
     v1::{
         state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
         types::Address as ProtoAddress,
@@ -24,10 +24,7 @@ use iota_types::{Address, Identifier, StructTag, framework::Coin};
 
 use crate::{
     Client, InterceptedChannel,
-    api::{
-        Error, LIST_OWNED_OBJECTS_READ_MASK, Result, TryFromProtoError, define_list_query,
-        field_mask_with_default,
-    },
+    api::{Error, Result, TryFromProtoError, define_list_query},
 };
 
 define_list_query! {
@@ -59,9 +56,9 @@ impl Client {
     /// auto-paginate through all results.
     ///
     /// Each returned [`Coin`] is converted from the underlying proto
-    /// `Object`. The `read_mask` controls which fields the server returns; pass
-    /// `None` for the default field mask [`LIST_OWNED_OBJECTS_READ_MASK`]
-    /// (which includes `bcs`, required for conversion), or an
+    /// `Object`. The `read_mask` controls which fields the server returns; use
+    /// `OwnedObjectReadMask::default()` for the default field mask (which
+    /// includes `bcs`, required for conversion), or pass an
     /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
     /// — it **must** include
     /// [`OwnedObjectField::BCS`](iota_grpc_types::read_mask_fields::OwnedObjectField::BCS)
@@ -75,19 +72,22 @@ impl Client {
     ///   lists all coin types (`0x2::coin::Coin`).
     /// - `page_size` - Optional maximum number of coins per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Optional field mask; `None` uses the default.
+    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
-    /// let page = client.get_coins(owner, None, None, None, None).await?;
+    /// let page = client
+    ///     .get_coins(owner, None, None, None, OwnedObjectReadMask::default())
+    ///     .await?;
     /// for coin in &page.body().items {
     ///     println!("Coin {}: {}", coin.id(), coin.balance());
     /// }
@@ -98,13 +98,14 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let all = client
-    ///     .get_coins(owner, None, Some(50), None, None)
+    ///     .get_coins(owner, None, Some(50), None, OwnedObjectReadMask::default())
     ///     .collect(Some(500))
     ///     .await?;
     /// for coin in all.body() {
@@ -119,14 +120,14 @@ impl Client {
         coin_type: impl Into<Option<StructTag>>,
         page_size: impl Into<Option<u32>>,
         page_token: impl Into<Option<prost::bytes::Bytes>>,
-        read_mask: impl Into<Option<OwnedObjectReadMask>>,
+        read_mask: impl IntoReadMask<OwnedObjectReadMask>,
     ) -> GetCoinsQuery {
         self.get_coins_internal(
             owner,
             coin_type.into(),
             page_size.into(),
             page_token.into(),
-            read_mask.into(),
+            read_mask.into_read_mask(),
         )
     }
 
@@ -136,7 +137,7 @@ impl Client {
         coin_type: Option<StructTag>,
         page_size: Option<u32>,
         page_token: Option<prost::bytes::Bytes>,
-        read_mask: Option<OwnedObjectReadMask>,
+        read_mask: OwnedObjectReadMask,
     ) -> GetCoinsQuery {
         // When no specific coin type is provided, query for the generic
         // `0x2::coin::Coin` (no type params); the server returns all
@@ -153,10 +154,7 @@ impl Client {
         let base_request = ListOwnedObjectsRequest::default()
             .with_owner(ProtoAddress::default().with_address(Vec::from(owner)))
             .with_object_type(coin_type.to_string())
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                LIST_OWNED_OBJECTS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         GetCoinsQuery::new(
             self.state_service_client(),

--- a/crates/iota-sdk-grpc-client/src/api/state/coins.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coins.rs
@@ -9,9 +9,10 @@
 //!
 //! # Read Mask
 //!
-//! The default read mask is [`LIST_OWNED_OBJECTS_READ_MASK`]; the `bcs` field
-//! is required for the proto `Object` → SDK `Coin` conversion, so callers
-//! supplying a custom mask must include it.
+//! The default read mask is
+//! [`LIST_OWNED_OBJECTS_READ_MASK`](iota_grpc_types::read_masks::LIST_OWNED_OBJECTS_READ_MASK);
+//! the `bcs` field is required for the proto `Object` → SDK `Coin` conversion,
+//! so callers supplying a custom mask must include it.
 
 use iota_grpc_types::{
     read_mask_fields::{IntoReadMask, OwnedObjectReadMask},

--- a/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
@@ -5,21 +5,25 @@
 //!
 //! # Read Mask
 //!
-//! Use [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
-//! constants with [`ReadMask::from`](crate::ReadMask::from) for field
-//! selection.
+//! Pass `None` for the default mask, or a
+//! [`DynamicFieldReadMask`](iota_grpc_types::read_mask_fields::DynamicFieldReadMask)
+//! built from a
+//! [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
+//! (or any slice/array/vec of fields).
 
-use iota_grpc_types::v1::{
-    dynamic_field::DynamicField,
-    state_service::{ListDynamicFieldsRequest, state_service_client::StateServiceClient},
+use iota_grpc_types::{
+    read_mask_fields::DynamicFieldReadMask,
+    v1::{
+        dynamic_field::DynamicField,
+        state_service::{ListDynamicFieldsRequest, state_service_client::StateServiceClient},
+    },
 };
 use iota_types::ObjectId;
 
 use crate::{
     Client, InterceptedChannel,
     api::{
-        LIST_DYNAMIC_FIELDS_READ_MASK, ReadMask, define_list_query, field_mask_with_default,
-        proto_object_id,
+        LIST_DYNAMIC_FIELDS_READ_MASK, define_list_query, field_mask_with_default, proto_object_id,
     },
 };
 
@@ -45,13 +49,19 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
+    /// The `read_mask` controls which fields the server returns; pass `None`
+    /// for the default field mask [`LIST_DYNAMIC_FIELDS_READ_MASK`], or a
+    /// [`DynamicFieldReadMask`](iota_grpc_types::read_mask_fields::DynamicFieldReadMask)
+    /// built from a
+    /// [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
+    /// or any slice/array/vec of fields.
+    ///
     /// # Parameters
     ///
     /// - `parent` - The object ID of the parent object.
     /// - `page_size` - Optional maximum number of fields per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Optional field mask. If `None`, uses
-    ///   [`LIST_DYNAMIC_FIELDS_READ_MASK`].
+    /// - `read_mask` - Optional field mask; `None` uses the default.
     ///
     /// # Examples
     ///
@@ -60,7 +70,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
     /// let page = client.list_dynamic_fields(parent, None, None, None).await?;
@@ -76,7 +86,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
     /// let all = client
@@ -92,14 +102,29 @@ impl Client {
     pub fn list_dynamic_fields(
         &self,
         parent: ObjectId,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+        read_mask: impl Into<Option<DynamicFieldReadMask>>,
+    ) -> ListDynamicFieldsQuery {
+        self.list_dynamic_fields_internal(
+            parent,
+            page_size.into(),
+            page_token.into(),
+            read_mask.into(),
+        )
+    }
+
+    fn list_dynamic_fields_internal(
+        &self,
+        parent: ObjectId,
         page_size: Option<u32>,
         page_token: Option<prost::bytes::Bytes>,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: Option<DynamicFieldReadMask>,
     ) -> ListDynamicFieldsQuery {
         let base_request = ListDynamicFieldsRequest::default()
             .with_parent(proto_object_id(parent))
             .with_read_mask(field_mask_with_default(
-                read_mask,
+                read_mask.as_ref().map(|m| m.as_str()),
                 LIST_DYNAMIC_FIELDS_READ_MASK,
             ));
 

--- a/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
@@ -5,9 +5,7 @@
 //!
 //! # Read Mask
 //!
-//! Pass `None` for the default mask, or a
-//! [`DynamicFieldReadMask`](iota_grpc_types::read_mask_fields::DynamicFieldReadMask)
-//! built from a
+//! Pass `None` for the default mask, or a [`DynamicFieldReadMask`] built from a
 //! [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
 //! (or any slice/array/vec of fields).
 

--- a/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
@@ -5,12 +5,13 @@
 //!
 //! # Read Mask
 //!
-//! Pass `None` for the default mask, or a [`DynamicFieldReadMask`] built from a
+//! Pass `DynamicFieldReadMask::default()` for the default mask, or a
+//! [`DynamicFieldReadMask`] built from a
 //! [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
 //! (or any slice/array/vec of fields).
 
 use iota_grpc_types::{
-    read_mask_fields::DynamicFieldReadMask,
+    read_mask_fields::{DynamicFieldReadMask, IntoReadMask},
     v1::{
         dynamic_field::DynamicField,
         state_service::{ListDynamicFieldsRequest, state_service_client::StateServiceClient},
@@ -20,9 +21,7 @@ use iota_types::ObjectId;
 
 use crate::{
     Client, InterceptedChannel,
-    api::{
-        LIST_DYNAMIC_FIELDS_READ_MASK, define_list_query, field_mask_with_default, proto_object_id,
-    },
+    api::{define_list_query, proto_object_id},
 };
 
 define_list_query! {
@@ -47,8 +46,8 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
-    /// The `read_mask` controls which fields the server returns; pass `None`
-    /// for the default field mask [`LIST_DYNAMIC_FIELDS_READ_MASK`], or a
+    /// The `read_mask` controls which fields the server returns; use
+    /// `DynamicFieldReadMask::default()` for the default field mask, or pass a
     /// [`DynamicFieldReadMask`](iota_grpc_types::read_mask_fields::DynamicFieldReadMask)
     /// built from a
     /// [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
@@ -59,19 +58,22 @@ impl Client {
     /// - `parent` - The object ID of the parent object.
     /// - `page_size` - Optional maximum number of fields per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Optional field mask; `None` uses the default.
+    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::DynamicFieldReadMask;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
-    /// let page = client.list_dynamic_fields(parent, None, None, None).await?;
+    /// let page = client
+    ///     .list_dynamic_fields(parent, None, None, DynamicFieldReadMask::default())
+    ///     .await?;
     /// for field in &page.body().items {
     ///     println!("Dynamic field: {:?}", field);
     /// }
@@ -82,13 +84,14 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::DynamicFieldReadMask;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
     /// let all = client
-    ///     .list_dynamic_fields(parent, Some(50), None, None)
+    ///     .list_dynamic_fields(parent, Some(50), None, DynamicFieldReadMask::default())
     ///     .collect(None)
     ///     .await?;
     /// for field in all.body() {
@@ -102,13 +105,13 @@ impl Client {
         parent: ObjectId,
         page_size: impl Into<Option<u32>>,
         page_token: impl Into<Option<prost::bytes::Bytes>>,
-        read_mask: impl Into<Option<DynamicFieldReadMask>>,
+        read_mask: impl IntoReadMask<DynamicFieldReadMask>,
     ) -> ListDynamicFieldsQuery {
         self.list_dynamic_fields_internal(
             parent,
             page_size.into(),
             page_token.into(),
-            read_mask.into(),
+            read_mask.into_read_mask(),
         )
     }
 
@@ -117,14 +120,11 @@ impl Client {
         parent: ObjectId,
         page_size: Option<u32>,
         page_token: Option<prost::bytes::Bytes>,
-        read_mask: Option<DynamicFieldReadMask>,
+        read_mask: DynamicFieldReadMask,
     ) -> ListDynamicFieldsQuery {
         let base_request = ListDynamicFieldsRequest::default()
             .with_parent(proto_object_id(parent))
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                LIST_DYNAMIC_FIELDS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         ListDynamicFieldsQuery::new(
             self.state_service_client(),

--- a/crates/iota-sdk-grpc-client/src/api/state/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/mod.rs
@@ -7,5 +7,6 @@
 //! and coin information.
 
 pub mod coin_info;
+pub mod coins;
 pub mod dynamic_fields;
 pub mod owned_objects;

--- a/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
@@ -5,10 +5,8 @@
 //!
 //! # Read Mask
 //!
-//! Pass `None` for the default mask, or an
-//! [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
-//! built from an
-//! [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
+//! Pass `None` for the default mask, or an [`OwnedObjectReadMask`] built from
+//! an [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
 //! (or any slice/array/vec of fields).
 
 use iota_grpc_types::{

--- a/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
@@ -5,20 +5,25 @@
 //!
 //! # Read Mask
 //!
-//! Use [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
-//! constants with [`ReadMask::from`](crate::ReadMask::from) for field
-//! selection.
+//! Pass `None` for the default mask, or an
+//! [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
+//! built from an
+//! [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
+//! (or any slice/array/vec of fields).
 
-use iota_grpc_types::v1::{
-    object::Object,
-    state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
-    types::Address as ProtoAddress,
+use iota_grpc_types::{
+    read_mask_fields::OwnedObjectReadMask,
+    v1::{
+        object::Object,
+        state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
+        types::Address as ProtoAddress,
+    },
 };
 use iota_types::{Address, StructTag};
 
 use crate::{
     Client, InterceptedChannel,
-    api::{LIST_OWNED_OBJECTS_READ_MASK, ReadMask, define_list_query, field_mask_with_default},
+    api::{LIST_OWNED_OBJECTS_READ_MASK, define_list_query, field_mask_with_default},
 };
 
 define_list_query! {
@@ -43,14 +48,20 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
+    /// The `read_mask` controls which fields the server returns; pass `None`
+    /// for the default field mask [`LIST_OWNED_OBJECTS_READ_MASK`], or an
+    /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
+    /// built from an
+    /// [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
+    /// or any slice/array/vec of fields.
+    ///
     /// # Parameters
     ///
     /// - `owner` - The address that owns the objects.
     /// - `object_type` - Optional type filter as a [`StructTag`].
     /// - `page_size` - Optional maximum number of objects per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Optional field mask. If `None`, uses
-    ///   [`LIST_OWNED_OBJECTS_READ_MASK`].
+    /// - `read_mask` - Optional field mask; `None` uses the default.
     ///
     /// # Examples
     ///
@@ -59,7 +70,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let page = client
@@ -67,12 +78,6 @@ impl Client {
     ///     .await?;
     /// for obj in &page.body().items {
     ///     println!("Owned object: {:?}", obj);
-    /// }
-    /// if let Some(token) = &page.body().next_page_token {
-    ///     // Fetch the next page using the token
-    ///     let next = client
-    ///         .list_owned_objects(owner, None, None, Some(token.clone()), None)
-    ///         .await?;
     /// }
     /// # Ok(())
     /// # }
@@ -83,7 +88,7 @@ impl Client {
     /// # use iota_sdk_grpc_client::Client;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = Client::new("http://localhost:9000")?;
+    /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let all = client
@@ -99,15 +104,32 @@ impl Client {
     pub fn list_owned_objects(
         &self,
         owner: Address,
+        object_type: impl Into<Option<StructTag>>,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+        read_mask: impl Into<Option<OwnedObjectReadMask>>,
+    ) -> ListOwnedObjectsQuery {
+        self.list_owned_objects_internal(
+            owner,
+            object_type.into(),
+            page_size.into(),
+            page_token.into(),
+            read_mask.into(),
+        )
+    }
+
+    fn list_owned_objects_internal(
+        &self,
+        owner: Address,
         object_type: Option<StructTag>,
         page_size: Option<u32>,
         page_token: Option<prost::bytes::Bytes>,
-        read_mask: Option<ReadMask<'_>>,
+        read_mask: Option<OwnedObjectReadMask>,
     ) -> ListOwnedObjectsQuery {
         let mut base_request = ListOwnedObjectsRequest::default()
             .with_owner(ProtoAddress::default().with_address(Vec::from(owner)))
             .with_read_mask(field_mask_with_default(
-                read_mask,
+                read_mask.as_ref().map(|m| m.as_str()),
                 LIST_OWNED_OBJECTS_READ_MASK,
             ));
 

--- a/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
@@ -5,12 +5,13 @@
 //!
 //! # Read Mask
 //!
-//! Pass `None` for the default mask, or an [`OwnedObjectReadMask`] built from
+//! Pass `OwnedObjectReadMask::default()` for the default mask, or an
+//! [`OwnedObjectReadMask`] built from
 //! an [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
 //! (or any slice/array/vec of fields).
 
 use iota_grpc_types::{
-    read_mask_fields::OwnedObjectReadMask,
+    read_mask_fields::{IntoReadMask, OwnedObjectReadMask},
     v1::{
         object::Object,
         state_service::{ListOwnedObjectsRequest, state_service_client::StateServiceClient},
@@ -19,10 +20,7 @@ use iota_grpc_types::{
 };
 use iota_types::{Address, StructTag};
 
-use crate::{
-    Client, InterceptedChannel,
-    api::{LIST_OWNED_OBJECTS_READ_MASK, define_list_query, field_mask_with_default},
-};
+use crate::{Client, InterceptedChannel, api::define_list_query};
 
 define_list_query! {
     /// Builder for listing objects owned by an address.
@@ -46,8 +44,8 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
-    /// The `read_mask` controls which fields the server returns; pass `None`
-    /// for the default field mask [`LIST_OWNED_OBJECTS_READ_MASK`], or an
+    /// The `read_mask` controls which fields the server returns; use
+    /// `OwnedObjectReadMask::default()` for the default field mask, or pass an
     /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
     /// built from an
     /// [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
@@ -59,20 +57,21 @@ impl Client {
     /// - `object_type` - Optional type filter as a [`StructTag`].
     /// - `page_size` - Optional maximum number of objects per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Optional field mask; `None` uses the default.
+    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let page = client
-    ///     .list_owned_objects(owner, None, None, None, None)
+    ///     .list_owned_objects(owner, None, None, None, OwnedObjectReadMask::default())
     ///     .await?;
     /// for obj in &page.body().items {
     ///     println!("Owned object: {:?}", obj);
@@ -84,13 +83,14 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let all = client
-    ///     .list_owned_objects(owner, None, Some(50), None, None)
+    ///     .list_owned_objects(owner, None, Some(50), None, OwnedObjectReadMask::default())
     ///     .collect(Some(500))
     ///     .await?;
     /// for obj in all.body() {
@@ -105,14 +105,14 @@ impl Client {
         object_type: impl Into<Option<StructTag>>,
         page_size: impl Into<Option<u32>>,
         page_token: impl Into<Option<prost::bytes::Bytes>>,
-        read_mask: impl Into<Option<OwnedObjectReadMask>>,
+        read_mask: impl IntoReadMask<OwnedObjectReadMask>,
     ) -> ListOwnedObjectsQuery {
         self.list_owned_objects_internal(
             owner,
             object_type.into(),
             page_size.into(),
             page_token.into(),
-            read_mask.into(),
+            read_mask.into_read_mask(),
         )
     }
 
@@ -122,14 +122,11 @@ impl Client {
         object_type: Option<StructTag>,
         page_size: Option<u32>,
         page_token: Option<prost::bytes::Bytes>,
-        read_mask: Option<OwnedObjectReadMask>,
+        read_mask: OwnedObjectReadMask,
     ) -> ListOwnedObjectsQuery {
         let mut base_request = ListOwnedObjectsRequest::default()
             .with_owner(ProtoAddress::default().with_address(Vec::from(owner)))
-            .with_read_mask(field_mask_with_default(
-                read_mask.as_ref().map(|m| m.as_str()),
-                LIST_OWNED_OBJECTS_READ_MASK,
-            ));
+            .with_read_mask(read_mask);
 
         if let Some(t) = object_type {
             base_request = base_request.with_object_type(t.to_string());

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -10,7 +10,10 @@
 //! # Example
 //!
 //! ```no_run
-//! use iota_sdk_grpc_client::Client;
+//! use iota_sdk_grpc_client::{
+//!     Client,
+//!     read_mask_fields::{ObjectReadMask, TransactionReadMask},
+//! };
 //! use iota_types::{ObjectId, TransactionDigest};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -18,14 +21,18 @@
 //!
 //! // Get a transaction with the default field mask.
 //! let digest: TransactionDigest = todo!();
-//! let txs = client.get_transactions([digest], None).await?;
+//! let txs = client
+//!     .get_transactions([digest], TransactionReadMask::default())
+//!     .await?;
 //! if let Some(tx) = txs.body().first() {
 //!     println!("Transaction digest: {:?}", tx.transaction()?.digest()?);
 //! }
 //!
 //! // Get an object with the default field mask.
 //! let object_id: ObjectId = "0x2".parse()?;
-//! let objects = client.get_objects([object_id], None).await?;
+//! let objects = client
+//!     .get_objects([object_id], ObjectReadMask::default())
+//!     .await?;
 //! if let Some(object) = objects.body().first() {
 //!     println!("Object version: {:?}", object.object_reference()?.version());
 //! }

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -14,18 +14,18 @@
 //! use iota_types::{ObjectId, TransactionDigest};
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = Client::new("http://localhost:9000")?;
+//! let client = Client::new_localnet()?;
 //!
-//! // Get a transaction with full details (None = use default field mask)
+//! // Get a transaction with the default field mask.
 //! let digest: TransactionDigest = todo!();
-//! let txs = client.get_transactions(&[digest], None).await?;
+//! let txs = client.get_transactions([digest], None).await?;
 //! if let Some(tx) = txs.body().first() {
 //!     println!("Transaction digest: {:?}", tx.transaction()?.digest()?);
 //! }
 //!
-//! // Get an object (None = use default field mask)
+//! // Get an object with the default field mask.
 //! let object_id: ObjectId = "0x2".parse()?;
-//! let objects = client.get_objects(&[(object_id, None)], None).await?;
+//! let objects = client.get_objects([object_id], None).await?;
 //! if let Some(object) = objects.body().first() {
 //!     println!("Object version: {:?}", object.object_reference()?.version());
 //! }
@@ -107,7 +107,10 @@ pub use api::{
 // Re-export query builders for convenience
 pub use api::{
     move_package::package_versions::ListPackageVersionsQuery,
-    state::{dynamic_fields::ListDynamicFieldsQuery, owned_objects::ListOwnedObjectsQuery},
+    state::{
+        coins::GetCoinsQuery, dynamic_fields::ListDynamicFieldsQuery,
+        owned_objects::ListOwnedObjectsQuery,
+    },
 };
 // Re-export typed read mask field enums
 pub use iota_grpc_types::read_mask_fields;

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -6,7 +6,10 @@
 use std::time::Duration;
 
 use iota_grpc_types::{
-    read_mask_fields::{EpochField, EpochReadMask, TransactionField, TransactionReadMask},
+    read_mask_fields::{
+        EpochField, EpochReadMask, ObjectReadMask, OwnedObjectReadMask, SimulateReadMask,
+        TransactionField, TransactionReadMask,
+    },
     v1::transaction_execution_service::SimulatedTransaction,
 };
 use iota_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx};
@@ -48,7 +51,7 @@ impl TransactionBuilderClient for Client {
         // Default read mask (`reference` + `bcs`) provides everything needed to
         // reconstruct the SDK object.
         match self
-            .get_objects_with_versions([(object_id, version.into())], None)
+            .get_objects_with_versions([(object_id, version.into())], ObjectReadMask::default())
             .await
         {
             Ok(envelope) => match envelope.into_inner().first() {
@@ -73,7 +76,7 @@ impl TransactionBuilderClient for Client {
                 struct_tag,
                 limit.map(saturating_usize_to_u32),
                 cursor.map(prost::bytes::Bytes::from),
-                None,
+                OwnedObjectReadMask::default(),
             )
             .await?
             .into_inner();
@@ -169,7 +172,9 @@ impl TransactionBuilderClient for Client {
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
         // Simulate with relaxed checks and read the gas used from the resulting
         // effects.
-        let simulated = self.simulate_transaction(tx.clone(), true, None).await?;
+        let simulated = self
+            .simulate_transaction(tx.clone(), true, SimulateReadMask::default())
+            .await?;
         let effects = simulated
             .into_inner()
             .executed_transaction()?
@@ -189,7 +194,7 @@ impl TransactionBuilderClient for Client {
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
         Ok(self
-            .simulate_transaction(tx.clone(), skip_checks, None)
+            .simulate_transaction(tx.clone(), skip_checks, SimulateReadMask::default())
             .await?
             .into_inner())
     }
@@ -207,7 +212,7 @@ impl TransactionBuilderClient for Client {
         };
         // The default execute read mask includes `effects`.
         let result = self
-            .execute_transaction(signed_transaction, None, None)
+            .execute_transaction(signed_transaction, None, TransactionReadMask::default())
             .await?
             .into_inner();
         let effects = result.effects()?.effects()?;

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -6,7 +6,8 @@
 use std::time::Duration;
 
 use iota_grpc_types::{
-    read_mask_fields::EpochField, v1::transaction_execution_service::SimulatedTransaction,
+    read_mask_fields::{EpochField, EpochReadMask, TransactionField, TransactionReadMask},
+    v1::transaction_execution_service::SimulatedTransaction,
 };
 use iota_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx};
 use iota_types::{
@@ -16,11 +17,7 @@ use iota_types::{
 
 use crate::{
     Client,
-    api::{
-        EXECUTED_TRANSACTION_CHECKPOINT, EXECUTED_TRANSACTION_SIGNATURES,
-        EXECUTED_TRANSACTION_TRANSACTION, Error, ReadMask, TRANSACTION_DIGEST,
-        TRANSACTION_EFFECTS_BCS, saturating_usize_to_u32,
-    },
+    api::{Error, saturating_usize_to_u32},
 };
 
 /// How long [`TransactionBuilderClient::wait_for_tx`] polls before giving up.
@@ -50,7 +47,10 @@ impl TransactionBuilderClient for Client {
     ) -> Result<Option<Object>, Self::Error> {
         // Default read mask (`reference` + `bcs`) provides everything needed to
         // reconstruct the SDK object.
-        match self.get_objects(&[(object_id, version.into())], None).await {
+        match self
+            .get_objects_with_versions([(object_id, version.into())], None)
+            .await
+        {
             Ok(envelope) => match envelope.into_inner().first() {
                 Some(obj) => Ok(Some(obj.object()?)),
                 None => Ok(None),
@@ -90,7 +90,7 @@ impl TransactionBuilderClient for Client {
         let epoch = self
             .get_epoch(
                 None,
-                Some(ReadMask::from(EpochField::PROTOCOL_CONFIG_ATTRIBUTES)),
+                EpochReadMask::from(EpochField::PROTOCOL_CONFIG_ATTRIBUTES),
             )
             .await?
             .into_inner();
@@ -108,11 +108,11 @@ impl TransactionBuilderClient for Client {
     ) -> Result<Option<SignedTransaction>, Self::Error> {
         match self
             .get_transactions(
-                &[digest],
-                Some(ReadMask::from(&[
-                    EXECUTED_TRANSACTION_TRANSACTION,
-                    EXECUTED_TRANSACTION_SIGNATURES,
-                ])),
+                [digest],
+                TransactionReadMask::from([
+                    TransactionField::TRANSACTION,
+                    TransactionField::SIGNATURES,
+                ]),
             )
             .await
         {
@@ -137,7 +137,10 @@ impl TransactionBuilderClient for Client {
         digest: TransactionDigest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
         match self
-            .get_transactions(&[digest], Some(ReadMask::from(TRANSACTION_EFFECTS_BCS)))
+            .get_transactions(
+                [digest],
+                TransactionReadMask::from(TransactionField::EFFECTS_BCS),
+            )
             .await
         {
             Ok(envelope) => match envelope.into_inner().into_iter().next() {
@@ -156,7 +159,7 @@ impl TransactionBuilderClient for Client {
         let epoch = self
             .get_epoch(
                 epoch.into(),
-                Some(ReadMask::from(EpochField::REFERENCE_GAS_PRICE)),
+                EpochReadMask::from(EpochField::REFERENCE_GAS_PRICE),
             )
             .await?
             .into_inner();
@@ -225,8 +228,10 @@ impl TransactionBuilderClient for Client {
         // transaction field confirms it is indexed on the node, while
         // `checkpoint` is only populated once it has been finalized.
         let mask = match wait_for {
-            WaitForTx::IndexedOnNode => ReadMask::from(TRANSACTION_DIGEST),
-            WaitForTx::Finalized => ReadMask::from(EXECUTED_TRANSACTION_CHECKPOINT),
+            WaitForTx::IndexedOnNode => {
+                TransactionReadMask::from(TransactionField::TRANSACTION_DIGEST)
+            }
+            WaitForTx::Finalized => TransactionReadMask::from(TransactionField::CHECKPOINT),
             _ => {
                 unimplemented!("a new WaitForTx enum variant was added and needs to be handled")
             }
@@ -236,7 +241,7 @@ impl TransactionBuilderClient for Client {
             let mut interval = tokio::time::interval(WAIT_FOR_TX_POLL_INTERVAL);
             loop {
                 interval.tick().await;
-                match self.get_transactions(&[digest], Some(mask.clone())).await {
+                match self.get_transactions([digest], mask.clone()).await {
                     Ok(envelope) => {
                         if let Some(tx) = envelope.into_inner().first() {
                             let ready = match wait_for {

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -6,22 +6,22 @@
 //! Each endpoint has a typed namespace (e.g. [`ObjectField`]) whose associated
 //! constants identify the fields the server can return, and a matching
 //! per-endpoint mask type (e.g. [`ObjectReadMask`]) that the client method
-//! accepts. Pass `None` for the endpoint's default mask, or build a mask from
-//! a single field, a slice, an array, or an owned vec of the matching kind —
-//! conversion happens automatically:
+//! accepts. Use the mask's `default()` for the endpoint's default mask, or
+//! build a mask from a single field, a slice, an array, or an owned vec of the
+//! matching kind — conversion happens automatically:
 //!
 //! ```ignore
 //! use iota_sdk_grpc_types::read_mask_fields::{ObjectField, ObjectReadMask};
 //!
 //! // Default mask.
-//! client.get_objects([id], None).await?;
+//! client.get_objects([id], ObjectReadMask::default()).await?;
 //!
 //! // A single field.
-//! client.get_objects([id], ObjectReadMask::from(ObjectField::BCS)).await?;
+//! client.get_objects([id], ObjectField::BCS).await?;
 //!
 //! // Multiple fields.
 //! client
-//!     .get_objects([id], ObjectReadMask::from([ObjectField::REFERENCE, ObjectField::BCS]))
+//!     .get_objects([id], [ObjectField::REFERENCE, ObjectField::BCS])
 //!     .await?;
 //! ```
 //!
@@ -29,7 +29,34 @@
 
 use std::borrow::Cow;
 
-use crate::field_mask_normalize;
+use crate::{
+    field_mask_normalize,
+    read_masks::{
+        GET_CHECKPOINT_READ_MASK, GET_EPOCH_READ_MASK, GET_OBJECTS_READ_MASK,
+        GET_SERVICE_INFO_READ_MASK, GET_TRANSACTIONS_READ_MASK, LIST_DYNAMIC_FIELDS_READ_MASK,
+        LIST_OWNED_OBJECTS_READ_MASK, SIMULATE_TRANSACTIONS_READ_MASK,
+    },
+};
+
+/// Conversion into an endpoint-scoped read mask.
+///
+/// This is the bound used by the client's `read_mask` parameters. It is
+/// implemented for everything convertible into the endpoint's mask type: the
+/// mask itself (e.g. `ObjectReadMask::default()` for the endpoint default), a
+/// field constant of the matching field namespace (e.g. [`ObjectField::BCS`]),
+/// arrays/slices/`Vec`s of such fields, and raw `&'static str`/`String` field
+/// paths.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid read mask for this endpoint",
+    label = "expected a value convertible into `{M}`",
+    note = "accepted: `{M}` itself (e.g. `{M}::default()` for the endpoint default), \
+            a field constant of the matching field namespace, an array/slice/`Vec` \
+            of such fields, or a `&str`/`String` field path"
+)]
+pub trait IntoReadMask<M> {
+    /// Convert `self` into the endpoint's read mask type.
+    fn into_read_mask(self) -> M;
+}
 
 // =============================================================================
 // Macros
@@ -96,7 +123,7 @@ macro_rules! define_field_paths {
 macro_rules! define_scoped_read_mask {
     (
         $(#[$attr:meta])*
-        pub struct $mask:ident from $field:ident;
+        pub struct $mask:ident from $field:ident default $default:expr;
     ) => {
         $(#[$attr])*
         #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -106,6 +133,12 @@ macro_rules! define_scoped_read_mask {
             /// The underlying comma-separated field mask string.
             pub fn as_str(&self) -> &str {
                 &self.0
+            }
+        }
+
+        impl Default for $mask {
+            fn default() -> Self {
+                Self::from($default)
             }
         }
 
@@ -173,6 +206,42 @@ macro_rules! define_scoped_read_mask {
                 Self::from(fields.as_slice())
             }
         }
+
+        impl From<$mask> for ::prost_types::FieldMask {
+            fn from(mask: $mask) -> Self {
+                use crate::field::FieldMaskUtil;
+                ::prost_types::FieldMask::from_str(mask.as_str())
+            }
+        }
+
+        // `IntoReadMask` impls are enumerated (instead of blanket-implemented
+        // over `Into<$mask>`) so that an invalid argument has *no* candidate
+        // impl, which lets the trait's `on_unimplemented` diagnostic fire.
+        impl_into_read_mask!($mask: $mask, $field, &$field, &[$field], Vec<$field>, &'static str, String);
+
+        impl<const N: usize> IntoReadMask<$mask> for [$field; N] {
+            fn into_read_mask(self) -> $mask {
+                self.into()
+            }
+        }
+
+        impl<const N: usize> IntoReadMask<$mask> for &[$field; N] {
+            fn into_read_mask(self) -> $mask {
+                self.into()
+            }
+        }
+    };
+}
+
+macro_rules! impl_into_read_mask {
+    ($mask:ident: $($ty:ty),* $(,)?) => {
+        $(
+            impl IntoReadMask<$mask> for $ty {
+                fn into_read_mask(self) -> $mask {
+                    self.into()
+                }
+            }
+        )*
     };
 }
 
@@ -200,7 +269,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `get_objects` / `get_objects_with_versions`.
-    pub struct ObjectReadMask from ObjectField;
+    pub struct ObjectReadMask from ObjectField default GET_OBJECTS_READ_MASK;
 }
 
 // =============================================================================
@@ -231,7 +300,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `list_owned_objects` and `get_coins`.
-    pub struct OwnedObjectReadMask from OwnedObjectField;
+    pub struct OwnedObjectReadMask from OwnedObjectField default LIST_OWNED_OBJECTS_READ_MASK;
 }
 
 // =============================================================================
@@ -312,7 +381,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `get_transactions` and `execute_transaction(s)`.
-    pub struct TransactionReadMask from TransactionField;
+    pub struct TransactionReadMask from TransactionField default GET_TRANSACTIONS_READ_MASK;
 }
 
 // =============================================================================
@@ -441,7 +510,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `get_service_info`.
-    pub struct ServiceInfoReadMask from ServiceInfoField;
+    pub struct ServiceInfoReadMask from ServiceInfoField default GET_SERVICE_INFO_READ_MASK;
 }
 
 // =============================================================================
@@ -519,7 +588,7 @@ impl EpochField {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `get_epoch`.
-    pub struct EpochReadMask from EpochField;
+    pub struct EpochReadMask from EpochField default GET_EPOCH_READ_MASK;
 }
 
 // =============================================================================
@@ -559,7 +628,7 @@ define_field_paths! {
 define_scoped_read_mask! {
     /// Scoped read mask for checkpoint queries (`get_checkpoint_*`,
     /// `stream_checkpoints`, `stream_checkpoints_filtered`).
-    pub struct CheckpointResponseReadMask from CheckpointResponseField;
+    pub struct CheckpointResponseReadMask from CheckpointResponseField default GET_CHECKPOINT_READ_MASK;
 }
 
 define_field_paths! {
@@ -624,7 +693,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `simulate_transaction(s)`.
-    pub struct SimulateReadMask from SimulateField;
+    pub struct SimulateReadMask from SimulateField default SIMULATE_TRANSACTIONS_READ_MASK;
 }
 
 // =============================================================================
@@ -659,7 +728,7 @@ define_field_paths! {
 
 define_scoped_read_mask! {
     /// Scoped read mask for `list_dynamic_fields`.
-    pub struct DynamicFieldReadMask from DynamicFieldField;
+    pub struct DynamicFieldReadMask from DynamicFieldField default LIST_DYNAMIC_FIELDS_READ_MASK;
 }
 
 // =============================================================================

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -1,305 +1,489 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Read mask field path constants for gRPC endpoints.
+//! Typed read mask field paths and per-endpoint mask types.
 //!
-//! Each endpoint has a dedicated namespace struct whose associated `&str`
-//! constants represent the fields that the server can return. Pass one or
-//! more constants to `ReadMask::from` (single field) or
-//! `ReadMask::from` with a `&[&str]` slice (multiple fields) in the
-//! `iota-sdk-grpc-client` crate.
+//! Each endpoint has a typed namespace (e.g. [`ObjectField`]) whose associated
+//! constants identify the fields the server can return, and a matching
+//! per-endpoint mask type (e.g. [`ObjectReadMask`]) that the client method
+//! accepts. Pass `None` for the endpoint's default mask, or build a mask from
+//! a single field, a slice, an array, or an owned vec of the matching kind —
+//! conversion happens automatically:
 //!
-//! # Example
+//! ```ignore
+//! use iota_sdk_grpc_types::read_mask_fields::{ObjectField, ObjectReadMask};
 //!
+//! // Default mask.
+//! client.get_objects([id], None).await?;
+//!
+//! // A single field.
+//! client.get_objects([id], ObjectReadMask::from(ObjectField::BCS)).await?;
+//!
+//! // Multiple fields.
+//! client
+//!     .get_objects([id], ObjectReadMask::from([ObjectField::REFERENCE, ObjectField::BCS]))
+//!     .await?;
 //! ```
-//! use iota_sdk_grpc_types::read_mask_fields::TransactionField;
 //!
-//! assert_eq!(TransactionField::EFFECTS, "effects");
-//! assert_eq!(TransactionField::EFFECTS_BCS, "effects.bcs");
-//! assert_eq!(TransactionField::CHECKPOINT, "checkpoint");
-//! ```
+//! Mixing the wrong field type with the wrong endpoint is a compile error.
+
+use std::borrow::Cow;
+
+use crate::field_mask_normalize;
+
+// =============================================================================
+// Macros
+// =============================================================================
+
+macro_rules! define_field_paths {
+    (
+        $(#[$attr:meta])*
+        pub struct $name:ident {
+            $(
+                $(#[$variant_attr:meta])*
+                $variant:ident = $path:expr
+            ),* $(,)?
+        }
+    ) => {
+        $(#[$attr])*
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        pub struct $name(Cow<'static, str>);
+
+        impl $name {
+            $(
+                $(#[$variant_attr])*
+                pub const $variant: Self = Self(Cow::Borrowed($path));
+            )*
+
+            /// Construct from a custom field path (escape hatch for paths not
+            /// covered by the named constants).
+            pub fn custom(path: impl Into<Cow<'static, str>>) -> Self {
+                Self(path.into())
+            }
+
+            /// The underlying field path string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+    };
+}
+
+macro_rules! define_scoped_read_mask {
+    (
+        $(#[$attr:meta])*
+        pub struct $mask:ident from $field:ident;
+    ) => {
+        $(#[$attr])*
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+        pub struct $mask(Cow<'static, str>);
+
+        impl $mask {
+            /// The underlying comma-separated field mask string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl AsRef<str> for $mask {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl From<$field> for $mask {
+            fn from(field: $field) -> Self {
+                Self(field.0)
+            }
+        }
+
+        impl From<&'static str> for $mask {
+            /// Escape hatch — build the mask from a raw comma-separated path
+            /// string (e.g. one of the pre-computed
+            /// [`read_masks`](crate::read_masks) constants). Prefer passing
+            /// typed field constants when possible.
+            fn from(s: &'static str) -> Self {
+                Self(Cow::Borrowed(s))
+            }
+        }
+
+        impl From<String> for $mask {
+            /// Escape hatch — build the mask from a raw comma-separated path
+            /// string. Prefer passing typed field constants when possible.
+            fn from(s: String) -> Self {
+                Self(Cow::Owned(s))
+            }
+        }
+
+        impl From<&$field> for $mask {
+            fn from(field: &$field) -> Self {
+                Self(field.0.clone())
+            }
+        }
+
+        impl From<&[$field]> for $mask {
+            fn from(fields: &[$field]) -> Self {
+                let joined = fields
+                    .iter()
+                    .map(|f| f.as_str())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                Self(Cow::Owned(field_mask_normalize(&joined)))
+            }
+        }
+
+        impl<const N: usize> From<&[$field; N]> for $mask {
+            fn from(fields: &[$field; N]) -> Self {
+                Self::from(fields.as_slice())
+            }
+        }
+
+        impl<const N: usize> From<[$field; N]> for $mask {
+            fn from(fields: [$field; N]) -> Self {
+                Self::from(fields.as_slice())
+            }
+        }
+
+        impl From<Vec<$field>> for $mask {
+            fn from(fields: Vec<$field>) -> Self {
+                Self::from(fields.as_slice())
+            }
+        }
+    };
+}
 
 // =============================================================================
 // get_objects
 // =============================================================================
 
-/// Field paths for `get_objects`.
-pub struct ObjectField;
+define_field_paths! {
+    /// Field paths for `get_objects`.
+    pub struct ObjectField {
+        /// Wildcard — request all object fields.
+        ALL = "*",
+        /// Object reference (object_id, version, digest).
+        REFERENCE = "reference",
+        /// The object ID.
+        REFERENCE_OBJECT_ID = "reference.object_id",
+        /// The object version.
+        REFERENCE_VERSION = "reference.version",
+        /// The object content digest.
+        REFERENCE_DIGEST = "reference.digest",
+        /// The full BCS-encoded object.
+        BCS = "bcs",
+    }
+}
 
-impl ObjectField {
-    /// Wildcard — request all object fields.
-    pub const ALL: &str = "*";
-    /// Object reference (object_id, version, digest).
-    pub const REFERENCE: &str = "reference";
-    /// The object ID.
-    pub const REFERENCE_OBJECT_ID: &str = "reference.object_id";
-    /// The object version.
-    pub const REFERENCE_VERSION: &str = "reference.version";
-    /// The object content digest.
-    pub const REFERENCE_DIGEST: &str = "reference.digest";
-    /// The full BCS-encoded object.
-    pub const BCS: &str = "bcs";
+define_scoped_read_mask! {
+    /// Scoped read mask for `get_objects` / `get_objects_with_versions`.
+    pub struct ObjectReadMask from ObjectField;
 }
 
 // =============================================================================
 // list_owned_objects
 // =============================================================================
 
-/// Field paths for `list_owned_objects`.
-pub struct OwnedObjectField;
+define_field_paths! {
+    /// Field paths for `list_owned_objects` and `get_coins`.
+    pub struct OwnedObjectField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// Object reference (object_id, version, digest).
+        REFERENCE = "reference",
+        /// The object ID.
+        REFERENCE_OBJECT_ID = "reference.object_id",
+        /// The object version.
+        REFERENCE_VERSION = "reference.version",
+        /// The object content digest.
+        REFERENCE_DIGEST = "reference.digest",
+        /// The Move type of the object.
+        OBJECT_TYPE = "object_type",
+        /// The object owner.
+        OWNER = "owner",
+        /// The full BCS-encoded object.
+        BCS = "bcs",
+    }
+}
 
-impl OwnedObjectField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// Object reference (object_id, version, digest).
-    pub const REFERENCE: &str = "reference";
-    /// The object ID.
-    pub const REFERENCE_OBJECT_ID: &str = "reference.object_id";
-    /// The object version.
-    pub const REFERENCE_VERSION: &str = "reference.version";
-    /// The object content digest.
-    pub const REFERENCE_DIGEST: &str = "reference.digest";
-    /// The Move type of the object.
-    pub const OBJECT_TYPE: &str = "object_type";
-    /// The object owner.
-    pub const OWNER: &str = "owner";
-    /// The full BCS-encoded object.
-    pub const BCS: &str = "bcs";
+define_scoped_read_mask! {
+    /// Scoped read mask for `list_owned_objects` and `get_coins`.
+    pub struct OwnedObjectReadMask from OwnedObjectField;
 }
 
 // =============================================================================
-// get_transactions / execute_transaction (unprefixed paths)
+// get_transactions / execute_transaction
 // =============================================================================
 
-/// Field paths for `get_transactions` / `execute_transaction`.
-pub struct TransactionField;
+define_field_paths! {
+    /// Field paths for `get_transactions` and `execute_transaction(s)`.
+    pub struct TransactionField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// Transaction data (all sub-fields).
+        TRANSACTION = "transaction",
+        /// The transaction digest.
+        TRANSACTION_DIGEST = "transaction.digest",
+        /// The full BCS-encoded transaction.
+        TRANSACTION_BCS = "transaction.bcs",
+        /// User signatures (all sub-fields).
+        SIGNATURES = "signatures",
+        /// The full BCS-encoded signatures.
+        SIGNATURES_BCS = "signatures.bcs",
+        /// Transaction effects (all sub-fields).
+        EFFECTS = "effects",
+        /// The effects digest.
+        EFFECTS_DIGEST = "effects.digest",
+        /// The full BCS-encoded effects.
+        EFFECTS_BCS = "effects.bcs",
+        /// Transaction events (all sub-fields).
+        EVENTS = "events",
+        /// The events digest.
+        EVENTS_DIGEST = "events.digest",
+        /// Individual events (all sub-fields).
+        EVENTS_EVENTS = "events.events",
+        /// Full BCS-encoded event.
+        EVENTS_EVENTS_BCS = "events.events.bcs",
+        /// The ID of the package that emitted the event.
+        EVENTS_EVENTS_PACKAGE_ID = "events.events.package_id",
+        /// The module that emitted the event.
+        EVENTS_EVENTS_MODULE = "events.events.module",
+        /// The sender that triggered the event.
+        EVENTS_EVENTS_SENDER = "events.events.sender",
+        /// The type of the event.
+        EVENTS_EVENTS_EVENT_TYPE = "events.events.event_type",
+        /// The full BCS-encoded contents of the event.
+        EVENTS_EVENTS_BCS_CONTENTS = "events.events.bcs_contents",
+        /// The JSON-encoded contents of the event.
+        EVENTS_EVENTS_JSON_CONTENTS = "events.events.json_contents",
+        /// Checkpoint sequence number that included the transaction.
+        CHECKPOINT = "checkpoint",
+        /// Timestamp of the checkpoint that included the transaction.
+        TIMESTAMP = "timestamp",
+        /// Input objects (all sub-fields).
+        INPUT_OBJECTS = "input_objects",
+        /// Input object reference (object_id, version, digest).
+        INPUT_OBJECTS_REFERENCE = "input_objects.reference",
+        /// Input object ID.
+        INPUT_OBJECTS_REFERENCE_OBJECT_ID = "input_objects.reference.object_id",
+        /// Input object version.
+        INPUT_OBJECTS_REFERENCE_VERSION = "input_objects.reference.version",
+        /// Input object digest.
+        INPUT_OBJECTS_REFERENCE_DIGEST = "input_objects.reference.digest",
+        /// The full BCS-encoded input object.
+        INPUT_OBJECTS_BCS = "input_objects.bcs",
+        /// Output objects (all sub-fields).
+        OUTPUT_OBJECTS = "output_objects",
+        /// Output object reference (object_id, version, digest).
+        OUTPUT_OBJECTS_REFERENCE = "output_objects.reference",
+        /// Output object ID.
+        OUTPUT_OBJECTS_REFERENCE_OBJECT_ID = "output_objects.reference.object_id",
+        /// Output object version.
+        OUTPUT_OBJECTS_REFERENCE_VERSION = "output_objects.reference.version",
+        /// Output object digest.
+        OUTPUT_OBJECTS_REFERENCE_DIGEST = "output_objects.reference.digest",
+        /// The full BCS-encoded output object.
+        OUTPUT_OBJECTS_BCS = "output_objects.bcs",
+    }
+}
 
-impl TransactionField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// Transaction data (all sub-fields).
-    pub const TRANSACTION: &str = "transaction";
-    /// The transaction digest.
-    pub const TRANSACTION_DIGEST: &str = "transaction.digest";
-    /// The full BCS-encoded transaction.
-    pub const TRANSACTION_BCS: &str = "transaction.bcs";
-    /// User signatures (all sub-fields).
-    pub const SIGNATURES: &str = "signatures";
-    /// The full BCS-encoded signatures.
-    pub const SIGNATURES_BCS: &str = "signatures.bcs";
-    /// Transaction effects (all sub-fields).
-    pub const EFFECTS: &str = "effects";
-    /// The effects digest.
-    pub const EFFECTS_DIGEST: &str = "effects.digest";
-    /// The full BCS-encoded effects.
-    pub const EFFECTS_BCS: &str = "effects.bcs";
-    /// Transaction events (all sub-fields).
-    pub const EVENTS: &str = "events";
-    /// The events digest.
-    pub const EVENTS_DIGEST: &str = "events.digest";
-    /// Individual events (all sub-fields).
-    pub const EVENTS_EVENTS: &str = "events.events";
-    /// Full BCS-encoded event.
-    pub const EVENTS_EVENTS_BCS: &str = "events.events.bcs";
-    /// The ID of the package that emitted the event.
-    pub const EVENTS_EVENTS_PACKAGE_ID: &str = "events.events.package_id";
-    /// The module that emitted the event.
-    pub const EVENTS_EVENTS_MODULE: &str = "events.events.module";
-    /// The sender that triggered the event.
-    pub const EVENTS_EVENTS_SENDER: &str = "events.events.sender";
-    /// The type of the event.
-    pub const EVENTS_EVENTS_EVENT_TYPE: &str = "events.events.event_type";
-    /// The full BCS-encoded contents of the event.
-    pub const EVENTS_EVENTS_BCS_CONTENTS: &str = "events.events.bcs_contents";
-    /// The JSON-encoded contents of the event.
-    pub const EVENTS_EVENTS_JSON_CONTENTS: &str = "events.events.json_contents";
-    /// Checkpoint sequence number that included the transaction.
-    pub const CHECKPOINT: &str = "checkpoint";
-    /// Timestamp of the checkpoint that included the transaction.
-    pub const TIMESTAMP: &str = "timestamp";
-    /// Input objects (all sub-fields).
-    pub const INPUT_OBJECTS: &str = "input_objects";
-    /// Input object reference (object_id, version, digest).
-    pub const INPUT_OBJECTS_REFERENCE: &str = "input_objects.reference";
-    /// Input object ID.
-    pub const INPUT_OBJECTS_REFERENCE_OBJECT_ID: &str = "input_objects.reference.object_id";
-    /// Input object version.
-    pub const INPUT_OBJECTS_REFERENCE_VERSION: &str = "input_objects.reference.version";
-    /// Input object digest.
-    pub const INPUT_OBJECTS_REFERENCE_DIGEST: &str = "input_objects.reference.digest";
-    /// The full BCS-encoded input object.
-    pub const INPUT_OBJECTS_BCS: &str = "input_objects.bcs";
-    /// Output objects (all sub-fields).
-    pub const OUTPUT_OBJECTS: &str = "output_objects";
-    /// Output object reference (object_id, version, digest).
-    pub const OUTPUT_OBJECTS_REFERENCE: &str = "output_objects.reference";
-    /// Output object ID.
-    pub const OUTPUT_OBJECTS_REFERENCE_OBJECT_ID: &str = "output_objects.reference.object_id";
-    /// Output object version.
-    pub const OUTPUT_OBJECTS_REFERENCE_VERSION: &str = "output_objects.reference.version";
-    /// Output object digest.
-    pub const OUTPUT_OBJECTS_REFERENCE_DIGEST: &str = "output_objects.reference.digest";
-    /// The full BCS-encoded output object.
-    pub const OUTPUT_OBJECTS_BCS: &str = "output_objects.bcs";
+define_scoped_read_mask! {
+    /// Scoped read mask for `get_transactions` and `execute_transaction(s)`.
+    pub struct TransactionReadMask from TransactionField;
 }
 
 // =============================================================================
 // Checkpoint transactions (prefixed with "transactions.")
 // =============================================================================
 
-/// Field paths for executed transactions within checkpoint responses.
-///
-/// All paths are prefixed with `transactions.`.
-pub struct CheckpointTransactionField;
-
-impl CheckpointTransactionField {
-    /// All transaction fields within the checkpoint.
-    pub const ALL: &str = "transactions";
-    /// Transaction data (all sub-fields).
-    pub const TRANSACTION: &str = "transactions.transaction";
-    /// The transaction digest.
-    pub const TRANSACTION_DIGEST: &str = "transactions.transaction.digest";
-    /// The full BCS-encoded transaction.
-    pub const TRANSACTION_BCS: &str = "transactions.transaction.bcs";
-    /// User signatures (all sub-fields).
-    pub const SIGNATURES: &str = "transactions.signatures";
-    /// The full BCS-encoded signatures.
-    pub const SIGNATURES_BCS: &str = "transactions.signatures.bcs";
-    /// Transaction effects (all sub-fields).
-    pub const EFFECTS: &str = "transactions.effects";
-    /// The effects digest.
-    pub const EFFECTS_DIGEST: &str = "transactions.effects.digest";
-    /// The full BCS-encoded effects.
-    pub const EFFECTS_BCS: &str = "transactions.effects.bcs";
-    /// Transaction events (all sub-fields).
-    pub const EVENTS: &str = "transactions.events";
-    /// The events digest.
-    pub const EVENTS_DIGEST: &str = "transactions.events.digest";
-    /// Checkpoint sequence number.
-    pub const CHECKPOINT: &str = "transactions.checkpoint";
-    /// Timestamp.
-    pub const TIMESTAMP: &str = "transactions.timestamp";
-    /// Input objects (all sub-fields).
-    pub const INPUT_OBJECTS: &str = "transactions.input_objects";
-    /// The full BCS-encoded input object.
-    pub const INPUT_OBJECTS_BCS: &str = "transactions.input_objects.bcs";
-    /// Output objects (all sub-fields).
-    pub const OUTPUT_OBJECTS: &str = "transactions.output_objects";
-    /// The full BCS-encoded output object.
-    pub const OUTPUT_OBJECTS_BCS: &str = "transactions.output_objects.bcs";
+define_field_paths! {
+    /// Field paths for executed transactions within checkpoint responses.
+    ///
+    /// All paths are prefixed with `transactions.`. Use these with
+    /// [`CheckpointResponseReadMask`].
+    pub struct CheckpointTransactionField {
+        /// All transaction fields within the checkpoint.
+        ALL = "transactions",
+        /// Transaction data (all sub-fields).
+        TRANSACTION = "transactions.transaction",
+        /// The transaction digest.
+        TRANSACTION_DIGEST = "transactions.transaction.digest",
+        /// The full BCS-encoded transaction.
+        TRANSACTION_BCS = "transactions.transaction.bcs",
+        /// User signatures (all sub-fields).
+        SIGNATURES = "transactions.signatures",
+        /// The full BCS-encoded signatures.
+        SIGNATURES_BCS = "transactions.signatures.bcs",
+        /// Transaction effects (all sub-fields).
+        EFFECTS = "transactions.effects",
+        /// The effects digest.
+        EFFECTS_DIGEST = "transactions.effects.digest",
+        /// The full BCS-encoded effects.
+        EFFECTS_BCS = "transactions.effects.bcs",
+        /// Transaction events (all sub-fields).
+        EVENTS = "transactions.events",
+        /// The events digest.
+        EVENTS_DIGEST = "transactions.events.digest",
+        /// Checkpoint sequence number.
+        CHECKPOINT = "transactions.checkpoint",
+        /// Timestamp.
+        TIMESTAMP = "transactions.timestamp",
+        /// Input objects (all sub-fields).
+        INPUT_OBJECTS = "transactions.input_objects",
+        /// The full BCS-encoded input object.
+        INPUT_OBJECTS_BCS = "transactions.input_objects.bcs",
+        /// Output objects (all sub-fields).
+        OUTPUT_OBJECTS = "transactions.output_objects",
+        /// The full BCS-encoded output object.
+        OUTPUT_OBJECTS_BCS = "transactions.output_objects.bcs",
+    }
 }
 
 // =============================================================================
 // Simulate executed transaction (prefixed with "executed_transaction.")
 // =============================================================================
 
-/// Field paths for the executed transaction within simulate responses.
-///
-/// All paths are prefixed with `executed_transaction.`.
-pub struct SimulateExecutedTransactionField;
-
-impl SimulateExecutedTransactionField {
-    /// All executed transaction fields.
-    pub const ALL: &str = "executed_transaction";
-    /// Transaction data (all sub-fields).
-    pub const TRANSACTION: &str = "executed_transaction.transaction";
-    /// The transaction digest.
-    pub const TRANSACTION_DIGEST: &str = "executed_transaction.transaction.digest";
-    /// The full BCS-encoded transaction.
-    pub const TRANSACTION_BCS: &str = "executed_transaction.transaction.bcs";
-    /// User signatures (all sub-fields).
-    pub const SIGNATURES: &str = "executed_transaction.signatures";
-    /// The full BCS-encoded signatures.
-    pub const SIGNATURES_BCS: &str = "executed_transaction.signatures.bcs";
-    /// Transaction effects (all sub-fields).
-    pub const EFFECTS: &str = "executed_transaction.effects";
-    /// The effects digest.
-    pub const EFFECTS_DIGEST: &str = "executed_transaction.effects.digest";
-    /// The full BCS-encoded effects.
-    pub const EFFECTS_BCS: &str = "executed_transaction.effects.bcs";
-    /// Transaction events (all sub-fields).
-    pub const EVENTS: &str = "executed_transaction.events";
-    /// The events digest.
-    pub const EVENTS_DIGEST: &str = "executed_transaction.events.digest";
-    /// Individual events — full BCS-encoded.
-    pub const EVENTS_EVENTS_BCS: &str = "executed_transaction.events.events.bcs";
-    /// Checkpoint sequence number.
-    pub const CHECKPOINT: &str = "executed_transaction.checkpoint";
-    /// Timestamp.
-    pub const TIMESTAMP: &str = "executed_transaction.timestamp";
-    /// Input objects (all sub-fields).
-    pub const INPUT_OBJECTS: &str = "executed_transaction.input_objects";
-    /// The full BCS-encoded input object.
-    pub const INPUT_OBJECTS_BCS: &str = "executed_transaction.input_objects.bcs";
-    /// Output objects (all sub-fields).
-    pub const OUTPUT_OBJECTS: &str = "executed_transaction.output_objects";
-    /// The full BCS-encoded output object.
-    pub const OUTPUT_OBJECTS_BCS: &str = "executed_transaction.output_objects.bcs";
+define_field_paths! {
+    /// Field paths for the executed transaction within simulate responses.
+    ///
+    /// All paths are prefixed with `executed_transaction.`. Use these with
+    /// [`SimulateReadMask`].
+    pub struct SimulateExecutedTransactionField {
+        /// All executed transaction fields.
+        ALL = "executed_transaction",
+        /// Transaction data (all sub-fields).
+        TRANSACTION = "executed_transaction.transaction",
+        /// The transaction digest.
+        TRANSACTION_DIGEST = "executed_transaction.transaction.digest",
+        /// The full BCS-encoded transaction.
+        TRANSACTION_BCS = "executed_transaction.transaction.bcs",
+        /// User signatures (all sub-fields).
+        SIGNATURES = "executed_transaction.signatures",
+        /// The full BCS-encoded signatures.
+        SIGNATURES_BCS = "executed_transaction.signatures.bcs",
+        /// Transaction effects (all sub-fields).
+        EFFECTS = "executed_transaction.effects",
+        /// The effects digest.
+        EFFECTS_DIGEST = "executed_transaction.effects.digest",
+        /// The full BCS-encoded effects.
+        EFFECTS_BCS = "executed_transaction.effects.bcs",
+        /// Transaction events (all sub-fields).
+        EVENTS = "executed_transaction.events",
+        /// The events digest.
+        EVENTS_DIGEST = "executed_transaction.events.digest",
+        /// Individual events — full BCS-encoded.
+        EVENTS_EVENTS_BCS = "executed_transaction.events.events.bcs",
+        /// Checkpoint sequence number.
+        CHECKPOINT = "executed_transaction.checkpoint",
+        /// Timestamp.
+        TIMESTAMP = "executed_transaction.timestamp",
+        /// Input objects (all sub-fields).
+        INPUT_OBJECTS = "executed_transaction.input_objects",
+        /// The full BCS-encoded input object.
+        INPUT_OBJECTS_BCS = "executed_transaction.input_objects.bcs",
+        /// Output objects (all sub-fields).
+        OUTPUT_OBJECTS = "executed_transaction.output_objects",
+        /// The full BCS-encoded output object.
+        OUTPUT_OBJECTS_BCS = "executed_transaction.output_objects.bcs",
+    }
 }
 
 // =============================================================================
 // get_service_info
 // =============================================================================
 
-/// Field paths for `get_service_info`.
-pub struct ServiceInfoField;
+define_field_paths! {
+    /// Field paths for `get_service_info`.
+    pub struct ServiceInfoField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// The chain ID (network identifier).
+        CHAIN_ID = "chain_id",
+        /// The chain identifier string.
+        CHAIN = "chain",
+        /// The current epoch.
+        EPOCH = "epoch",
+        /// Height of the last executed checkpoint.
+        EXECUTED_CHECKPOINT_HEIGHT = "executed_checkpoint_height",
+        /// Timestamp of the last executed checkpoint.
+        EXECUTED_CHECKPOINT_TIMESTAMP = "executed_checkpoint_timestamp",
+        /// Lowest available checkpoint for transaction/checkpoint data.
+        LOWEST_AVAILABLE_CHECKPOINT = "lowest_available_checkpoint",
+        /// Lowest available checkpoint for object data.
+        LOWEST_AVAILABLE_CHECKPOINT_OBJECTS = "lowest_available_checkpoint_objects",
+        /// The server version.
+        SERVER = "server",
+    }
+}
 
-impl ServiceInfoField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// The chain ID (network identifier).
-    pub const CHAIN_ID: &str = "chain_id";
-    /// The chain identifier string.
-    pub const CHAIN: &str = "chain";
-    /// The current epoch.
-    pub const EPOCH: &str = "epoch";
-    /// Height of the last executed checkpoint.
-    pub const EXECUTED_CHECKPOINT_HEIGHT: &str = "executed_checkpoint_height";
-    /// Timestamp of the last executed checkpoint.
-    pub const EXECUTED_CHECKPOINT_TIMESTAMP: &str = "executed_checkpoint_timestamp";
-    /// Lowest available checkpoint for transaction/checkpoint data.
-    pub const LOWEST_AVAILABLE_CHECKPOINT: &str = "lowest_available_checkpoint";
-    /// Lowest available checkpoint for object data.
-    pub const LOWEST_AVAILABLE_CHECKPOINT_OBJECTS: &str = "lowest_available_checkpoint_objects";
-    /// The server version.
-    pub const SERVER: &str = "server";
+define_scoped_read_mask! {
+    /// Scoped read mask for `get_service_info`.
+    pub struct ServiceInfoReadMask from ServiceInfoField;
 }
 
 // =============================================================================
 // get_epoch
 // =============================================================================
 
-/// Field paths for `get_epoch`.
-pub struct EpochField;
+define_field_paths! {
+    /// Field paths for `get_epoch`.
+    ///
+    /// Use [`EpochField::feature_flag`] and [`EpochField::attribute`] for
+    /// individual protocol-config map entries.
+    pub struct EpochField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// The epoch number.
+        EPOCH = "epoch",
+        /// The validator committee for this epoch.
+        COMMITTEE = "committee",
+        /// The BCS-encoded system state.
+        BCS_SYSTEM_STATE = "bcs_system_state",
+        /// The first checkpoint in the epoch.
+        FIRST_CHECKPOINT = "first_checkpoint",
+        /// The last checkpoint in the epoch.
+        LAST_CHECKPOINT = "last_checkpoint",
+        /// The start timestamp of the epoch.
+        START = "start",
+        /// The end timestamp of the epoch.
+        END = "end",
+        /// The reference gas price during the epoch (in NANOS).
+        REFERENCE_GAS_PRICE = "reference_gas_price",
+        /// All protocol configuration fields.
+        PROTOCOL_CONFIG = "protocol_config",
+        /// The protocol version.
+        PROTOCOL_CONFIG_PROTOCOL_VERSION = "protocol_config.protocol_version",
+        /// All feature flags.
+        PROTOCOL_CONFIG_FEATURE_FLAGS = "protocol_config.feature_flags",
+        /// All protocol attributes.
+        PROTOCOL_CONFIG_ATTRIBUTES = "protocol_config.attributes",
+    }
+}
 
 impl EpochField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// The epoch number.
-    pub const EPOCH: &str = "epoch";
-    /// The validator committee for this epoch.
-    pub const COMMITTEE: &str = "committee";
-    /// The BCS-encoded system state.
-    pub const BCS_SYSTEM_STATE: &str = "bcs_system_state";
-    /// The first checkpoint in the epoch.
-    pub const FIRST_CHECKPOINT: &str = "first_checkpoint";
-    /// The last checkpoint in the epoch.
-    pub const LAST_CHECKPOINT: &str = "last_checkpoint";
-    /// The start timestamp of the epoch.
-    pub const START: &str = "start";
-    /// The end timestamp of the epoch.
-    pub const END: &str = "end";
-    /// The reference gas price during the epoch (in NANOS).
-    pub const REFERENCE_GAS_PRICE: &str = "reference_gas_price";
-    /// All protocol configuration fields.
-    pub const PROTOCOL_CONFIG: &str = "protocol_config";
-    /// The protocol version.
-    pub const PROTOCOL_CONFIG_PROTOCOL_VERSION: &str = "protocol_config.protocol_version";
-    /// All feature flags.
-    pub const PROTOCOL_CONFIG_FEATURE_FLAGS: &str = "protocol_config.feature_flags";
-    /// All protocol attributes.
-    pub const PROTOCOL_CONFIG_ATTRIBUTES: &str = "protocol_config.attributes";
-
     /// Field path for a specific feature flag by key.
     ///
     /// # Example
@@ -308,12 +492,12 @@ impl EpochField {
     /// use iota_sdk_grpc_types::read_mask_fields::EpochField;
     ///
     /// assert_eq!(
-    ///     EpochField::feature_flag("enable_vdf"),
+    ///     EpochField::feature_flag("enable_vdf").as_str(),
     ///     "protocol_config.feature_flags.enable_vdf",
     /// );
     /// ```
-    pub fn feature_flag(key: &str) -> String {
-        format!("protocol_config.feature_flags.{key}")
+    pub fn feature_flag(key: &str) -> Self {
+        Self::custom(format!("protocol_config.feature_flags.{key}"))
     }
 
     /// Field path for a specific protocol attribute by key.
@@ -324,136 +508,158 @@ impl EpochField {
     /// use iota_sdk_grpc_types::read_mask_fields::EpochField;
     ///
     /// assert_eq!(
-    ///     EpochField::attribute("max_tx_gas"),
+    ///     EpochField::attribute("max_tx_gas").as_str(),
     ///     "protocol_config.attributes.max_tx_gas",
     /// );
     /// ```
-    pub fn attribute(key: &str) -> String {
-        format!("protocol_config.attributes.{key}")
+    pub fn attribute(key: &str) -> Self {
+        Self::custom(format!("protocol_config.attributes.{key}"))
     }
+}
+
+define_scoped_read_mask! {
+    /// Scoped read mask for `get_epoch`.
+    pub struct EpochReadMask from EpochField;
 }
 
 // =============================================================================
 // Checkpoint responses (get_checkpoint_*, stream_checkpoints*)
 // =============================================================================
 
-/// Field paths for checkpoint responses.
-pub struct CheckpointResponseField;
-
-impl CheckpointResponseField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// All checkpoint data fields.
-    pub const CHECKPOINT: &str = "checkpoint";
-    /// The checkpoint sequence number.
-    pub const CHECKPOINT_SEQUENCE_NUMBER: &str = "checkpoint.sequence_number";
-    /// Checkpoint summary (all sub-fields).
-    pub const CHECKPOINT_SUMMARY: &str = "checkpoint.summary";
-    /// The checkpoint summary digest.
-    pub const CHECKPOINT_SUMMARY_DIGEST: &str = "checkpoint.summary.digest";
-    /// The full BCS-encoded checkpoint summary.
-    pub const CHECKPOINT_SUMMARY_BCS: &str = "checkpoint.summary.bcs";
-    /// Checkpoint contents (all sub-fields).
-    pub const CHECKPOINT_CONTENTS: &str = "checkpoint.contents";
-    /// The checkpoint contents digest.
-    pub const CHECKPOINT_CONTENTS_DIGEST: &str = "checkpoint.contents.digest";
-    /// The full BCS-encoded checkpoint contents.
-    pub const CHECKPOINT_CONTENTS_BCS: &str = "checkpoint.contents.bcs";
-    /// The validator aggregated signature.
-    pub const CHECKPOINT_SIGNATURE: &str = "checkpoint.signature";
-    /// All transactions in the checkpoint.
-    pub const TRANSACTIONS: &str = "transactions";
-    /// All events in the checkpoint.
-    pub const EVENTS: &str = "events";
+define_field_paths! {
+    /// Field paths for checkpoint responses.
+    pub struct CheckpointResponseField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// All checkpoint data fields.
+        CHECKPOINT = "checkpoint",
+        /// The checkpoint sequence number.
+        CHECKPOINT_SEQUENCE_NUMBER = "checkpoint.sequence_number",
+        /// Checkpoint summary (all sub-fields).
+        CHECKPOINT_SUMMARY = "checkpoint.summary",
+        /// The checkpoint summary digest.
+        CHECKPOINT_SUMMARY_DIGEST = "checkpoint.summary.digest",
+        /// The full BCS-encoded checkpoint summary.
+        CHECKPOINT_SUMMARY_BCS = "checkpoint.summary.bcs",
+        /// Checkpoint contents (all sub-fields).
+        CHECKPOINT_CONTENTS = "checkpoint.contents",
+        /// The checkpoint contents digest.
+        CHECKPOINT_CONTENTS_DIGEST = "checkpoint.contents.digest",
+        /// The full BCS-encoded checkpoint contents.
+        CHECKPOINT_CONTENTS_BCS = "checkpoint.contents.bcs",
+        /// The validator aggregated signature.
+        CHECKPOINT_SIGNATURE = "checkpoint.signature",
+        /// All transactions in the checkpoint.
+        TRANSACTIONS = "transactions",
+        /// All events in the checkpoint.
+        EVENTS = "events",
+    }
 }
 
-/// Field paths for checkpoint-level events.
-pub struct CheckpointEventField;
+define_scoped_read_mask! {
+    /// Scoped read mask for checkpoint queries (`get_checkpoint_*`,
+    /// `stream_checkpoints`, `stream_checkpoints_filtered`).
+    pub struct CheckpointResponseReadMask from CheckpointResponseField;
+}
 
-impl CheckpointEventField {
-    /// All event fields.
-    pub const ALL: &str = "events";
-    /// Full BCS-encoded event.
-    pub const BCS: &str = "events.bcs";
-    /// The ID of the package that emitted the event.
-    pub const PACKAGE_ID: &str = "events.package_id";
-    /// The module that emitted the event.
-    pub const MODULE: &str = "events.module";
-    /// The sender that triggered the event.
-    pub const SENDER: &str = "events.sender";
-    /// The type of the event.
-    pub const EVENT_TYPE: &str = "events.event_type";
-    /// The full BCS-encoded contents of the event.
-    pub const BCS_CONTENTS: &str = "events.bcs_contents";
-    /// The JSON-encoded contents of the event.
-    pub const JSON_CONTENTS: &str = "events.json_contents";
+define_field_paths! {
+    /// Field paths for checkpoint-level events.
+    ///
+    /// All paths are prefixed with `events.`. Use these with
+    /// [`CheckpointResponseReadMask`].
+    pub struct CheckpointEventField {
+        /// All event fields.
+        ALL = "events",
+        /// Full BCS-encoded event.
+        BCS = "events.bcs",
+        /// The ID of the package that emitted the event.
+        PACKAGE_ID = "events.package_id",
+        /// The module that emitted the event.
+        MODULE = "events.module",
+        /// The sender that triggered the event.
+        SENDER = "events.sender",
+        /// The type of the event.
+        EVENT_TYPE = "events.event_type",
+        /// The full BCS-encoded contents of the event.
+        BCS_CONTENTS = "events.bcs_contents",
+        /// The JSON-encoded contents of the event.
+        JSON_CONTENTS = "events.json_contents",
+    }
 }
 
 // =============================================================================
 // simulate_transaction
 // =============================================================================
 
-/// Field paths for `simulate_transaction`.
-pub struct SimulateField;
+define_field_paths! {
+    /// Field paths for `simulate_transaction(s)`.
+    pub struct SimulateField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// The simulated executed transaction (all sub-fields).
+        EXECUTED_TRANSACTION = "executed_transaction",
+        /// The suggested gas price (in NANOS).
+        SUGGESTED_GAS_PRICE = "suggested_gas_price",
+        /// Execution result (all sub-fields).
+        EXECUTION_RESULT = "execution_result",
+        /// Per-command results (on success, all sub-fields).
+        EXECUTION_RESULT_COMMAND_RESULTS = "execution_result.command_results",
+        /// Objects mutated by reference.
+        EXECUTION_RESULT_COMMAND_RESULTS_MUTATED_BY_REF =
+            "execution_result.command_results.mutated_by_ref",
+        /// Return values from the command.
+        EXECUTION_RESULT_COMMAND_RESULTS_RETURN_VALUES =
+            "execution_result.command_results.return_values",
+        /// Execution error details (on failure, all sub-fields).
+        EXECUTION_RESULT_EXECUTION_ERROR = "execution_result.execution_error",
+        /// The BCS-encoded error kind.
+        EXECUTION_RESULT_EXECUTION_ERROR_BCS_KIND = "execution_result.execution_error.bcs_kind",
+        /// The error source description.
+        EXECUTION_RESULT_EXECUTION_ERROR_SOURCE = "execution_result.execution_error.source",
+        /// The index of the command that failed.
+        EXECUTION_RESULT_EXECUTION_ERROR_COMMAND_INDEX =
+            "execution_result.execution_error.command_index",
+    }
+}
 
-impl SimulateField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// The simulated executed transaction (all sub-fields).
-    pub const EXECUTED_TRANSACTION: &str = "executed_transaction";
-    /// The suggested gas price (in NANOS).
-    pub const SUGGESTED_GAS_PRICE: &str = "suggested_gas_price";
-    /// Execution result (all sub-fields).
-    pub const EXECUTION_RESULT: &str = "execution_result";
-    /// Per-command results (on success, all sub-fields).
-    pub const EXECUTION_RESULT_COMMAND_RESULTS: &str = "execution_result.command_results";
-    /// Objects mutated by reference.
-    pub const EXECUTION_RESULT_COMMAND_RESULTS_MUTATED_BY_REF: &str =
-        "execution_result.command_results.mutated_by_ref";
-    /// Return values from the command.
-    pub const EXECUTION_RESULT_COMMAND_RESULTS_RETURN_VALUES: &str =
-        "execution_result.command_results.return_values";
-    /// Execution error details (on failure, all sub-fields).
-    pub const EXECUTION_RESULT_EXECUTION_ERROR: &str = "execution_result.execution_error";
-    /// The BCS-encoded error kind.
-    pub const EXECUTION_RESULT_EXECUTION_ERROR_BCS_KIND: &str =
-        "execution_result.execution_error.bcs_kind";
-    /// The error source description.
-    pub const EXECUTION_RESULT_EXECUTION_ERROR_SOURCE: &str =
-        "execution_result.execution_error.source";
-    /// The index of the command that failed.
-    pub const EXECUTION_RESULT_EXECUTION_ERROR_COMMAND_INDEX: &str =
-        "execution_result.execution_error.command_index";
+define_scoped_read_mask! {
+    /// Scoped read mask for `simulate_transaction(s)`.
+    pub struct SimulateReadMask from SimulateField;
 }
 
 // =============================================================================
 // list_dynamic_fields
 // =============================================================================
 
-/// Field paths for `list_dynamic_fields`.
-pub struct DynamicFieldField;
+define_field_paths! {
+    /// Field paths for `list_dynamic_fields`.
+    pub struct DynamicFieldField {
+        /// Wildcard — request all fields.
+        ALL = "*",
+        /// The kind of dynamic field (field or object).
+        KIND = "kind",
+        /// The parent object ID.
+        PARENT = "parent",
+        /// The field object ID.
+        FIELD_ID = "field_id",
+        /// The child object ID (for dynamic object fields).
+        CHILD_ID = "child_id",
+        /// BCS-encoded field name.
+        NAME = "name",
+        /// BCS-encoded field value.
+        VALUE = "value",
+        /// The Move type of the value.
+        VALUE_TYPE = "value_type",
+        /// The full field object (sub-fields match `get_objects`).
+        FIELD_OBJECT = "field_object",
+        /// The full child object (sub-fields match `get_objects`).
+        CHILD_OBJECT = "child_object",
+    }
+}
 
-impl DynamicFieldField {
-    /// Wildcard — request all fields.
-    pub const ALL: &str = "*";
-    /// The kind of dynamic field (field or object).
-    pub const KIND: &str = "kind";
-    /// The parent object ID.
-    pub const PARENT: &str = "parent";
-    /// The field object ID.
-    pub const FIELD_ID: &str = "field_id";
-    /// The child object ID (for dynamic object fields).
-    pub const CHILD_ID: &str = "child_id";
-    /// BCS-encoded field name.
-    pub const NAME: &str = "name";
-    /// BCS-encoded field value.
-    pub const VALUE: &str = "value";
-    /// The Move type of the value.
-    pub const VALUE_TYPE: &str = "value_type";
-    /// The full field object (sub-fields match `get_objects`).
-    pub const FIELD_OBJECT: &str = "field_object";
-    /// The full child object (sub-fields match `get_objects`).
-    pub const CHILD_OBJECT: &str = "child_object";
+define_scoped_read_mask! {
+    /// Scoped read mask for `list_dynamic_fields`.
+    pub struct DynamicFieldReadMask from DynamicFieldField;
 }
 
 // =============================================================================
@@ -466,33 +672,48 @@ mod tests {
 
     #[test]
     fn object_field_paths() {
-        assert_eq!(ObjectField::ALL, "*");
-        assert_eq!(ObjectField::REFERENCE, "reference");
-        assert_eq!(ObjectField::REFERENCE_OBJECT_ID, "reference.object_id");
-        assert_eq!(ObjectField::BCS, "bcs");
+        assert_eq!(ObjectField::ALL.as_str(), "*");
+        assert_eq!(ObjectField::REFERENCE.as_str(), "reference");
+        assert_eq!(
+            ObjectField::REFERENCE_OBJECT_ID.as_str(),
+            "reference.object_id"
+        );
+        assert_eq!(ObjectField::BCS.as_str(), "bcs");
     }
 
     #[test]
     fn transaction_field_paths() {
-        assert_eq!(TransactionField::ALL, "*");
-        assert_eq!(TransactionField::TRANSACTION_DIGEST, "transaction.digest");
-        assert_eq!(TransactionField::EFFECTS_BCS, "effects.bcs");
-        assert_eq!(TransactionField::EVENTS, "events");
-        assert_eq!(TransactionField::EVENTS_EVENTS_BCS, "events.events.bcs");
-        assert_eq!(TransactionField::CHECKPOINT, "checkpoint");
-        assert_eq!(TransactionField::INPUT_OBJECTS_BCS, "input_objects.bcs");
-        assert_eq!(TransactionField::OUTPUT_OBJECTS_BCS, "output_objects.bcs");
+        assert_eq!(TransactionField::ALL.as_str(), "*");
+        assert_eq!(
+            TransactionField::TRANSACTION_DIGEST.as_str(),
+            "transaction.digest"
+        );
+        assert_eq!(TransactionField::EFFECTS_BCS.as_str(), "effects.bcs");
+        assert_eq!(TransactionField::EVENTS.as_str(), "events");
+        assert_eq!(
+            TransactionField::EVENTS_EVENTS_BCS.as_str(),
+            "events.events.bcs"
+        );
+        assert_eq!(TransactionField::CHECKPOINT.as_str(), "checkpoint");
+        assert_eq!(
+            TransactionField::INPUT_OBJECTS_BCS.as_str(),
+            "input_objects.bcs"
+        );
+        assert_eq!(
+            TransactionField::OUTPUT_OBJECTS_BCS.as_str(),
+            "output_objects.bcs"
+        );
     }
 
     #[test]
     fn checkpoint_transaction_field_paths() {
-        assert_eq!(CheckpointTransactionField::ALL, "transactions");
+        assert_eq!(CheckpointTransactionField::ALL.as_str(), "transactions");
         assert_eq!(
-            CheckpointTransactionField::TRANSACTION_DIGEST,
+            CheckpointTransactionField::TRANSACTION_DIGEST.as_str(),
             "transactions.transaction.digest"
         );
         assert_eq!(
-            CheckpointTransactionField::EFFECTS_BCS,
+            CheckpointTransactionField::EFFECTS_BCS.as_str(),
             "transactions.effects.bcs"
         );
     }
@@ -500,37 +721,40 @@ mod tests {
     #[test]
     fn simulate_executed_transaction_field_paths() {
         assert_eq!(
-            SimulateExecutedTransactionField::ALL,
+            SimulateExecutedTransactionField::ALL.as_str(),
             "executed_transaction"
         );
         assert_eq!(
-            SimulateExecutedTransactionField::EFFECTS,
+            SimulateExecutedTransactionField::EFFECTS.as_str(),
             "executed_transaction.effects"
         );
         assert_eq!(
-            SimulateExecutedTransactionField::EFFECTS_BCS,
+            SimulateExecutedTransactionField::EFFECTS_BCS.as_str(),
             "executed_transaction.effects.bcs"
         );
     }
 
     #[test]
     fn service_info_field_paths() {
-        assert_eq!(ServiceInfoField::ALL, "*");
-        assert_eq!(ServiceInfoField::CHAIN_ID, "chain_id");
-        assert_eq!(ServiceInfoField::SERVER, "server");
+        assert_eq!(ServiceInfoField::ALL.as_str(), "*");
+        assert_eq!(ServiceInfoField::CHAIN_ID.as_str(), "chain_id");
+        assert_eq!(ServiceInfoField::SERVER.as_str(), "server");
     }
 
     #[test]
     fn epoch_field_paths() {
-        assert_eq!(EpochField::ALL, "*");
-        assert_eq!(EpochField::EPOCH, "epoch");
-        assert_eq!(EpochField::REFERENCE_GAS_PRICE, "reference_gas_price");
+        assert_eq!(EpochField::ALL.as_str(), "*");
+        assert_eq!(EpochField::EPOCH.as_str(), "epoch");
         assert_eq!(
-            EpochField::PROTOCOL_CONFIG_PROTOCOL_VERSION,
+            EpochField::REFERENCE_GAS_PRICE.as_str(),
+            "reference_gas_price"
+        );
+        assert_eq!(
+            EpochField::PROTOCOL_CONFIG_PROTOCOL_VERSION.as_str(),
             "protocol_config.protocol_version"
         );
         assert_eq!(
-            EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS,
+            EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS.as_str(),
             "protocol_config.feature_flags"
         );
     }
@@ -538,53 +762,87 @@ mod tests {
     #[test]
     fn epoch_dynamic_paths() {
         assert_eq!(
-            EpochField::feature_flag("enable_vdf"),
+            EpochField::feature_flag("enable_vdf").as_str(),
             "protocol_config.feature_flags.enable_vdf"
         );
         assert_eq!(
-            EpochField::attribute("max_tx_gas"),
+            EpochField::attribute("max_tx_gas").as_str(),
             "protocol_config.attributes.max_tx_gas"
         );
     }
 
     #[test]
     fn checkpoint_response_field_paths() {
-        assert_eq!(CheckpointResponseField::ALL, "*");
-        assert_eq!(CheckpointResponseField::CHECKPOINT, "checkpoint");
+        assert_eq!(CheckpointResponseField::ALL.as_str(), "*");
+        assert_eq!(CheckpointResponseField::CHECKPOINT.as_str(), "checkpoint");
         assert_eq!(
-            CheckpointResponseField::CHECKPOINT_SUMMARY_BCS,
+            CheckpointResponseField::CHECKPOINT_SUMMARY_BCS.as_str(),
             "checkpoint.summary.bcs"
         );
-        assert_eq!(CheckpointResponseField::TRANSACTIONS, "transactions");
-        assert_eq!(CheckpointResponseField::EVENTS, "events");
+        assert_eq!(
+            CheckpointResponseField::TRANSACTIONS.as_str(),
+            "transactions"
+        );
+        assert_eq!(CheckpointResponseField::EVENTS.as_str(), "events");
     }
 
     #[test]
     fn checkpoint_event_field_paths() {
-        assert_eq!(CheckpointEventField::ALL, "events");
-        assert_eq!(CheckpointEventField::BCS, "events.bcs");
-        assert_eq!(CheckpointEventField::PACKAGE_ID, "events.package_id");
+        assert_eq!(CheckpointEventField::ALL.as_str(), "events");
+        assert_eq!(CheckpointEventField::BCS.as_str(), "events.bcs");
+        assert_eq!(
+            CheckpointEventField::PACKAGE_ID.as_str(),
+            "events.package_id"
+        );
     }
 
     #[test]
     fn simulate_field_paths() {
-        assert_eq!(SimulateField::ALL, "*");
-        assert_eq!(SimulateField::SUGGESTED_GAS_PRICE, "suggested_gas_price");
+        assert_eq!(SimulateField::ALL.as_str(), "*");
         assert_eq!(
-            SimulateField::EXECUTION_RESULT_COMMAND_RESULTS,
+            SimulateField::SUGGESTED_GAS_PRICE.as_str(),
+            "suggested_gas_price"
+        );
+        assert_eq!(
+            SimulateField::EXECUTION_RESULT_COMMAND_RESULTS.as_str(),
             "execution_result.command_results"
         );
         assert_eq!(
-            SimulateField::EXECUTION_RESULT_EXECUTION_ERROR_BCS_KIND,
+            SimulateField::EXECUTION_RESULT_EXECUTION_ERROR_BCS_KIND.as_str(),
             "execution_result.execution_error.bcs_kind"
         );
     }
 
     #[test]
     fn dynamic_field_field_paths() {
-        assert_eq!(DynamicFieldField::ALL, "*");
-        assert_eq!(DynamicFieldField::KIND, "kind");
-        assert_eq!(DynamicFieldField::NAME, "name");
-        assert_eq!(DynamicFieldField::CHILD_OBJECT, "child_object");
+        assert_eq!(DynamicFieldField::ALL.as_str(), "*");
+        assert_eq!(DynamicFieldField::KIND.as_str(), "kind");
+        assert_eq!(DynamicFieldField::NAME.as_str(), "name");
+        assert_eq!(DynamicFieldField::CHILD_OBJECT.as_str(), "child_object");
+    }
+
+    #[test]
+    fn scoped_read_mask_from_single_field() {
+        let mask: ObjectReadMask = ObjectField::BCS.into();
+        assert_eq!(mask.as_str(), "bcs");
+    }
+
+    #[test]
+    fn scoped_read_mask_from_slice_normalizes() {
+        // BCS subsumes nothing, REFERENCE subsumes REFERENCE_OBJECT_ID
+        let mask: ObjectReadMask = [
+            ObjectField::REFERENCE,
+            ObjectField::REFERENCE_OBJECT_ID,
+            ObjectField::BCS,
+        ]
+        .into();
+        assert_eq!(mask.as_str(), "bcs,reference");
+    }
+
+    #[test]
+    fn scoped_read_mask_from_array_ref() {
+        let fields = [ObjectField::REFERENCE, ObjectField::BCS];
+        let mask: ObjectReadMask = (&fields).into();
+        assert_eq!(mask.as_str(), "bcs,reference");
     }
 }

--- a/crates/iota-sdk-transaction-builder/Cargo.toml
+++ b/crates/iota-sdk-transaction-builder/Cargo.toml
@@ -34,7 +34,7 @@ iota-types = { workspace = true, features = ["serde", "hash"] }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [dev-dependencies]
 # external dependencies

--- a/crates/iota-sdk-types/src/transaction/fixtures/update-transaction-fixtures/Cargo.toml
+++ b/crates/iota-sdk-types/src/transaction/fixtures/update-transaction-fixtures/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 bcs.workspace = true
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "5f2c63266a065996d53f98156f0412782b468597" }
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 iota-json-rpc-types = { path = "../../../../../../../iota/crates/iota-json-rpc-types" }
 iota-types = { path = "../../../../../../../iota/crates/iota-types" }

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -45,7 +45,12 @@ move-types = ["dep:iota-move-types"]
 # GraphQL
 graphql = ["dep:iota-graphql-client"]
 # gRPC
-grpc = ["dep:iota-grpc-client", "dep:iota-grpc-types"]
+grpc = [
+  "dep:iota-grpc-client",
+  "dep:iota-grpc-types",
+  "iota-grpc-client/tls-native-roots",
+  "iota-grpc-client/tls-ring",
+]
 # Transaction Builder
 txn-builder = ["dep:iota-transaction-builder"]
 # Types
@@ -69,14 +74,33 @@ base64ct = { workspace = true, features = ["alloc", "std"] }
 bcs.workspace = true
 cynic.workspace = true
 eyre.workspace = true
+futures.workspace = true
 hex.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "json"] }
 serde_json.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [build-dependencies]
 iota-graphql-client-build.workspace = true
+
+# gRPC examples: skipped unless the `grpc` feature is enabled
+# (e.g. `cargo run --example chain_id_grpc --features grpc`).
+[[example]]
+name = "chain_id_grpc"
+required-features = ["grpc"]
+
+[[example]]
+name = "get_object_grpc"
+required-features = ["grpc"]
+
+[[example]]
+name = "owned_objects_grpc"
+required-features = ["grpc"]
+
+[[example]]
+name = "stream_checkpoints_grpc"
+required-features = ["grpc"]
 
 [[example]]
 name = "decode_staked_iota"

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -48,9 +48,11 @@ graphql = ["dep:iota-graphql-client"]
 grpc = [
   "dep:iota-grpc-client",
   "dep:iota-grpc-types",
-  "iota-grpc-client/tls-native-roots",
-  "iota-grpc-client/tls-ring",
 ]
+# TLS support for the gRPC client (required to reach `https://` endpoints
+# such as the public testnet/mainnet nodes).
+grpc-tls-native-roots = ["grpc", "iota-grpc-client/tls-native-roots"]
+grpc-tls-ring = ["grpc", "iota-grpc-client/tls-ring"]
 # Transaction Builder
 txn-builder = ["dep:iota-transaction-builder"]
 # Types
@@ -84,23 +86,23 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 [build-dependencies]
 iota-graphql-client-build.workspace = true
 
-# gRPC examples: skipped unless the `grpc` feature is enabled
-# (e.g. `cargo run --example chain_id_grpc --features grpc`).
+# gRPC examples: skipped unless the gRPC TLS features are enabled (e.g.
+# `cargo run --example chain_id_grpc --features grpc-tls-native-roots,grpc-tls-ring`).
 [[example]]
 name = "chain_id_grpc"
-required-features = ["grpc"]
+required-features = ["grpc-tls-native-roots", "grpc-tls-ring"]
 
 [[example]]
 name = "get_object_grpc"
-required-features = ["grpc"]
+required-features = ["grpc-tls-native-roots", "grpc-tls-ring"]
 
 [[example]]
 name = "owned_objects_grpc"
-required-features = ["grpc"]
+required-features = ["grpc-tls-native-roots", "grpc-tls-ring"]
 
 [[example]]
 name = "stream_checkpoints_grpc"
-required-features = ["grpc"]
+required-features = ["grpc-tls-native-roots", "grpc-tls-ring"]
 
 [[example]]
 name = "decode_staked_iota"

--- a/crates/iota-sdk/examples/chain_id_grpc.rs
+++ b/crates/iota-sdk/examples/chain_id_grpc.rs
@@ -9,14 +9,16 @@
 //! you observed).
 
 use eyre::{OptionExt, Result};
-use iota_sdk::grpc_client::{Client, ResponseExt};
+use iota_sdk::grpc_client::{Client, ResponseExt, read_mask_fields::ServiceInfoReadMask};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_testnet()?;
 
     // Option 1: explicit service info RPC.
-    let info = client.get_service_info(None).await?;
+    let info = client
+        .get_service_info(ServiceInfoReadMask::default())
+        .await?;
     let chain_id = info
         .body()
         .chain_id

--- a/crates/iota-sdk/examples/chain_id_grpc.rs
+++ b/crates/iota-sdk/examples/chain_id_grpc.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Same idea as `chain_id.rs`, but over gRPC.
+//!
+//! Demonstrates two ways to get the chain id: the explicit `get_service_info`
+//! RPC, and the `ResponseExt` headers that ride along with *every* gRPC
+//! response (so any call already tells you what chain / epoch / checkpoint
+//! you observed).
+
+use eyre::{OptionExt, Result};
+use iota_sdk::grpc_client::{Client, ResponseExt};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_testnet()?;
+
+    // Option 1: explicit service info RPC.
+    let info = client.get_service_info(None).await?;
+    let chain_id = info
+        .body()
+        .chain_id
+        .as_ref()
+        .and_then(|d| d.digest().ok())
+        .ok_or_eyre("missing chain id")?;
+    println!("Chain ID:  {chain_id}");
+    if let Some(chain) = &info.body().chain {
+        println!("Chain:     {chain}");
+    }
+    if let Some(epoch) = info.body().epoch {
+        println!("Epoch:     {epoch}");
+    }
+
+    // Option 2: the same data piggybacks on response headers via
+    // `ResponseExt`. Any RPC works — here we reuse the response above.
+    println!("---");
+    println!("From response headers:");
+    if let Some(chain_id) = info.chain_id() {
+        println!("Chain ID:  {chain_id}");
+    }
+    if let Some(epoch) = info.epoch() {
+        println!("Epoch:     {epoch}");
+    }
+    if let Some(height) = info.checkpoint_height() {
+        println!("Height:    {height}");
+    }
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/get_object_grpc.rs
+++ b/crates/iota-sdk/examples/get_object_grpc.rs
@@ -11,7 +11,7 @@
 
 use eyre::{Result, bail};
 use iota_sdk::{
-    grpc_client::Client,
+    grpc_client::{Client, read_mask_fields::ObjectReadMask},
     types::{ObjectId, Owner},
 };
 
@@ -22,7 +22,9 @@ async fn main() -> Result<()> {
     let object_id: ObjectId =
         "0x541b117cac18fb1c07a293db300acd12b05c01fa81232b37151b005ca7d4f755".parse()?;
 
-    let response = client.get_objects([object_id], None).await?;
+    let response = client
+        .get_objects([object_id], ObjectReadMask::default())
+        .await?;
     let proto_obj = response
         .body()
         .first()

--- a/crates/iota-sdk/examples/get_object_grpc.rs
+++ b/crates/iota-sdk/examples/get_object_grpc.rs
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC counterpart to `get_object.rs`.
+//!
+//! Highlights two things about the gRPC API:
+//! - `get_objects` is batched (it takes an iterable of ids and streams the
+//!   matched objects back), so we just hand it one id.
+//! - The returned proto `Object` is *lazy* — you convert into the SDK type only
+//!   when you need the deserialized fields.
+
+use eyre::{Result, bail};
+use iota_sdk::{
+    grpc_client::Client,
+    types::{ObjectId, Owner},
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_testnet()?;
+
+    let object_id: ObjectId =
+        "0x541b117cac18fb1c07a293db300acd12b05c01fa81232b37151b005ca7d4f755".parse()?;
+
+    let response = client.get_objects([object_id], None).await?;
+    let proto_obj = response
+        .body()
+        .first()
+        .ok_or_else(|| eyre::eyre!("missing object"))?;
+
+    // Deserialize the proto Object into the SDK Object type.
+    let obj = proto_obj.object()?;
+
+    println!("Object ID: {}", obj.id());
+    println!("Version: {}", obj.version());
+    println!(
+        "Previous transaction: {}",
+        obj.previous_transaction().to_base58()
+    );
+    println!(
+        "Owner: {}",
+        match obj.owner() {
+            Owner::Address(address) => format!("Address({address})"),
+            Owner::Object(object_id) => format!("Object({object_id})"),
+            Owner::Shared(version) => format!("Shared({version})"),
+            Owner::Immutable => "Immutable".to_owned(),
+            _ => bail!("unknown owner type"),
+        }
+    );
+    println!("Storage rebate: {}", obj.storage_rebate());
+    println!(
+        "Type: {}",
+        match obj.object_type() {
+            iota_sdk::types::ObjectType::Package => "Package".to_owned(),
+            iota_sdk::types::ObjectType::Struct(tag) => format!("{tag}"),
+        }
+    );
+    println!("BCS bytes: {}", hex::encode(obj.as_struct().contents()));
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/owned_objects_grpc.rs
+++ b/crates/iota-sdk/examples/owned_objects_grpc.rs
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! gRPC counterpart to `owned_objects.rs`.
+//!
+//! Demonstrates the gRPC pagination builder: the query is *lazy* until
+//! awaited or `.collect()`-ed. Awaiting returns a single `Page` with a
+//! continuation token; `.collect(limit)` auto-paginates up to `limit`
+//! items (or all of them if `limit` is `None`).
+
+use eyre::Result;
+use iota_sdk::{
+    grpc_client::Client,
+    types::{Address, StructTag},
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_testnet()?;
+
+    let owner: Address =
+        "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151".parse()?;
+
+    // First page: 10 results, no filter on type. The returned page includes
+    // a `next_page_token` to feed back in for the following page.
+    let page = client
+        .list_owned_objects(owner, None, 10, None, None)
+        .await?;
+    println!("First page: {} objects", page.body().items.len());
+    for obj in &page.body().items {
+        println!("  {}", obj.object_reference()?.object_id);
+    }
+    if page.body().next_page_token.is_some() {
+        println!("  ...more pages available");
+    }
+
+    // Auto-paginate: only IOTA coins, capped at 50 across all pages.
+    let iota_coin: StructTag = "0x2::coin::Coin<0x2::iota::IOTA>".parse()?;
+    let coins = client
+        .list_owned_objects(owner, iota_coin, 25, None, None)
+        .collect(Some(50))
+        .await?;
+    println!("---");
+    println!(
+        "Up to 50 IOTA coin objects ({} returned):",
+        coins.body().len()
+    );
+    for obj in coins.body() {
+        let r = obj.object_reference()?;
+        println!("  {}  v{}", r.object_id, r.version);
+    }
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/owned_objects_grpc.rs
+++ b/crates/iota-sdk/examples/owned_objects_grpc.rs
@@ -10,7 +10,7 @@
 
 use eyre::Result;
 use iota_sdk::{
-    grpc_client::Client,
+    grpc_client::{Client, read_mask_fields::OwnedObjectReadMask},
     types::{Address, StructTag},
 };
 
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     // First page: 10 results, no filter on type. The returned page includes
     // a `next_page_token` to feed back in for the following page.
     let page = client
-        .list_owned_objects(owner, None, 10, None, None)
+        .list_owned_objects(owner, None, 10, None, OwnedObjectReadMask::default())
         .await?;
     println!("First page: {} objects", page.body().items.len());
     for obj in &page.body().items {
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     // Auto-paginate: only IOTA coins, capped at 50 across all pages.
     let iota_coin: StructTag = "0x2::coin::Coin<0x2::iota::IOTA>".parse()?;
     let coins = client
-        .list_owned_objects(owner, iota_coin, 25, None, None)
+        .list_owned_objects(owner, iota_coin, 25, None, OwnedObjectReadMask::default())
         .collect(Some(50))
         .await?;
     println!("---");

--- a/crates/iota-sdk/examples/release/Cargo.toml
+++ b/crates/iota-sdk/examples/release/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2024"
 
 [dependencies]
 iota-sdk = "^3.0.0-alpha"
-tokio = "1.40.0"
+tokio = "1.52.3"

--- a/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
+++ b/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tail recent checkpoints over gRPC.
+//!
+//! This is one of gRPC's headline features — there's no equivalent in the
+//! GraphQL client. We open a server-streaming RPC and pull a handful of
+//! checkpoint summaries out of it.
+
+use eyre::Result;
+use futures::StreamExt;
+use iota_sdk::grpc_client::{
+    Client,
+    read_mask_fields::{CheckpointResponseField, CheckpointResponseReadMask},
+};
+
+const HOW_MANY: u64 = 5;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new_testnet()?;
+
+    // Pick a starting point a few checkpoints behind head so the example
+    // returns promptly instead of waiting on new blocks.
+    let head = client
+        .get_checkpoint_latest(None, None, None)
+        .await?
+        .body()
+        .sequence_number();
+    let start = head.saturating_sub(HOW_MANY - 1);
+    let end = head;
+
+    // Only ask for the summary — keeps the message small. Drop the mask
+    // (or compose more fields) to pull more data per checkpoint.
+    let mut stream = client
+        .stream_checkpoints(
+            start,
+            end,
+            CheckpointResponseReadMask::from(CheckpointResponseField::CHECKPOINT_SUMMARY),
+            None,
+            None,
+        )
+        .await?;
+
+    println!("Streaming checkpoints {start}..={end}");
+    while let Some(checkpoint) = stream.body_mut().next().await {
+        let checkpoint = checkpoint?;
+        let summary = checkpoint.summary()?;
+        println!(
+            "  cp {:>6}  epoch {:>3}  txs {:>4}  ts {}",
+            checkpoint.sequence_number(),
+            summary.summary()?.epoch,
+            summary.summary()?.network_total_transactions,
+            summary.summary()?.timestamp_ms,
+        );
+    }
+
+    Ok(())
+}

--- a/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
+++ b/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
@@ -23,22 +23,23 @@ async fn main() -> Result<()> {
     // Pick a starting point a few checkpoints behind head so the example
     // returns promptly instead of waiting on new blocks.
     let head = client
-        .get_checkpoint_latest(None, None, None)
+        .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
         .await?
         .body()
         .sequence_number();
     let start = head.saturating_sub(HOW_MANY - 1);
     let end = head;
 
-    // Only ask for the summary — keeps the message small. Drop the mask
-    // (or compose more fields) to pull more data per checkpoint.
+    // Only ask for the summary — keeps the message small. Pass
+    // `CheckpointResponseReadMask::default()` (or compose more fields) to
+    // pull more data per checkpoint.
     let mut stream = client
         .stream_checkpoints(
             start,
             end,
-            CheckpointResponseReadMask::from(CheckpointResponseField::CHECKPOINT_SUMMARY),
             None,
             None,
+            CheckpointResponseField::CHECKPOINT_SUMMARY,
         )
         .await?;
 


### PR DESCRIPTION
Split out of #1147. This is the first of two PRs; the `_masked` methods land separately in a follow-up stacked on top of this one.

## Why
Reworks the gRPC client's read-mask handling and general ergonomics, keeping a **single unified method per endpoint** that takes an optional typed mask.

## What
- Typed, per-endpoint read mask types (`ObjectReadMask`, `TransactionReadMask`, `EpochReadMask`, …) — mixing a mask with the wrong endpoint is a compile error. Each query method takes `impl Into<Option<XxxReadMask>>`; pass `None` for the endpoint default.
- `impl Into<Option<..>>` for optional scalars and `impl IntoIterator` for id lists, dropping most `Some(..)`/slice boilerplate.
- New `get_coins` query + a `map_item` variant of `define_list_query!` for per-item proto→SDK conversion.
- Runnable gRPC examples, gated behind the `grpc` feature.
- Dependency housekeeping (tokio bump / feature narrowing, tls features).

## Test plan
- `cargo check`/`clippy -Dwarnings` clean for `iota-sdk-grpc-client` (+ tests) and `iota-sdk --features grpc --examples`.
- `cargo test --doc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)