### PR TITLE
feat(grpc): add dedicated `_masked` query methods

### DIFF
--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -194,8 +194,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Most callers should use the scoped per-endpoint mask types in
 /// [`read_mask_fields`](crate::read_mask_fields)
 /// (e.g. [`ObjectReadMask`](crate::read_mask_fields::ObjectReadMask)) which
-/// are passed directly to the client methods. This type is the underlying
-/// string holder, useful when composing masks by hand:
+/// are passed directly to the masked client methods. This type is the
+/// underlying string holder, useful when composing masks by hand:
 ///
 /// ```
 /// use iota_sdk_grpc_client::ReadMask;

--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -35,17 +35,19 @@ impl Client {
     /// - `result.balance_changes()` - Get balance changes (if requested)
     /// - `result.object_changes()` - Get object changes (if requested)
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `ExecuteTransactionReadMask::default()` for the default mask. Pass a
-    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Uses the default field mask `TransactionReadMask::default()` which
+    /// includes effects, events, and input/output objects. Use
+    /// [`execute_transaction_masked`](Self::execute_transaction_masked) to
+    /// specify a custom mask.
     ///
     /// # Checkpoint Inclusion
     ///
     /// If `checkpoint_inclusion_timeout_ms` is set, the server will wait up to
     /// the specified duration (in milliseconds) for the transaction to be
-    /// included in a checkpoint before returning. When set, include
-    /// `checkpoint` and `timestamp` in the `read_mask` to receive the data.
+    /// included in a checkpoint before returning. When set, callers wanting
+    /// the checkpoint metadata should use
+    /// [`execute_transaction_masked`](Self::execute_transaction_masked) with a
+    /// mask that includes `checkpoint` and `timestamp`.
     ///
     /// # Example
     ///
@@ -57,9 +59,7 @@ impl Client {
     /// let client = Client::new_localnet()?;
     ///
     /// let signed_tx: SignedTransaction = todo!();
-    /// let result = client
-    ///     .execute_transaction(signed_tx, None, ExecuteTransactionReadMask::default())
-    ///     .await?;
+    /// let result = client.execute_transaction(signed_tx, None).await?;
     ///
     /// let effects = result.body().effects()?.effects()?;
     /// println!("Status: {:?}", effects.as_v1().status);
@@ -75,12 +75,32 @@ impl Client {
         &self,
         signed_transaction: SignedTransaction,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
+    ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
+        self.execute_transactions_internal(
+            vec![signed_transaction],
+            checkpoint_inclusion_timeout_ms.into(),
+            Default::default(),
+        )
+        .await?
+        .try_map(extract_single_execution_result)
+    }
+
+    /// Execute a signed transaction, with a custom read mask.
+    ///
+    /// See [`execute_transaction`](Self::execute_transaction) for behavior.
+    /// Pass a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn execute_transaction_masked(
+        &self,
+        signed_transaction: SignedTransaction,
+        checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
         read_mask: impl IntoReadMask<ExecuteTransactionReadMask>,
     ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
-        self.execute_transactions(
+        self.execute_transactions_internal(
             vec![signed_transaction],
-            checkpoint_inclusion_timeout_ms,
-            read_mask,
+            checkpoint_inclusion_timeout_ms.into(),
+            read_mask.into_read_mask(),
         )
         .await?
         .try_map(extract_single_execution_result)
@@ -95,18 +115,18 @@ impl Client {
     /// input. Each element is either the successfully executed transaction or
     /// the per-item error returned by the server.
     ///
-    /// The `read_mask` controls which fields the server returns for each
-    /// `ExecutedTransaction`; use `ExecuteTransactionReadMask::default()` for
-    /// the default mask. Pass a
-    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Uses the default field mask `TransactionReadMask::default()`. Use
+    /// [`execute_transactions_masked`](Self::execute_transactions_masked) to
+    /// specify a custom mask.
     ///
     /// # Checkpoint Inclusion
     ///
     /// If `checkpoint_inclusion_timeout_ms` is set, the server will wait up to
     /// the specified duration (in milliseconds) for all executed transactions
-    /// to be included in a checkpoint before returning. When set, include
-    /// `checkpoint` and `timestamp` in the `read_mask` to receive the data.
+    /// to be included in a checkpoint before returning. Callers wanting the
+    /// checkpoint metadata should use
+    /// [`execute_transactions_masked`](Self::execute_transactions_masked) with
+    /// a mask that includes `checkpoint` and `timestamp`.
     ///
     /// # Errors
     ///
@@ -117,10 +137,41 @@ impl Client {
         &self,
         transactions: Vec<SignedTransaction>,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
+    ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
+        self.execute_transactions_internal(
+            transactions,
+            checkpoint_inclusion_timeout_ms.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Execute a batch of signed transactions, with a custom read mask.
+    ///
+    /// See [`execute_transactions`](Self::execute_transactions) for behavior.
+    /// Pass a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn execute_transactions_masked(
+        &self,
+        transactions: Vec<SignedTransaction>,
+        checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
         read_mask: impl IntoReadMask<ExecuteTransactionReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
-        let read_mask = read_mask.into_read_mask();
-        let checkpoint_inclusion_timeout_ms = checkpoint_inclusion_timeout_ms.into();
+        self.execute_transactions_internal(
+            transactions,
+            checkpoint_inclusion_timeout_ms.into(),
+            read_mask.into_read_mask(),
+        )
+        .await
+    }
+
+    async fn execute_transactions_internal(
+        &self,
+        transactions: Vec<SignedTransaction>,
+        checkpoint_inclusion_timeout_ms: Option<u64>,
+        read_mask: ExecuteTransactionReadMask,
+    ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
         }

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -34,6 +34,11 @@ impl Client {
     /// This allows you to preview the effects of a transaction before
     /// actually submitting it to the network.
     ///
+    /// Uses the default field mask `SimulateReadMask::default()` which includes
+    /// effects, events, and input/output objects. Use
+    /// [`simulate_transaction_masked`](Self::simulate_transaction_masked) to
+    /// specify a custom mask.
+    ///
     /// # Parameters
     ///
     /// - `transaction`: The transaction to simulate
@@ -67,9 +72,7 @@ impl Client {
     /// let client = Client::new_localnet()?;
     ///
     /// let tx: Transaction = todo!();
-    /// let result = client
-    ///     .simulate_transaction(tx, false, SimulateReadMask::default())
-    ///     .await?;
+    /// let result = client.simulate_transaction(tx, false).await?;
     ///
     /// let executed_tx = result.body().executed_transaction()?;
     /// let effects = executed_tx.effects()?.effects()?;
@@ -80,23 +83,40 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
+    pub async fn simulate_transaction(
+        &self,
+        transaction: Transaction,
+        skip_checks: bool,
+    ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
+        self.simulate_transactions_internal(
+            vec![SimulateTransactionInput {
+                transaction,
+                skip_checks,
+            }],
+            Default::default(),
+        )
+        .await?
+        .try_map(extract_single_simulation_result)
+    }
+
+    /// Simulate a transaction without executing it, with a custom read mask.
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `SimulateReadMask::default()` for the default mask. Pass a
+    /// See [`simulate_transaction`](Self::simulate_transaction) for behavior.
+    /// Pass a
     /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
     /// any slice/array/vec of fields — conversion is automatic.
-    pub async fn simulate_transaction(
+    pub async fn simulate_transaction_masked(
         &self,
         transaction: Transaction,
         skip_checks: bool,
         read_mask: impl IntoReadMask<SimulateReadMask>,
     ) -> Result<MetadataEnvelope<SimulatedTransaction>> {
-        self.simulate_transactions(
+        self.simulate_transactions_internal(
             vec![SimulateTransactionInput {
                 transaction,
                 skip_checks,
             }],
-            read_mask,
+            read_mask.into_read_mask(),
         )
         .await?
         .try_map(extract_single_simulation_result)
@@ -111,11 +131,9 @@ impl Client {
     /// input. Each element is either the successfully simulated transaction or
     /// the per-item error returned by the server.
     ///
-    /// The `read_mask` controls which fields the server returns for each
-    /// `SimulatedTransaction`; use `SimulateReadMask::default()` for the
-    /// default mask. Pass a
-    /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
-    /// any slice/array/vec of fields — conversion is automatic.
+    /// Uses the default field mask `SimulateReadMask::default()`. Use
+    /// [`simulate_transactions_masked`](Self::simulate_transactions_masked) to
+    /// specify a custom mask.
     ///
     /// # Errors
     ///
@@ -125,9 +143,31 @@ impl Client {
     pub async fn simulate_transactions(
         &self,
         transactions: Vec<SimulateTransactionInput>,
+    ) -> Result<MetadataEnvelope<Vec<Result<SimulatedTransaction>>>> {
+        self.simulate_transactions_internal(transactions, Default::default())
+            .await
+    }
+
+    /// Simulate a batch of transactions, with a custom read mask.
+    ///
+    /// See [`simulate_transactions`](Self::simulate_transactions) for
+    /// behavior. Pass a
+    /// [`SimulateField`](iota_grpc_types::read_mask_fields::SimulateField) or
+    /// any slice/array/vec of fields — conversion is automatic.
+    pub async fn simulate_transactions_masked(
+        &self,
+        transactions: Vec<SimulateTransactionInput>,
         read_mask: impl IntoReadMask<SimulateReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<SimulatedTransaction>>>> {
-        let read_mask = read_mask.into_read_mask();
+        self.simulate_transactions_internal(transactions, read_mask.into_read_mask())
+            .await
+    }
+
+    async fn simulate_transactions_internal(
+        &self,
+        transactions: Vec<SimulateTransactionInput>,
+        read_mask: SimulateReadMask,
+    ) -> Result<MetadataEnvelope<Vec<Result<SimulatedTransaction>>>> {
         if transactions.is_empty() {
             return Err(Error::EmptyRequest);
         }

--- a/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/checkpoints.rs
@@ -5,11 +5,11 @@
 //!
 //! # Read Mask
 //!
-//! All checkpoint query methods accept a `read_mask` to control which data is
-//! included in the response. Pass `CheckpointResponseReadMask::default()` for
-//! the default mask, or a
+//! Each checkpoint query has a default variant that uses
+//! `CheckpointResponseReadMask::default()` and a `_masked` variant that accepts
+//! a custom mask. Pass a
 //! [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-//! (or any slice/array/vec of fields) — conversion is automatic.
+//! (or any slice/array/vec of fields) to the latter — conversion is automatic.
 
 use std::pin::Pin;
 
@@ -38,33 +38,48 @@ use crate::{
 impl Client {
     /// Get the latest checkpoint.
     ///
-    /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
-    /// default field mask. Pass a
-    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Returns the checkpoint with fields populated according to the default
+    /// field mask `CheckpointResponseReadMask::default()`. Use
+    /// [`get_checkpoint_latest_masked`](Self::get_checkpoint_latest_masked) to
+    /// specify a custom mask.
     ///
     /// # Parameters
     ///
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
-    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
-    /// let checkpoint = client
-    ///     .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
-    ///     .await?;
+    /// let checkpoint = client.get_checkpoint_latest(None, None).await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_checkpoint_latest(
+        &self,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+    ) -> Result<MetadataEnvelope<CheckpointResponse>> {
+        self.get_checkpoint_internal(
+            get_checkpoint_request::CheckpointId::Latest(true),
+            transactions_filter.into(),
+            events_filter.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Get the latest checkpoint, with a custom read mask.
+    ///
+    /// See [`get_checkpoint_latest`](Self::get_checkpoint_latest) for behavior.
+    /// Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn get_checkpoint_latest_masked(
         &self,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
         events_filter: impl Into<Option<grpc_filter::EventFilter>>,
@@ -81,34 +96,53 @@ impl Client {
 
     /// Get checkpoint by sequence number.
     ///
-    /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
-    /// default field mask. Pass a
-    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Returns the checkpoint with fields populated according to the default
+    /// field mask `CheckpointResponseReadMask::default()`. Use
+    /// [`get_checkpoint_by_sequence_number_masked`](Self::get_checkpoint_by_sequence_number_masked)
+    /// to specify a custom mask.
     ///
     /// # Parameters
     ///
     /// * `sequence_number` - The checkpoint sequence number to fetch
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
-    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let checkpoint = client
-    ///     .get_checkpoint_by_sequence_number(100, None, None, CheckpointResponseReadMask::default())
+    ///     .get_checkpoint_by_sequence_number(100, None, None)
     ///     .await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_checkpoint_by_sequence_number(
+        &self,
+        sequence_number: CheckpointSequenceNumber,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+    ) -> Result<MetadataEnvelope<CheckpointResponse>> {
+        self.get_checkpoint_internal(
+            get_checkpoint_request::CheckpointId::SequenceNumber(sequence_number),
+            transactions_filter.into(),
+            events_filter.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Get checkpoint by sequence number, with a custom read mask.
+    ///
+    /// See
+    /// [`get_checkpoint_by_sequence_number`](Self::get_checkpoint_by_sequence_number)
+    /// for behavior. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn get_checkpoint_by_sequence_number_masked(
         &self,
         sequence_number: CheckpointSequenceNumber,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
@@ -126,36 +160,52 @@ impl Client {
 
     /// Get checkpoint by digest.
     ///
-    /// Returns the checkpoint with fields populated according to the
-    /// `read_mask`; use `CheckpointResponseReadMask::default()` for the
-    /// default field mask. Pass a
-    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Returns the checkpoint with fields populated according to the default
+    /// field mask `CheckpointResponseReadMask::default()`. Use
+    /// [`get_checkpoint_by_digest_masked`](Self::get_checkpoint_by_digest_masked)
+    /// to specify a custom mask.
     ///
     /// # Parameters
     ///
     /// * `digest` - The checkpoint digest to fetch
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
-    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use iota_types::CheckpointDigest;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let digest: CheckpointDigest = todo!();
-    /// let checkpoint = client
-    ///     .get_checkpoint_by_digest(digest, None, None, CheckpointResponseReadMask::default())
-    ///     .await?;
+    /// let checkpoint = client.get_checkpoint_by_digest(digest, None, None).await?;
     /// println!("Received checkpoint {}", checkpoint.body().sequence_number,);
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_checkpoint_by_digest(
+        &self,
+        digest: CheckpointDigest,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+    ) -> Result<MetadataEnvelope<CheckpointResponse>> {
+        self.get_checkpoint_internal(
+            get_checkpoint_request::CheckpointId::Digest(digest.into()),
+            transactions_filter.into(),
+            events_filter.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Get checkpoint by digest, with a custom read mask.
+    ///
+    /// See [`get_checkpoint_by_digest`](Self::get_checkpoint_by_digest) for
+    /// behavior. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn get_checkpoint_by_digest_masked(
         &self,
         digest: CheckpointDigest,
         transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
@@ -242,11 +292,9 @@ impl Client {
     /// To skip non-matching checkpoints entirely, use
     /// [`stream_checkpoints_filtered`](Self::stream_checkpoints_filtered).
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `CheckpointResponseReadMask::default()` for the default field mask.
-    /// Pass a
-    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Uses the default field mask `CheckpointResponseReadMask::default()`. Use
+    /// [`stream_checkpoints_masked`](Self::stream_checkpoints_masked) to
+    /// specify a custom mask.
     ///
     /// **Note:** The metadata in the returned [`MetadataEnvelope`] is captured
     /// from the initial gRPC response headers when the stream is opened. It is
@@ -260,24 +308,16 @@ impl Client {
     ///   indefinitely.
     /// * `transactions_filter` - Optional filter to apply to transactions
     /// * `events_filter` - Optional filter to apply to events
-    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let mut stream = client
-    ///     .stream_checkpoints(
-    ///         Some(0),
-    ///         Some(10),
-    ///         None,
-    ///         None,
-    ///         CheckpointResponseReadMask::default(),
-    ///     )
+    ///     .stream_checkpoints(Some(0), Some(10), None, None)
     ///     .await?;
     ///
     /// while let Some(checkpoint) = stream.body_mut().next().await {
@@ -288,6 +328,30 @@ impl Client {
     /// # }
     /// ```
     pub async fn stream_checkpoints(
+        &self,
+        start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+    ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointResponse>> + Send>>>>
+    {
+        self.stream_checkpoints_internal(
+            start_sequence_number.into(),
+            end_sequence_number.into(),
+            transactions_filter.into(),
+            events_filter.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Stream checkpoints across a range, with a custom read mask.
+    ///
+    /// See [`stream_checkpoints`](Self::stream_checkpoints) for behavior. Pass
+    /// a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub async fn stream_checkpoints_masked(
         &self,
         start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
         end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
@@ -362,11 +426,9 @@ impl Client {
     ///
     /// At least one of `transactions_filter` or `events_filter` must be set.
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `CheckpointResponseReadMask::default()` for the default field mask.
-    /// Pass a
-    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
-    /// or any slice/array/vec of fields — conversion is automatic.
+    /// Uses the default field mask `CheckpointResponseReadMask::default()`. Use
+    /// [`stream_checkpoints_filtered_masked`](Self::stream_checkpoints_filtered_masked)
+    /// to specify a custom mask.
     ///
     /// # Parameters
     ///
@@ -378,13 +440,11 @@ impl Client {
     /// * `events_filter` - Optional filter to apply to events
     /// * `progress_interval_ms` - Optional progress message interval in
     ///   milliseconds. Defaults to 2000ms. Minimum 500ms.
-    /// * `read_mask` - Field mask controlling the returned fields
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::{Client, CheckpointStreamItem};
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # use iota_grpc_types::v1::filter as grpc_filter;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -392,14 +452,7 @@ impl Client {
     /// // At least one filter is required
     /// let tx_filter = grpc_filter::TransactionFilter::default();
     /// let mut stream = client
-    ///     .stream_checkpoints_filtered(
-    ///         Some(0),
-    ///         None,
-    ///         Some(tx_filter),
-    ///         None,
-    ///         None,
-    ///         CheckpointResponseReadMask::default(),
-    ///     )
+    ///     .stream_checkpoints_filtered(Some(0), None, Some(tx_filter), None, None)
     ///     .await?;
     ///
     /// while let Some(item) = stream.body_mut().next().await {
@@ -419,6 +472,35 @@ impl Client {
     /// # }
     /// ```
     pub async fn stream_checkpoints_filtered(
+        &self,
+        start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
+        transactions_filter: impl Into<Option<grpc_filter::TransactionFilter>>,
+        events_filter: impl Into<Option<grpc_filter::EventFilter>>,
+        progress_interval_ms: impl Into<Option<u32>>,
+    ) -> Result<MetadataEnvelope<Pin<Box<dyn Stream<Item = Result<CheckpointStreamItem>> + Send>>>>
+    {
+        self.stream_checkpoints_raw(
+            start_sequence_number.into(),
+            end_sequence_number.into(),
+            transactions_filter.into(),
+            events_filter.into(),
+            true,
+            progress_interval_ms.into(),
+            Default::default(),
+        )
+        .await
+    }
+
+    /// Stream checkpoints, skipping those with no matching data, with a
+    /// custom read mask.
+    ///
+    /// See [`stream_checkpoints_filtered`](Self::stream_checkpoints_filtered)
+    /// for behavior. Pass a
+    /// [`CheckpointResponseField`](iota_grpc_types::read_mask_fields::CheckpointResponseField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn stream_checkpoints_filtered_masked(
         &self,
         start_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,
         end_sequence_number: impl Into<Option<CheckpointSequenceNumber>>,

--- a/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/epochs.rs
@@ -17,14 +17,42 @@ use crate::{
 impl Client {
     /// Get epoch information.
     ///
-    /// Returns the [`Epoch`] proto type with fields populated according to the
-    /// `read_mask`; use `EpochReadMask::default()` for the default field mask.
-    /// Pass an
-    /// [`EpochReadMask`](iota_grpc_types::read_mask_fields::EpochReadMask)
-    /// built from an
+    /// Returns the [`Epoch`] proto type populated with the default field mask
+    /// `EpochReadMask::default()`. Use
+    /// [`get_epoch_masked`](Self::get_epoch_masked) to specify a custom mask.
+    ///
+    /// # Parameters
+    ///
+    /// * `epoch` - The epoch to query. If `None`, returns the current epoch.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    ///
+    /// // Get current epoch
+    /// let epoch = client.get_epoch(None).await?;
+    /// println!("Epoch: {:?}", epoch.body().epoch);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_epoch(
+        &self,
+        epoch: impl Into<Option<u64>>,
+    ) -> Result<MetadataEnvelope<Epoch>> {
+        self.get_epoch_internal(epoch.into(), Default::default())
+            .await
+    }
+
+    /// Get epoch information, with a custom read mask.
+    ///
+    /// Returns the [`Epoch`] proto type with fields populated according to
+    /// `read_mask`. Pass an
     /// [`EpochField`](iota_grpc_types::read_mask_fields::EpochField) or any
-    /// slice/array/vec of fields. For individual protocol config map entries,
-    /// use
+    /// slice/array/vec of fields — conversion is automatic. For individual
+    /// protocol config map entries, use
     /// [`EpochField::feature_flag`](iota_grpc_types::read_mask_fields::EpochField::feature_flag)
     /// and
     /// [`EpochField::attribute`](iota_grpc_types::read_mask_fields::EpochField::attribute).
@@ -38,63 +66,62 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::{EpochField, EpochReadMask};
+    /// # use iota_sdk_grpc_client::read_mask_fields::EpochField;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
     /// // Current epoch with the default mask.
-    /// let epoch = client.get_epoch(None, EpochReadMask::default()).await?;
+    /// let epoch = client.get_epoch(None).await?;
     /// println!("Epoch: {:?}", epoch.body().epoch);
     ///
     /// // Specific epoch with selected fields.
     /// let epoch = client
-    ///     .get_epoch(
+    ///     .get_epoch_masked(
     ///         Some(0),
-    ///         EpochReadMask::from([
+    ///         [
     ///             EpochField::EPOCH,
     ///             EpochField::REFERENCE_GAS_PRICE,
     ///             EpochField::FIRST_CHECKPOINT,
-    ///         ]),
+    ///         ],
     ///     )
     ///     .await?;
     ///
     /// // All feature flags for the current epoch.
     /// let epoch = client
-    ///     .get_epoch(
-    ///         None,
-    ///         EpochReadMask::from(EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS),
-    ///     )
+    ///     .get_epoch_masked(None, EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS)
     ///     .await?
     ///     .into_inner();
     /// let flags = epoch.protocol_config.unwrap().feature_flags.unwrap().flags;
     ///
     /// // A single named feature flag.
     /// let epoch = client
-    ///     .get_epoch(
-    ///         None,
-    ///         EpochReadMask::from(EpochField::feature_flag("enable_vdf")),
-    ///     )
+    ///     .get_epoch_masked(None, EpochField::feature_flag("enable_vdf"))
     ///     .await?;
     ///
     /// // A single named attribute.
     /// let epoch = client
-    ///     .get_epoch(
-    ///         None,
-    ///         EpochReadMask::from(EpochField::attribute("max_tx_gas")),
-    ///     )
+    ///     .get_epoch_masked(None, EpochField::attribute("max_tx_gas"))
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_epoch(
+    pub async fn get_epoch_masked(
         &self,
         epoch: impl Into<Option<u64>>,
         read_mask: impl IntoReadMask<EpochReadMask>,
     ) -> Result<MetadataEnvelope<Epoch>> {
-        let read_mask = read_mask.into_read_mask();
+        self.get_epoch_internal(epoch.into(), read_mask.into_read_mask())
+            .await
+    }
+
+    async fn get_epoch_internal(
+        &self,
+        epoch: Option<u64>,
+        read_mask: EpochReadMask,
+    ) -> Result<MetadataEnvelope<Epoch>> {
         let mut request = GetEpochRequest::default().with_read_mask(read_mask);
 
-        if let Some(epoch) = epoch.into() {
+        if let Some(epoch) = epoch {
             request = request.with_epoch(epoch);
         }
 

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -48,14 +48,9 @@ impl Client {
     /// [`UnexpectedResultCount`]: crate::ProtocolError::UnexpectedResultCount
     /// [`UnexpectedObject`]: crate::ProtocolError::UnexpectedObject
     ///
-    /// # Read Mask
-    ///
-    /// The `read_mask` parameter controls which fields the server returns; use
-    /// `ObjectReadMask::default()` for the default mask, or pass an
-    /// [`ObjectReadMask`](iota_grpc_types::read_mask_fields::ObjectReadMask)
-    /// built from an
-    /// [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField) or any
-    /// slice/array/vec of fields.
+    /// Uses the default field mask `ObjectReadMask::default()`. Use
+    /// [`get_objects_masked`](Self::get_objects_masked) to specify a custom
+    /// mask.
     ///
     /// # Example
     ///
@@ -68,15 +63,88 @@ impl Client {
     /// let object_id: ObjectId = "0x2".parse()?;
     /// let ids = [object_id];
     ///
-    /// // Default mask
-    /// let objs = client.get_objects(ids, ObjectReadMask::default()).await?;
+    /// let objs = client.get_objects(ids).await?;
     ///
-    /// // Selected fields
+    /// for obj in objs.body() {
+    ///     let obj = match obj {
+    ///         Ok(obj) => obj,
+    ///         // Only this ID failed; the remaining objects are still usable
+    ///         Err(e) => {
+    ///             eprintln!("could not read object: {e}");
+    ///             continue;
+    ///         }
+    ///     };
+    ///
+    ///     // Convert proto object to SDK type
+    ///     let sdk_obj = obj.object()?;
+    ///     println!("Got object ID: {:?}", sdk_obj.id());
+    ///     let obj_ref = obj.object_reference()?;
+    ///     println!("Object version: {:?}", obj_ref.version());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_objects(
+        &self,
+        refs: impl IntoIterator<Item = ObjectId>,
+    ) -> Result<MetadataEnvelope<Vec<Result<Object>>>> {
+        let refs = refs.into_iter().map(|id| (id, None)).collect::<Vec<_>>();
+
+        self.get_objects_internal(refs, Default::default()).await
+    }
+
+    /// Get objects by their IDs.
+    ///
+    /// Returns proto `Object` types. Use `obj.object()` to convert to SDK
+    /// type, or use `obj.object_reference()` to get the object reference.
+    ///
+    /// Results are returned in the same order as the input refs.
+    /// If an object is not found, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyRequest`] if `refs` is empty.
+    ///
+    /// Each ID gets its own result: an object that is not found (never
+    /// existed, was deleted, or has been pruned by the serving node) yields
+    /// [`Error::Server`] with code `NOT_FOUND` in that slot only, leaving the
+    /// other objects intact. The outer `Result` is reserved for failures of the
+    /// call itself, such as a transport error, and for a server that answered
+    /// with a different number of results than IDs requested
+    /// ([`UnexpectedResultCount`]), which leaves no way to tell which ID each
+    /// result belongs to, or answered a position with a different object than
+    /// the one requested there ([`UnexpectedObject`]). The answered id is read
+    /// from the object reference or its BCS, so a read mask that includes
+    /// neither leaves nothing to check.
+    ///
+    /// [`UnexpectedResultCount`]: crate::ProtocolError::UnexpectedResultCount
+    /// [`UnexpectedObject`]: crate::ProtocolError::UnexpectedObject
+    ///
+    /// # Read Mask
+    ///
+    /// The `read_mask` parameter controls which fields the server returns.
+    /// Pass an [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::ObjectField;
+    /// # use iota_types::ObjectId;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let object_id: ObjectId = "0x2".parse()?;
+    /// let ids = [object_id];
+    ///
+    /// // Single field
     /// let objs = client
-    ///     .get_objects(
-    ///         ids,
-    ///         ObjectReadMask::from([ObjectField::REFERENCE, ObjectField::BCS]),
-    ///     )
+    ///     .get_objects_masked(ids, ObjectField::REFERENCE_OBJECT_ID)
+    ///     .await?;
+    ///
+    /// // Multiple fields
+    /// let objs = client
+    ///     .get_objects_masked(ids, [ObjectField::REFERENCE, ObjectField::BCS])
     ///     .await?;
     ///
     /// for obj in objs.body() {
@@ -110,7 +178,7 @@ impl Client {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_objects(
+    pub async fn get_objects_masked(
         &self,
         refs: impl IntoIterator<Item = ObjectId>,
         read_mask: impl IntoReadMask<ObjectReadMask>,
@@ -148,30 +216,22 @@ impl Client {
     /// # Example
     ///
     /// ```no_run
-    /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::{ObjectField, ObjectReadMask};
+    /// # use iota_sdk_grpc_client::{Client, ReadMask};
+    /// # use iota_sdk_grpc_client::read_mask_fields::ObjectField;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let object_id: ObjectId = "0x2".parse()?;
     ///
-    /// // Default mask
+    /// // Get objects with default mask
     /// let objs = client
-    ///     .get_objects_with_versions([(object_id, None)], ObjectReadMask::default())
-    ///     .await?;
-    ///
-    /// // Selected fields
-    /// let objs = client
-    ///     .get_objects_with_versions(
-    ///         [(object_id, None)],
-    ///         ObjectReadMask::from(ObjectField::REFERENCE_OBJECT_ID),
-    ///     )
+    ///     .get_objects_with_versions([(object_id, None)])
     ///     .await?;
     ///
     /// for obj in objs.body() {
     ///     let obj = match obj {
     ///         Ok(obj) => obj,
-    ///         // Only this ref failed; the remaining objects are still usable
+    ///         // Only this ID failed; the remaining objects are still usable
     ///         Err(e) => {
     ///             eprintln!("could not read object: {e}");
     ///             continue;
@@ -188,6 +248,74 @@ impl Client {
     /// # }
     /// ```
     pub async fn get_objects_with_versions(
+        &self,
+        refs: impl IntoIterator<Item = (ObjectId, Option<Version>)>,
+    ) -> Result<MetadataEnvelope<Vec<Result<Object>>>> {
+        self.get_objects_internal(refs.into_iter().collect(), Default::default())
+            .await
+    }
+
+    /// Get objects by their IDs and optional versions.
+    ///
+    /// Returns proto `Object` types. Use `obj.object()` to convert to SDK
+    /// type, or use `obj.object_reference()` to get the object reference.
+    ///
+    /// Results are returned in the same order as the input refs.
+    /// If an object is not found, an error is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::EmptyRequest`] if `refs` is empty.
+    ///
+    /// # Read Mask
+    ///
+    /// The `read_mask` parameter controls which fields the server returns.
+    /// Pass an [`ObjectField`](iota_grpc_types::read_mask_fields::ObjectField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::{ObjectField, ObjectReadMask};
+    /// # use iota_types::ObjectId;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let object_id: ObjectId = "0x2".parse()?;
+    ///
+    /// // Default mask
+    /// let objs = client
+    ///     .get_objects_with_versions_masked([(object_id, None)], ObjectReadMask::default())
+    ///     .await?;
+    ///
+    /// // Selected fields
+    /// let objs = client
+    ///     .get_objects_with_versions_masked(
+    ///         [(object_id, None)],
+    ///         ObjectReadMask::from(ObjectField::REFERENCE_OBJECT_ID),
+    ///     )
+    ///     .await?;
+    ///
+    /// for obj in objs.body() {
+    ///     let obj = match obj {
+    ///         Ok(obj) => obj,
+    ///         // Only this ID failed; the remaining objects are still usable
+    ///         Err(e) => {
+    ///             eprintln!("could not read object: {e}");
+    ///             continue;
+    ///         }
+    ///     };
+    ///
+    ///     // Convert proto object to SDK type
+    ///     let sdk_obj = obj.object()?;
+    ///     println!("Got object ID: {:?}", sdk_obj.id());
+    ///     let obj_ref = obj.object_reference()?;
+    ///     println!("Object version: {:?}", obj_ref.version());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_objects_with_versions_masked(
         &self,
         refs: impl IntoIterator<Item = (ObjectId, Option<Version>)>,
         read_mask: impl IntoReadMask<ObjectReadMask>,

--- a/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/service_info.rs
@@ -16,43 +16,60 @@ use crate::{
 impl Client {
     /// Get service info from the node.
     ///
-    /// Returns the [`GetServiceInfoResponse`] proto type with fields populated
-    /// according to the `read_mask`; use `ServiceInfoReadMask::default()` for
-    /// the default read mask, or pass a
-    /// [`ServiceInfoReadMask`](iota_grpc_types::read_mask_fields::ServiceInfoReadMask)
-    /// built from a
-    /// [`ServiceInfoField`](iota_grpc_types::read_mask_fields::ServiceInfoField)
-    /// or any slice/array/vec of fields.
+    /// Returns the [`GetServiceInfoResponse`] proto type populated with the
+    /// default field mask `ServiceInfoReadMask::default()`. Use
+    /// [`get_service_info_masked`](Self::get_service_info_masked) to specify a
+    /// custom mask.
     ///
     /// # Example
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::{ServiceInfoField, ServiceInfoReadMask};
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    ///
+    /// let info = client.get_service_info().await?;
+    /// println!("Chain ID: {:?}", info.body().chain_id);
+    /// println!("Epoch: {:?}", info.body().epoch);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_service_info(&self) -> Result<MetadataEnvelope<GetServiceInfoResponse>> {
+        self.get_service_info_internal(Default::default()).await
+    }
+
+    /// Get service info from the node, with a custom read mask.
+    ///
+    /// Pass a
+    /// [`ServiceInfoField`](iota_grpc_types::read_mask_fields::ServiceInfoField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::ServiceInfoField;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
     /// let info = client
-    ///     .get_service_info(ServiceInfoReadMask::default())
-    ///     .await?;
-    /// println!("Chain ID: {:?}", info.body().chain_id);
-    /// println!("Epoch: {:?}", info.body().epoch);
-    ///
-    /// // With a custom mask.
-    /// let info = client
-    ///     .get_service_info(ServiceInfoReadMask::from([
-    ///         ServiceInfoField::CHAIN_ID,
-    ///         ServiceInfoField::EPOCH,
-    ///     ]))
+    ///     .get_service_info_masked([ServiceInfoField::CHAIN_ID, ServiceInfoField::EPOCH])
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn get_service_info(
+    pub async fn get_service_info_masked(
         &self,
         read_mask: impl IntoReadMask<ServiceInfoReadMask>,
     ) -> Result<MetadataEnvelope<GetServiceInfoResponse>> {
-        let read_mask = read_mask.into_read_mask();
+        self.get_service_info_internal(read_mask.into_read_mask())
+            .await
+    }
+
+    async fn get_service_info_internal(
+        &self,
+        read_mask: ServiceInfoReadMask,
+    ) -> Result<MetadataEnvelope<GetServiceInfoResponse>> {
         let request = GetServiceInfoRequest::default().with_read_mask(read_mask);
 
         let mut client = self.ledger_service_client();

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -60,12 +60,9 @@ impl Client {
     ///
     /// # Read Mask
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `TransactionReadMask::default()` for the default field mask, or pass a
-    /// [`TransactionReadMask`](iota_grpc_types::read_mask_fields::TransactionReadMask)
-    /// built from a
-    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
-    /// or any slice/array/vec of fields.
+    /// Uses the default field mask `TransactionReadMask::default()`. Use
+    /// [`get_transactions_masked`](Self::get_transactions_masked) to specify a
+    /// custom mask.
     ///
     /// The `input_objects`, `output_objects`, `balance_changes` and
     /// `object_changes` fields (also included by wildcard masks) require the
@@ -79,16 +76,12 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::{TransactionField, TransactionReadMask};
     /// # use iota_types::TransactionDigest;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let digest: TransactionDigest = TransactionDigest::ZERO;
     ///
-    /// // Default mask
-    /// let txs = client
-    ///     .get_transactions([digest], TransactionReadMask::default())
-    ///     .await?;
+    /// let txs = client.get_transactions([digest]).await?;
     /// for tx in txs.body() {
     ///     let tx = match tx {
     ///         Ok(tx) => tx,
@@ -108,23 +101,56 @@ impl Client {
     ///     let checkpoint = tx.checkpoint_sequence_number()?;
     ///     println!("Checkpoint: {}", checkpoint);
     /// }
-    ///
-    /// // Selected fields
-    /// let txs = client
-    ///     .get_transactions(
-    ///         [digest],
-    ///         TransactionReadMask::from([TransactionField::EFFECTS, TransactionField::CHECKPOINT]),
-    ///     )
-    ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn get_transactions(
         &self,
         digests: impl IntoIterator<Item = TransactionDigest>,
+    ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
+        self.get_transactions_internal(digests.into_iter().collect(), Default::default())
+            .await
+    }
+
+    /// Get transactions by their digests, with a custom read mask.
+    ///
+    /// See [`get_transactions`](Self::get_transactions) for behavior. Pass a
+    /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use iota_sdk_grpc_client::Client;
+    /// # use iota_sdk_grpc_client::read_mask_fields::TransactionField;
+    /// # use iota_types::TransactionDigest;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let client = Client::new_localnet()?;
+    /// let digest: TransactionDigest = TransactionDigest::ZERO;
+    ///
+    /// let txs = client
+    ///     .get_transactions_masked(
+    ///         [digest],
+    ///         [TransactionField::EFFECTS, TransactionField::CHECKPOINT],
+    ///     )
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_transactions_masked(
+        &self,
+        digests: impl IntoIterator<Item = TransactionDigest>,
         read_mask: impl IntoReadMask<TransactionReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
-        let digests = digests.into_iter().collect::<Vec<_>>();
+        self.get_transactions_internal(digests.into_iter().collect(), read_mask.into_read_mask())
+            .await
+    }
+
+    async fn get_transactions_internal(
+        &self,
+        digests: Vec<TransactionDigest>,
+        read_mask: TransactionReadMask,
+    ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
         if digests.is_empty() {
             return Err(Error::EmptyRequest);
         }

--- a/crates/iota-sdk-grpc-client/src/api/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/mod.rs
@@ -212,12 +212,9 @@ impl CheckpointResponse {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::CheckpointResponseReadMask;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
-    /// let cp = client
-    ///     .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
-    ///     .await?;
+    /// let cp = client.get_checkpoint_latest(None, None).await?;
     /// let data = cp.body().checkpoint_data()?;
     /// # Ok(())
     /// # }

--- a/crates/iota-sdk-grpc-client/src/api/state/coins.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/coins.rs
@@ -56,15 +56,10 @@ impl Client {
     /// access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
-    /// Each returned [`Coin`] is converted from the underlying proto
-    /// `Object`. The `read_mask` controls which fields the server returns; use
-    /// `OwnedObjectReadMask::default()` for the default field mask (which
-    /// includes `bcs`, required for conversion), or pass an
-    /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
-    /// — it **must** include
-    /// [`OwnedObjectField::BCS`](iota_grpc_types::read_mask_fields::OwnedObjectField::BCS)
-    /// because the proto `Object` → SDK `Coin` conversion deserializes the BCS
-    /// payload.
+    /// Each returned [`Coin`] is converted from the underlying proto `Object`.
+    /// Uses the default field mask `OwnedObjectReadMask::default()`, which
+    /// includes the `bcs` field required for that conversion. Use
+    /// [`get_coins_masked`](Self::get_coins_masked) to specify a custom mask.
     ///
     /// # Parameters
     ///
@@ -74,22 +69,18 @@ impl Client {
     ///   types (with type `0x2::coin::Coin`).
     /// - `page_size` - Optional maximum number of coins per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
-    /// let page = client
-    ///     .get_coins(owner, None, None, None, OwnedObjectReadMask::default())
-    ///     .await?;
+    /// let page = client.get_coins(owner, None, None, None).await?;
     /// for coin in &page.body().items {
     ///     println!("Coin {}: {}", coin.id(), coin.balance());
     /// }
@@ -100,14 +91,13 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let all = client
-    ///     .get_coins(owner, None, Some(50), None, OwnedObjectReadMask::default())
+    ///     .get_coins(owner, None, Some(50), None)
     ///     .collect(Some(500))
     ///     .await?;
     /// for coin in all.body() {
@@ -117,6 +107,28 @@ impl Client {
     /// # }
     /// ```
     pub fn get_coins(
+        &self,
+        owner: Address,
+        coin_type: impl Into<Option<StructTag>>,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+    ) -> GetCoinsQuery {
+        self.get_coins_internal(
+            owner,
+            coin_type.into(),
+            page_size.into(),
+            page_token.into(),
+            Default::default(),
+        )
+    }
+
+    /// List coins owned by an address, with a custom read mask.
+    ///
+    /// See [`get_coins`](Self::get_coins) for behavior. The mask **must**
+    /// include [`OwnedObjectField::BCS`](iota_grpc_types::read_mask_fields::OwnedObjectField::BCS)
+    /// because the proto `Object` → SDK `Coin` conversion deserializes the BCS
+    /// payload.
+    pub fn get_coins_masked(
         &self,
         owner: Address,
         coin_type: impl Into<Option<StructTag>>,

--- a/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/dynamic_fields.rs
@@ -5,8 +5,9 @@
 //!
 //! # Read Mask
 //!
-//! Pass `DynamicFieldReadMask::default()` for the default mask, or a
-//! [`DynamicFieldReadMask`] built from a
+//! [`list_dynamic_fields`](Client::list_dynamic_fields) uses the default field
+//! mask `DynamicFieldReadMask::default()`. Use
+//! [`list_dynamic_fields_masked`](Client::list_dynamic_fields_masked) to pass a
 //! [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
 //! (or any slice/array/vec of fields).
 
@@ -46,34 +47,27 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `DynamicFieldReadMask::default()` for the default field mask, or pass a
-    /// [`DynamicFieldReadMask`](iota_grpc_types::read_mask_fields::DynamicFieldReadMask)
-    /// built from a
-    /// [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
-    /// or any slice/array/vec of fields.
+    /// Uses the default field mask `DynamicFieldReadMask::default()`. Use
+    /// [`list_dynamic_fields_masked`](Self::list_dynamic_fields_masked) to
+    /// specify a custom mask.
     ///
     /// # Parameters
     ///
     /// - `parent` - The object ID of the parent object.
     /// - `page_size` - Optional maximum number of fields per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::DynamicFieldReadMask;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
-    /// let page = client
-    ///     .list_dynamic_fields(parent, None, None, DynamicFieldReadMask::default())
-    ///     .await?;
+    /// let page = client.list_dynamic_fields(parent, None, None).await?;
     /// for field in &page.body().items {
     ///     println!("Dynamic field: {:?}", field);
     /// }
@@ -84,14 +78,13 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::DynamicFieldReadMask;
     /// # use iota_types::ObjectId;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let parent: ObjectId = "0x2".parse()?;
     ///
     /// let all = client
-    ///     .list_dynamic_fields(parent, Some(50), None, DynamicFieldReadMask::default())
+    ///     .list_dynamic_fields(parent, Some(50), None)
     ///     .collect(None)
     ///     .await?;
     /// for field in all.body() {
@@ -101,6 +94,26 @@ impl Client {
     /// # }
     /// ```
     pub fn list_dynamic_fields(
+        &self,
+        parent: ObjectId,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+    ) -> ListDynamicFieldsQuery {
+        self.list_dynamic_fields_internal(
+            parent,
+            page_size.into(),
+            page_token.into(),
+            Default::default(),
+        )
+    }
+
+    /// List dynamic fields owned by a parent object, with a custom read mask.
+    ///
+    /// See [`list_dynamic_fields`](Self::list_dynamic_fields) for behavior.
+    /// Pass a
+    /// [`DynamicFieldField`](iota_grpc_types::read_mask_fields::DynamicFieldField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub fn list_dynamic_fields_masked(
         &self,
         parent: ObjectId,
         page_size: impl Into<Option<u32>>,

--- a/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/state/owned_objects.rs
@@ -5,9 +5,10 @@
 //!
 //! # Read Mask
 //!
-//! Pass `OwnedObjectReadMask::default()` for the default mask, or an
-//! [`OwnedObjectReadMask`] built from
-//! an [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
+//! [`list_owned_objects`](Client::list_owned_objects) uses the default field
+//! mask `OwnedObjectReadMask::default()`. Use
+//! [`list_owned_objects_masked`](Client::list_owned_objects_masked) to pass an
+//! [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
 //! (or any slice/array/vec of fields).
 
 use iota_grpc_types::{
@@ -44,12 +45,9 @@ impl Client {
     /// (with access to `next_page_token`), or call `.collect(limit)` to
     /// auto-paginate through all results.
     ///
-    /// The `read_mask` controls which fields the server returns; use
-    /// `OwnedObjectReadMask::default()` for the default field mask, or pass an
-    /// [`OwnedObjectReadMask`](iota_grpc_types::read_mask_fields::OwnedObjectReadMask)
-    /// built from an
-    /// [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
-    /// or any slice/array/vec of fields.
+    /// Uses the default field mask `OwnedObjectReadMask::default()`. Use
+    /// [`list_owned_objects_masked`](Self::list_owned_objects_masked) to
+    /// specify a custom mask.
     ///
     /// # Parameters
     ///
@@ -57,22 +55,18 @@ impl Client {
     /// - `object_type` - Optional type filter as a [`StructTag`].
     /// - `page_size` - Optional maximum number of objects per page.
     /// - `page_token` - Optional continuation token from a previous page.
-    /// - `read_mask` - Field mask controlling the returned fields.
     ///
     /// # Examples
     ///
     /// Single page:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
-    /// let page = client
-    ///     .list_owned_objects(owner, None, None, None, OwnedObjectReadMask::default())
-    ///     .await?;
+    /// let page = client.list_owned_objects(owner, None, None, None).await?;
     /// for obj in &page.body().items {
     ///     println!("Owned object: {:?}", obj);
     /// }
@@ -83,14 +77,13 @@ impl Client {
     /// Auto-paginate:
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::OwnedObjectReadMask;
     /// # use iota_types::Address;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     /// let owner: Address = "0x1".parse()?;
     ///
     /// let all = client
-    ///     .list_owned_objects(owner, None, Some(50), None, OwnedObjectReadMask::default())
+    ///     .list_owned_objects(owner, None, Some(50), None)
     ///     .collect(Some(500))
     ///     .await?;
     /// for obj in all.body() {
@@ -100,6 +93,28 @@ impl Client {
     /// # }
     /// ```
     pub fn list_owned_objects(
+        &self,
+        owner: Address,
+        object_type: impl Into<Option<StructTag>>,
+        page_size: impl Into<Option<u32>>,
+        page_token: impl Into<Option<prost::bytes::Bytes>>,
+    ) -> ListOwnedObjectsQuery {
+        self.list_owned_objects_internal(
+            owner,
+            object_type.into(),
+            page_size.into(),
+            page_token.into(),
+            Default::default(),
+        )
+    }
+
+    /// List objects owned by an address, with a custom read mask.
+    ///
+    /// See [`list_owned_objects`](Self::list_owned_objects) for behavior. Pass
+    /// an
+    /// [`OwnedObjectField`](iota_grpc_types::read_mask_fields::OwnedObjectField)
+    /// or any slice/array/vec of fields — conversion is automatic.
+    pub fn list_owned_objects_masked(
         &self,
         owner: Address,
         object_type: impl Into<Option<StructTag>>,

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -23,9 +23,7 @@
 //! // The batched reads return one result per request, so a transaction the
 //! // node cannot serve fails only its own slot.
 //! let digest: TransactionDigest = todo!();
-//! let txs = client
-//!     .get_transactions([digest], TransactionReadMask::default())
-//!     .await?;
+//! let txs = client.get_transactions([digest]).await?;
 //! for tx in txs.body() {
 //!     match tx {
 //!         Ok(tx) => println!("Transaction digest: {:?}", tx.transaction()?.digest()?),
@@ -35,9 +33,7 @@
 //!
 //! // Get an object with the default field mask.
 //! let object_id: ObjectId = "0x2".parse()?;
-//! let objects = client
-//!     .get_objects([object_id], ObjectReadMask::default())
-//!     .await?;
+//! let objects = client.get_objects([object_id]).await?;
 //! for object in objects.body() {
 //!     match object {
 //!         Ok(object) => println!("Object version: {:?}", object.object_reference()?.version()),

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -6,10 +6,7 @@
 use std::time::Duration;
 
 use iota_grpc_types::{
-    read_mask_fields::{
-        EpochField, EpochReadMask, ExecuteTransactionReadMask, ObjectReadMask, OwnedObjectReadMask,
-        SimulateReadMask, TransactionField, TransactionReadMask,
-    },
+    read_mask_fields::{EpochField, TransactionField},
     v1::transaction_execution_service::SimulatedTransaction,
 };
 use iota_transaction_builder::{ObjectsPage, ProtocolConfig, TransactionBuilderClient, WaitForTx};
@@ -63,7 +60,7 @@ impl TransactionBuilderClient for Client {
         // Default read mask (`reference` + `bcs`) provides everything needed to
         // reconstruct the SDK object.
         let response = self
-            .get_objects_with_versions([(object_id, version.into())], ObjectReadMask::default())
+            .get_objects_with_versions([(object_id, version.into())])
             .await;
 
         match single_item(response)? {
@@ -82,7 +79,7 @@ impl TransactionBuilderClient for Client {
         // Default read mask (`reference` + `bcs`) provides everything needed to
         // reconstruct the SDK objects, which `get_objects` returns in request
         // order.
-        self.get_objects_with_versions(object_ids.iter().copied(), ObjectReadMask::default())
+        self.get_objects_with_versions(object_ids.iter().copied())
             .await?
             .into_inner()
             .into_iter()
@@ -107,7 +104,6 @@ impl TransactionBuilderClient for Client {
                 struct_tag,
                 limit.map(saturating_usize_to_u32),
                 cursor.map(prost::bytes::Bytes::from),
-                OwnedObjectReadMask::default(),
             )
             .await?
             .into_inner();
@@ -122,10 +118,7 @@ impl TransactionBuilderClient for Client {
 
     async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
         let epoch = self
-            .get_epoch(
-                None,
-                EpochReadMask::from(EpochField::PROTOCOL_CONFIG_ATTRIBUTES),
-            )
+            .get_epoch_masked(None, EpochField::PROTOCOL_CONFIG_ATTRIBUTES)
             .await?
             .into_inner();
         let attributes = epoch
@@ -141,12 +134,9 @@ impl TransactionBuilderClient for Client {
         digest: TransactionDigest,
     ) -> Result<Option<SignedTransaction>, Self::Error> {
         let response = self
-            .get_transactions(
+            .get_transactions_masked(
                 [digest],
-                TransactionReadMask::from([
-                    TransactionField::TRANSACTION,
-                    TransactionField::SIGNATURES,
-                ]),
+                [TransactionField::TRANSACTION, TransactionField::SIGNATURES],
             )
             .await;
 
@@ -168,10 +158,7 @@ impl TransactionBuilderClient for Client {
         digest: TransactionDigest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
         let response = self
-            .get_transactions(
-                [digest],
-                TransactionReadMask::from(TransactionField::EFFECTS_BCS),
-            )
+            .get_transactions_masked([digest], TransactionField::EFFECTS_BCS)
             .await;
 
         match single_item(response)? {
@@ -185,10 +172,7 @@ impl TransactionBuilderClient for Client {
         epoch: impl Into<Option<u64>>,
     ) -> Result<Option<u64>, Self::Error> {
         let epoch = self
-            .get_epoch(
-                epoch.into(),
-                EpochReadMask::from(EpochField::REFERENCE_GAS_PRICE),
-            )
+            .get_epoch_masked(epoch.into(), EpochField::REFERENCE_GAS_PRICE)
             .await?
             .into_inner();
         Ok(epoch.reference_gas_price)
@@ -197,9 +181,7 @@ impl TransactionBuilderClient for Client {
     async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
         // Simulate with relaxed checks and read the gas used from the resulting
         // effects.
-        let simulated = self
-            .simulate_transaction(tx.clone(), true, SimulateReadMask::default())
-            .await?;
+        let simulated = self.simulate_transaction(tx.clone(), true).await?;
         let effects = simulated
             .into_inner()
             .executed_transaction()?
@@ -219,7 +201,7 @@ impl TransactionBuilderClient for Client {
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
         Ok(self
-            .simulate_transaction(tx.clone(), skip_checks, SimulateReadMask::default())
+            .simulate_transaction(tx.clone(), skip_checks)
             .await?
             .into_inner())
     }
@@ -237,11 +219,7 @@ impl TransactionBuilderClient for Client {
         };
         // The default execute read mask includes `effects`.
         let result = self
-            .execute_transaction(
-                signed_transaction,
-                None,
-                ExecuteTransactionReadMask::default(),
-            )
+            .execute_transaction(signed_transaction, None)
             .await?
             .into_inner();
         let effects = result.effects()?.effects()?;
@@ -262,10 +240,8 @@ impl TransactionBuilderClient for Client {
         // transaction field confirms it is indexed on the node, while
         // `checkpoint` is only populated once it has been finalized.
         let mask = match wait_for {
-            WaitForTx::IndexedOnNode => {
-                TransactionReadMask::from(TransactionField::TRANSACTION_DIGEST)
-            }
-            WaitForTx::Finalized => TransactionReadMask::from(TransactionField::CHECKPOINT),
+            WaitForTx::IndexedOnNode => TransactionField::TRANSACTION_DIGEST,
+            WaitForTx::Finalized => TransactionField::CHECKPOINT,
             _ => {
                 unimplemented!("a new WaitForTx enum variant was added and needs to be handled")
             }
@@ -275,7 +251,7 @@ impl TransactionBuilderClient for Client {
             let mut interval = tokio::time::interval(WAIT_FOR_TX_POLL_INTERVAL);
             loop {
                 interval.tick().await;
-                let response = self.get_transactions([digest], mask.clone()).await;
+                let response = self.get_transactions_masked([digest], mask.clone()).await;
 
                 // An absent transaction is not indexed yet — keep polling.
                 if let Some(tx) = single_item(response)? {

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -11,17 +11,17 @@
 //! matching kind — conversion happens automatically:
 //!
 //! ```ignore
-//! use iota_sdk_grpc_types::read_mask_fields::{ObjectField, ObjectReadMask};
+//! use iota_sdk_grpc_types::read_mask_fields::ObjectField;
 //!
 //! // Default mask.
-//! client.get_objects([id], ObjectReadMask::default()).await?;
+//! client.get_objects([id]).await?;
 //!
 //! // A single field.
-//! client.get_objects([id], ObjectField::BCS).await?;
+//! client.get_objects_masked([id], ObjectField::BCS).await?;
 //!
 //! // Multiple fields.
 //! client
-//!     .get_objects([id], [ObjectField::REFERENCE, ObjectField::BCS])
+//!     .get_objects_masked([id], [ObjectField::REFERENCE, ObjectField::BCS])
 //!     .await?;
 //! ```
 //!
@@ -642,8 +642,8 @@ define_field_paths! {
 }
 
 define_scoped_read_mask! {
-    /// Scoped read mask for checkpoint queries (`get_checkpoint_*`,
-    /// `stream_checkpoints`, `stream_checkpoints_filtered`).
+    /// Scoped read mask for checkpoint queries (`get_checkpoint_*_masked`,
+    /// `stream_checkpoints_masked`, `stream_checkpoints_filtered_masked`).
     pub struct CheckpointResponseReadMask from CheckpointResponseField default GET_CHECKPOINT_READ_MASK;
 }
 

--- a/crates/iota-sdk/examples/chain_id_grpc.rs
+++ b/crates/iota-sdk/examples/chain_id_grpc.rs
@@ -9,16 +9,14 @@
 //! you observed).
 
 use eyre::{OptionExt, Result};
-use iota_sdk::grpc_client::{Client, ResponseExt, read_mask_fields::ServiceInfoReadMask};
+use iota_sdk::grpc_client::{Client, ResponseExt};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_testnet()?;
 
     // Option 1: explicit service info RPC.
-    let info = client
-        .get_service_info(ServiceInfoReadMask::default())
-        .await?;
+    let info = client.get_service_info().await?;
     let chain_id = info
         .body()
         .chain_id

--- a/crates/iota-sdk/examples/get_object_grpc.rs
+++ b/crates/iota-sdk/examples/get_object_grpc.rs
@@ -11,7 +11,7 @@
 
 use eyre::{Result, bail};
 use iota_sdk::{
-    grpc_client::{Client, read_mask_fields::ObjectReadMask},
+    grpc_client::Client,
     types::{ObjectId, Owner},
 };
 
@@ -22,9 +22,7 @@ async fn main() -> Result<()> {
     let object_id: ObjectId =
         "0x541b117cac18fb1c07a293db300acd12b05c01fa81232b37151b005ca7d4f755".parse()?;
 
-    let response = client
-        .get_objects([object_id], ObjectReadMask::default())
-        .await?;
+    let response = client.get_objects([object_id]).await?;
     // Each requested id gets its own result, so a failure here concerns only
     // this object.
     let proto_obj = match response.body().first() {

--- a/crates/iota-sdk/examples/owned_objects_grpc.rs
+++ b/crates/iota-sdk/examples/owned_objects_grpc.rs
@@ -10,7 +10,7 @@
 
 use eyre::Result;
 use iota_sdk::{
-    grpc_client::{Client, read_mask_fields::OwnedObjectReadMask},
+    grpc_client::Client,
     types::{Address, StructTag},
 };
 
@@ -23,9 +23,7 @@ async fn main() -> Result<()> {
 
     // First page: 10 results, no filter on type. The returned page includes
     // a `next_page_token` to feed back in for the following page.
-    let page = client
-        .list_owned_objects(owner, None, 10, None, OwnedObjectReadMask::default())
-        .await?;
+    let page = client.list_owned_objects(owner, None, 10, None).await?;
     println!("First page: {} objects", page.body().items.len());
     for obj in &page.body().items {
         println!("  {}", obj.object_reference()?.object_id);
@@ -37,7 +35,7 @@ async fn main() -> Result<()> {
     // Auto-paginate: only IOTA coins, capped at 50 across all pages.
     let iota_coin: StructTag = "0x2::coin::Coin<0x2::iota::IOTA>".parse()?;
     let coins = client
-        .list_owned_objects(owner, iota_coin, 25, None, OwnedObjectReadMask::default())
+        .list_owned_objects(owner, iota_coin, 25, None)
         .collect(Some(50))
         .await?;
     println!("---");

--- a/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
+++ b/crates/iota-sdk/examples/stream_checkpoints_grpc.rs
@@ -9,10 +9,7 @@
 
 use eyre::Result;
 use futures::StreamExt;
-use iota_sdk::grpc_client::{
-    Client,
-    read_mask_fields::{CheckpointResponseField, CheckpointResponseReadMask},
-};
+use iota_sdk::grpc_client::{Client, read_mask_fields::CheckpointResponseField};
 
 const HOW_MANY: u64 = 5;
 
@@ -23,7 +20,7 @@ async fn main() -> Result<()> {
     // Pick a starting point a few checkpoints behind head so the example
     // returns promptly instead of waiting on new blocks.
     let head = client
-        .get_checkpoint_latest(None, None, CheckpointResponseReadMask::default())
+        .get_checkpoint_latest(None, None)
         .await?
         .body()
         .sequence_number();
@@ -34,7 +31,7 @@ async fn main() -> Result<()> {
     // `CheckpointResponseReadMask::default()` (or compose more fields) to
     // pull more data per checkpoint.
     let mut stream = client
-        .stream_checkpoints(
+        .stream_checkpoints_masked(
             start,
             end,
             None,


### PR DESCRIPTION
Split out of #1147. **Stacked on #1253** — review/merge that one first; this PR's diff is only the `_masked` split.

## Why
Adds ergonomic, mask-explicit variants of the gRPC query methods so callers can pass a bare field / slice / array / vec of fields without wrapping in a `XxxReadMask`.

## What
Splits each query endpoint into two methods:
- the plain method uses the endpoint's default read mask (its read-mask parameter is dropped), and
- a new `_masked` variant takes an explicit `impl Into<XxxReadMask>`.

Internal callers (`transaction_builder_client`, examples) use the `_masked` variants where a custom mask is required.

## Test plan
- `cargo check`/`clippy -Dwarnings` clean for `iota-sdk-grpc-client` (+ tests) and `iota-sdk --features grpc --examples`.
- `cargo test --doc` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)