### PR TITLE
feat: add `balance_changes` and `object_changes` to `ExecutedTransaction` proto

### DIFF
--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -30,6 +30,8 @@ impl Client {
     /// - `result.events()` - Get transaction events (if available)
     /// - `result.input_objects()` - Get input objects (if requested)
     /// - `result.output_objects()` - Get output objects (if requested)
+    /// - `result.balance_changes()` - Get balance changes (if requested)
+    /// - `result.object_changes()` - Get object changes (if requested)
     ///
     /// # Read Mask
     ///

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -51,6 +51,10 @@ impl Client {
     ///   (if requested)
     /// - `result.executed_transaction()?.output_objects()` - Get output objects
     ///   (if requested)
+    /// - `result.executed_transaction()?.balance_changes()` - Get balance
+    ///   changes (if requested)
+    /// - `result.executed_transaction()?.object_changes()` - Get object changes
+    ///   (if requested)
     ///
     /// # Read Mask
     ///

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -45,6 +45,14 @@ impl Client {
     /// Use [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// constants with [`ReadMask::from`] for field selection.
     ///
+    /// The `input_objects`, `output_objects`, `balance_changes` and
+    /// `object_changes` fields (also included by wildcard masks) require the
+    /// serving node to still have the transaction's objects. If one has been
+    /// pruned, the transaction's result is a `FAILED_PRECONDITION` error
+    /// instead of a silently incomplete answer — narrow the read mask, or
+    /// fetch objects individually via
+    /// [`get_objects`](Client::get_objects) for best-effort retrieval.
+    ///
     /// # Example
     ///
     /// ```no_run

--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/transaction.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/transaction.proto
@@ -121,10 +121,11 @@ message BalanceChange {
   // The type of the coin, e.g. `0x2::iota::IOTA`.
   optional iota.grpc.v1.types.TypeTag coin_type = 2;
 
-  // The amount the balance changed by, encoded as a decimal string
-  // (128-bit signed integer). A negative amount means the net flow of
-  // value is away from the owner.
-  optional string amount = 3;
+  // The amount the balance changed by: a 128-bit signed integer in
+  // big-endian two's-complement encoding (exactly 16 bytes,
+  // `i128::to_be_bytes`). A negative amount means the net flow of value is
+  // away from the owner.
+  optional bytes amount = 3;
 }
 
 // A list of balance changes.
@@ -163,7 +164,7 @@ message ObjectChangeMutated {
   optional iota.grpc.v1.types.Owner owner = 2;
 
   // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-  optional string object_type = 3;
+  optional iota.grpc.v1.types.TypeTag object_type = 3;
 
   // The ID of the object.
   optional iota.grpc.v1.types.ObjectId object_id = 4;
@@ -186,7 +187,7 @@ message ObjectChangeDeleted {
   optional iota.grpc.v1.types.Address sender = 1;
 
   // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-  optional string object_type = 2;
+  optional iota.grpc.v1.types.TypeTag object_type = 2;
 
   // The ID of the object.
   optional iota.grpc.v1.types.ObjectId object_id = 3;
@@ -203,7 +204,7 @@ message ObjectChangeWrapped {
   optional iota.grpc.v1.types.Address sender = 1;
 
   // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-  optional string object_type = 2;
+  optional iota.grpc.v1.types.TypeTag object_type = 2;
 
   // The ID of the object.
   optional iota.grpc.v1.types.ObjectId object_id = 3;
@@ -223,7 +224,7 @@ message ObjectChangeUnwrapped {
   optional iota.grpc.v1.types.Owner owner = 2;
 
   // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-  optional string object_type = 3;
+  optional iota.grpc.v1.types.TypeTag object_type = 3;
 
   // The ID of the object.
   optional iota.grpc.v1.types.ObjectId object_id = 4;
@@ -246,7 +247,7 @@ message ObjectChangeCreated {
   optional iota.grpc.v1.types.Owner owner = 2;
 
   // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-  optional string object_type = 3;
+  optional iota.grpc.v1.types.TypeTag object_type = 3;
 
   // The ID of the object.
   optional iota.grpc.v1.types.ObjectId object_id = 4;

--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/transaction.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/transaction.proto
@@ -77,10 +77,207 @@ message ExecutedTransaction {
   optional google.protobuf.Timestamp timestamp = 6;
 
   // Set of input objects used by this transaction.
+  //
+  // The returned set is always complete: if the serving node no longer has
+  // one of the objects (e.g. pruned), requesting this field fails with
+  // `FAILED_PRECONDITION` instead of returning a silently shortened list.
+  // Narrow the read mask, or fetch objects individually via `GetObjects`
+  // for best-effort retrieval.
   optional iota.grpc.v1.object.Objects input_objects = 7;
 
   // Set of output objects produced by this transaction.
+  //
+  // The returned set is always complete: if the serving node no longer has
+  // one of the objects (e.g. pruned), requesting this field fails with
+  // `FAILED_PRECONDITION` instead of returning a silently shortened list.
+  // Narrow the read mask, or fetch objects individually via `GetObjects`
+  // for best-effort retrieval.
   optional iota.grpc.v1.object.Objects output_objects = 8;
+
+  // The balance changes caused by this transaction.
+  //
+  // Derived from the transaction's effects and input/output objects. If the
+  // serving node no longer has a required object (e.g. pruned), requesting
+  // this field fails with `FAILED_PRECONDITION` instead of returning a
+  // silently wrong result; retry without this field in the read mask.
+  optional BalanceChanges balance_changes = 9;
+
+  // The object changes caused by this transaction.
+  //
+  // Derived from the transaction's effects and input/output objects. If the
+  // serving node no longer has a required object (e.g. pruned), requesting
+  // this field fails with `FAILED_PRECONDITION` instead of returning a
+  // silently incomplete result; retry without this field in the read mask.
+  optional ObjectChanges object_changes = 10;
+}
+
+// The delta, or change, in balance of a particular coin type for an owner.
+message BalanceChange {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The owner whose balance changed.
+  optional iota.grpc.v1.types.Owner owner = 1;
+
+  // The type of the coin, e.g. `0x2::iota::IOTA`.
+  optional iota.grpc.v1.types.TypeTag coin_type = 2;
+
+  // The amount the balance changed by, encoded as a decimal string
+  // (128-bit signed integer). A negative amount means the net flow of
+  // value is away from the owner.
+  optional string amount = 3;
+}
+
+// A list of balance changes.
+message BalanceChanges {
+  option (iota.grpc.message_accessors) = "with";
+  option (iota.grpc.field_mask_transparent) = true;
+
+  repeated BalanceChange balance_changes = 1;
+}
+
+// A package was published.
+message ObjectChangePublished {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The ID of the published package.
+  optional iota.grpc.v1.types.ObjectId package_id = 1;
+
+  // The version of the published package.
+  optional uint64 version = 2;
+
+  // The digest of the published package.
+  optional iota.grpc.v1.types.Digest digest = 3;
+
+  // The set of modules in the published package.
+  repeated string modules = 4;
+}
+
+// An object was mutated.
+message ObjectChangeMutated {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The sender of the transaction.
+  optional iota.grpc.v1.types.Address sender = 1;
+
+  // The owner of the object.
+  optional iota.grpc.v1.types.Owner owner = 2;
+
+  // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+  optional string object_type = 3;
+
+  // The ID of the object.
+  optional iota.grpc.v1.types.ObjectId object_id = 4;
+
+  // The version of the object.
+  optional uint64 version = 5;
+
+  // The version of the object before it was mutated.
+  optional uint64 previous_version = 6;
+
+  // The digest of the object.
+  optional iota.grpc.v1.types.Digest digest = 7;
+}
+
+// An object was deleted.
+message ObjectChangeDeleted {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The sender of the transaction.
+  optional iota.grpc.v1.types.Address sender = 1;
+
+  // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+  optional string object_type = 2;
+
+  // The ID of the object.
+  optional iota.grpc.v1.types.ObjectId object_id = 3;
+
+  // The version the object was deleted at.
+  optional uint64 version = 4;
+}
+
+// An object was wrapped inside another object.
+message ObjectChangeWrapped {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The sender of the transaction.
+  optional iota.grpc.v1.types.Address sender = 1;
+
+  // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+  optional string object_type = 2;
+
+  // The ID of the object.
+  optional iota.grpc.v1.types.ObjectId object_id = 3;
+
+  // The version the object was wrapped at.
+  optional uint64 version = 4;
+}
+
+// An object was unwrapped from inside another object.
+message ObjectChangeUnwrapped {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The sender of the transaction.
+  optional iota.grpc.v1.types.Address sender = 1;
+
+  // The owner of the object.
+  optional iota.grpc.v1.types.Owner owner = 2;
+
+  // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+  optional string object_type = 3;
+
+  // The ID of the object.
+  optional iota.grpc.v1.types.ObjectId object_id = 4;
+
+  // The version of the object.
+  optional uint64 version = 5;
+
+  // The digest of the object.
+  optional iota.grpc.v1.types.Digest digest = 6;
+}
+
+// A new object was created.
+message ObjectChangeCreated {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The sender of the transaction.
+  optional iota.grpc.v1.types.Address sender = 1;
+
+  // The owner of the object.
+  optional iota.grpc.v1.types.Owner owner = 2;
+
+  // The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+  optional string object_type = 3;
+
+  // The ID of the object.
+  optional iota.grpc.v1.types.ObjectId object_id = 4;
+
+  // The version of the object.
+  optional uint64 version = 5;
+
+  // The digest of the object.
+  optional iota.grpc.v1.types.Digest digest = 6;
+}
+
+// A change to an object caused by executing a transaction.
+message ObjectChange {
+  option (iota.grpc.message_accessors) = "with";
+
+  oneof kind {
+    ObjectChangePublished published = 1;
+    ObjectChangeMutated mutated = 2;
+    ObjectChangeDeleted deleted = 3;
+    ObjectChangeWrapped wrapped = 4;
+    ObjectChangeUnwrapped unwrapped = 5;
+    ObjectChangeCreated created = 6;
+  }
+}
+
+// A list of object changes.
+message ObjectChanges {
+  option (iota.grpc.message_accessors) = "with";
+  option (iota.grpc.field_mask_transparent) = true;
+
+  repeated ObjectChange object_changes = 1;
 }
 
 message ExecutedTransactions {

--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/types.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/types.proto
@@ -40,6 +40,23 @@ message ObjectReference {
   optional Digest digest = 3;
 }
 
+// Ownership information for an object.
+message Owner {
+  option (iota.grpc.message_accessors) = "with";
+
+  oneof kind {
+    // Object is exclusively owned by a single address, and is mutable.
+    Address address_owner = 1;
+    // Object is exclusively owned by a single object, and is mutable.
+    ObjectId object_owner = 2;
+    // Object is shared and can be used by any address. The value is the
+    // version at which the object became shared.
+    uint64 shared = 3;
+    // Object is immutable, and hence ownership doesn't matter.
+    bool immutable = 4;
+  }
+}
+
 message TypeTagVector {
   TypeTag inner_type = 1;
 }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.accessors.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.accessors.rs
@@ -22,7 +22,7 @@ mod _accessor_impls {
             self
         }
         /// Sets `amount` with the provided value.
-        pub fn with_amount<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_amount<T: Into<::prost::bytes::Bytes>>(mut self, field: T) -> Self {
             self.amount = Some(field.into());
             self
         }
@@ -197,7 +197,10 @@ mod _accessor_impls {
             self
         }
         /// Sets `object_type` with the provided value.
-        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_object_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
             self.object_type = Some(field.into());
             self
         }
@@ -233,7 +236,10 @@ mod _accessor_impls {
             self
         }
         /// Sets `object_type` with the provided value.
-        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_object_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
             self.object_type = Some(field.into());
             self
         }
@@ -269,7 +275,10 @@ mod _accessor_impls {
             self
         }
         /// Sets `object_type` with the provided value.
-        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_object_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
             self.object_type = Some(field.into());
             self
         }
@@ -346,7 +355,10 @@ mod _accessor_impls {
             self
         }
         /// Sets `object_type` with the provided value.
-        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_object_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
             self.object_type = Some(field.into());
             self
         }
@@ -382,7 +394,10 @@ mod _accessor_impls {
             self
         }
         /// Sets `object_type` with the provided value.
-        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+        pub fn with_object_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
             self.object_type = Some(field.into());
             self
         }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.accessors.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.accessors.rs
@@ -4,6 +4,36 @@
 
 mod _accessor_impls {
     #![allow(clippy::useless_conversion)]
+    impl super::BalanceChange {
+        /// Sets `owner` with the provided value.
+        pub fn with_owner<T: Into<super::super::types::Owner>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.owner = Some(field.into());
+            self
+        }
+        /// Sets `coin_type` with the provided value.
+        pub fn with_coin_type<T: Into<super::super::types::TypeTag>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.coin_type = Some(field.into());
+            self
+        }
+        /// Sets `amount` with the provided value.
+        pub fn with_amount<T: Into<String>>(mut self, field: T) -> Self {
+            self.amount = Some(field.into());
+            self
+        }
+    }
+    impl super::BalanceChanges {
+        /// Sets `balance_changes` with the provided value.
+        pub fn with_balance_changes(mut self, field: Vec<super::BalanceChange>) -> Self {
+            self.balance_changes = field;
+            self
+        }
+    }
     impl super::ExecutedTransaction {
         /// Sets `transaction` with the provided value.
         pub fn with_transaction<T: Into<super::Transaction>>(
@@ -66,6 +96,22 @@ mod _accessor_impls {
             self.output_objects = Some(field.into());
             self
         }
+        /// Sets `balance_changes` with the provided value.
+        pub fn with_balance_changes<T: Into<super::BalanceChanges>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.balance_changes = Some(field.into());
+            self
+        }
+        /// Sets `object_changes` with the provided value.
+        pub fn with_object_changes<T: Into<super::ObjectChanges>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_changes = Some(field.into());
+            self
+        }
     }
     impl super::ExecutedTransactions {
         /// Sets `executed_transactions` with the provided value.
@@ -74,6 +120,290 @@ mod _accessor_impls {
             field: Vec<super::ExecutedTransaction>,
         ) -> Self {
             self.executed_transactions = field;
+            self
+        }
+    }
+    impl super::ObjectChange {
+        /// Sets `published` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_published<T: Into<super::ObjectChangePublished>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Published(field.into()));
+            self
+        }
+        /// Sets `mutated` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_mutated<T: Into<super::ObjectChangeMutated>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Mutated(field.into()));
+            self
+        }
+        /// Sets `deleted` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_deleted<T: Into<super::ObjectChangeDeleted>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Deleted(field.into()));
+            self
+        }
+        /// Sets `wrapped` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_wrapped<T: Into<super::ObjectChangeWrapped>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Wrapped(field.into()));
+            self
+        }
+        /// Sets `unwrapped` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_unwrapped<T: Into<super::ObjectChangeUnwrapped>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Unwrapped(field.into()));
+            self
+        }
+        /// Sets `created` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_created<T: Into<super::ObjectChangeCreated>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.kind = Some(super::object_change::Kind::Created(field.into()));
+            self
+        }
+    }
+    impl super::ObjectChangeCreated {
+        /// Sets `sender` with the provided value.
+        pub fn with_sender<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.sender = Some(field.into());
+            self
+        }
+        /// Sets `owner` with the provided value.
+        pub fn with_owner<T: Into<super::super::types::Owner>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.owner = Some(field.into());
+            self
+        }
+        /// Sets `object_type` with the provided value.
+        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+            self.object_type = Some(field.into());
+            self
+        }
+        /// Sets `object_id` with the provided value.
+        pub fn with_object_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+        /// Sets `digest` with the provided value.
+        pub fn with_digest<T: Into<super::super::types::Digest>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.digest = Some(field.into());
+            self
+        }
+    }
+    impl super::ObjectChangeDeleted {
+        /// Sets `sender` with the provided value.
+        pub fn with_sender<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.sender = Some(field.into());
+            self
+        }
+        /// Sets `object_type` with the provided value.
+        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+            self.object_type = Some(field.into());
+            self
+        }
+        /// Sets `object_id` with the provided value.
+        pub fn with_object_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+    }
+    impl super::ObjectChangeMutated {
+        /// Sets `sender` with the provided value.
+        pub fn with_sender<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.sender = Some(field.into());
+            self
+        }
+        /// Sets `owner` with the provided value.
+        pub fn with_owner<T: Into<super::super::types::Owner>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.owner = Some(field.into());
+            self
+        }
+        /// Sets `object_type` with the provided value.
+        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+            self.object_type = Some(field.into());
+            self
+        }
+        /// Sets `object_id` with the provided value.
+        pub fn with_object_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+        /// Sets `previous_version` with the provided value.
+        pub fn with_previous_version(mut self, field: u64) -> Self {
+            self.previous_version = Some(field);
+            self
+        }
+        /// Sets `digest` with the provided value.
+        pub fn with_digest<T: Into<super::super::types::Digest>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.digest = Some(field.into());
+            self
+        }
+    }
+    impl super::ObjectChangePublished {
+        /// Sets `package_id` with the provided value.
+        pub fn with_package_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.package_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+        /// Sets `digest` with the provided value.
+        pub fn with_digest<T: Into<super::super::types::Digest>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.digest = Some(field.into());
+            self
+        }
+        /// Sets `modules` with the provided value.
+        pub fn with_modules(mut self, field: Vec<String>) -> Self {
+            self.modules = field;
+            self
+        }
+    }
+    impl super::ObjectChangeUnwrapped {
+        /// Sets `sender` with the provided value.
+        pub fn with_sender<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.sender = Some(field.into());
+            self
+        }
+        /// Sets `owner` with the provided value.
+        pub fn with_owner<T: Into<super::super::types::Owner>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.owner = Some(field.into());
+            self
+        }
+        /// Sets `object_type` with the provided value.
+        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+            self.object_type = Some(field.into());
+            self
+        }
+        /// Sets `object_id` with the provided value.
+        pub fn with_object_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+        /// Sets `digest` with the provided value.
+        pub fn with_digest<T: Into<super::super::types::Digest>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.digest = Some(field.into());
+            self
+        }
+    }
+    impl super::ObjectChangeWrapped {
+        /// Sets `sender` with the provided value.
+        pub fn with_sender<T: Into<super::super::types::Address>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.sender = Some(field.into());
+            self
+        }
+        /// Sets `object_type` with the provided value.
+        pub fn with_object_type<T: Into<String>>(mut self, field: T) -> Self {
+            self.object_type = Some(field.into());
+            self
+        }
+        /// Sets `object_id` with the provided value.
+        pub fn with_object_id<T: Into<super::super::types::ObjectId>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.object_id = Some(field.into());
+            self
+        }
+        /// Sets `version` with the provided value.
+        pub fn with_version(mut self, field: u64) -> Self {
+            self.version = Some(field);
+            self
+        }
+    }
+    impl super::ObjectChanges {
+        /// Sets `object_changes` with the provided value.
+        pub fn with_object_changes(mut self, field: Vec<super::ObjectChange>) -> Self {
+            self.object_changes = field;
             self
         }
     }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.field_info.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.field_info.rs
@@ -565,7 +565,7 @@ mod _field_impls {
             number: 3i32,
             is_optional: true,
             is_map: false,
-            message_fields: None,
+            message_fields: Some(TypeTag::FIELDS),
         };
         pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
             name: "object_id",
@@ -639,9 +639,9 @@ mod _field_impls {
             self.path.push(ObjectChangeMutated::OWNER_FIELD.name);
             OwnerFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn object_type(mut self) -> String {
+        pub fn object_type(mut self) -> TypeTagFieldPathBuilder {
             self.path.push(ObjectChangeMutated::OBJECT_TYPE_FIELD.name);
-            self.finish()
+            TypeTagFieldPathBuilder::new_with_base(self.path)
         }
         pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
             self.path.push(ObjectChangeMutated::OBJECT_ID_FIELD.name);
@@ -675,7 +675,7 @@ mod _field_impls {
             number: 2i32,
             is_optional: true,
             is_map: false,
-            message_fields: None,
+            message_fields: Some(TypeTag::FIELDS),
         };
         pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
             name: "object_id",
@@ -726,9 +726,9 @@ mod _field_impls {
             self.path.push(ObjectChangeDeleted::SENDER_FIELD.name);
             AddressFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn object_type(mut self) -> String {
+        pub fn object_type(mut self) -> TypeTagFieldPathBuilder {
             self.path.push(ObjectChangeDeleted::OBJECT_TYPE_FIELD.name);
-            self.finish()
+            TypeTagFieldPathBuilder::new_with_base(self.path)
         }
         pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
             self.path.push(ObjectChangeDeleted::OBJECT_ID_FIELD.name);
@@ -754,7 +754,7 @@ mod _field_impls {
             number: 2i32,
             is_optional: true,
             is_map: false,
-            message_fields: None,
+            message_fields: Some(TypeTag::FIELDS),
         };
         pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
             name: "object_id",
@@ -805,9 +805,9 @@ mod _field_impls {
             self.path.push(ObjectChangeWrapped::SENDER_FIELD.name);
             AddressFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn object_type(mut self) -> String {
+        pub fn object_type(mut self) -> TypeTagFieldPathBuilder {
             self.path.push(ObjectChangeWrapped::OBJECT_TYPE_FIELD.name);
-            self.finish()
+            TypeTagFieldPathBuilder::new_with_base(self.path)
         }
         pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
             self.path.push(ObjectChangeWrapped::OBJECT_ID_FIELD.name);
@@ -841,7 +841,7 @@ mod _field_impls {
             number: 3i32,
             is_optional: true,
             is_map: false,
-            message_fields: None,
+            message_fields: Some(TypeTag::FIELDS),
         };
         pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
             name: "object_id",
@@ -906,9 +906,9 @@ mod _field_impls {
             self.path.push(ObjectChangeUnwrapped::OWNER_FIELD.name);
             OwnerFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn object_type(mut self) -> String {
+        pub fn object_type(mut self) -> TypeTagFieldPathBuilder {
             self.path.push(ObjectChangeUnwrapped::OBJECT_TYPE_FIELD.name);
-            self.finish()
+            TypeTagFieldPathBuilder::new_with_base(self.path)
         }
         pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
             self.path.push(ObjectChangeUnwrapped::OBJECT_ID_FIELD.name);
@@ -946,7 +946,7 @@ mod _field_impls {
             number: 3i32,
             is_optional: true,
             is_map: false,
-            message_fields: None,
+            message_fields: Some(TypeTag::FIELDS),
         };
         pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
             name: "object_id",
@@ -1011,9 +1011,9 @@ mod _field_impls {
             self.path.push(ObjectChangeCreated::OWNER_FIELD.name);
             OwnerFieldPathBuilder::new_with_base(self.path)
         }
-        pub fn object_type(mut self) -> String {
+        pub fn object_type(mut self) -> TypeTagFieldPathBuilder {
             self.path.push(ObjectChangeCreated::OBJECT_TYPE_FIELD.name);
-            self.finish()
+            TypeTagFieldPathBuilder::new_with_base(self.path)
         }
         pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
             self.path.push(ObjectChangeCreated::OBJECT_ID_FIELD.name);

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.field_info.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.field_info.rs
@@ -24,9 +24,25 @@ mod _field_impls {
     #[allow(unused_imports)]
     use crate::v1::signatures::UserSignatureFieldPathBuilder;
     #[allow(unused_imports)]
+    use crate::v1::types::Address;
+    #[allow(unused_imports)]
+    use crate::v1::types::AddressFieldPathBuilder;
+    #[allow(unused_imports)]
     use crate::v1::types::Digest;
     #[allow(unused_imports)]
     use crate::v1::types::DigestFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::types::ObjectId;
+    #[allow(unused_imports)]
+    use crate::v1::types::ObjectIdFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::types::Owner;
+    #[allow(unused_imports)]
+    use crate::v1::types::OwnerFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::types::TypeTag;
+    #[allow(unused_imports)]
+    use crate::v1::types::TypeTagFieldPathBuilder;
     impl Transaction {
         pub const DIGEST_FIELD: &'static MessageField = &MessageField {
             name: "digest",
@@ -251,6 +267,22 @@ mod _field_impls {
             is_map: false,
             message_fields: Some(Object::FIELDS),
         };
+        pub const BALANCE_CHANGES_FIELD: &'static MessageField = &MessageField {
+            name: "balance_changes",
+            json_name: "balanceChanges",
+            number: 9i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(BalanceChange::FIELDS),
+        };
+        pub const OBJECT_CHANGES_FIELD: &'static MessageField = &MessageField {
+            name: "object_changes",
+            json_name: "objectChanges",
+            number: 10i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectChange::FIELDS),
+        };
     }
     impl MessageFields for ExecutedTransaction {
         const FIELDS: &'static [&'static MessageField] = &[
@@ -262,6 +294,8 @@ mod _field_impls {
             Self::TIMESTAMP_FIELD,
             Self::INPUT_OBJECTS_FIELD,
             Self::OUTPUT_OBJECTS_FIELD,
+            Self::BALANCE_CHANGES_FIELD,
+            Self::OBJECT_CHANGES_FIELD,
         ];
     }
     impl ExecutedTransaction {
@@ -315,6 +349,830 @@ mod _field_impls {
         pub fn output_objects(mut self) -> ObjectFieldPathBuilder {
             self.path.push(ExecutedTransaction::OUTPUT_OBJECTS_FIELD.name);
             ObjectFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn balance_changes(mut self) -> BalanceChangeFieldPathBuilder {
+            self.path.push(ExecutedTransaction::BALANCE_CHANGES_FIELD.name);
+            BalanceChangeFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_changes(mut self) -> ObjectChangeFieldPathBuilder {
+            self.path.push(ExecutedTransaction::OBJECT_CHANGES_FIELD.name);
+            ObjectChangeFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl BalanceChange {
+        pub const OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "owner",
+            json_name: "owner",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Owner::FIELDS),
+        };
+        pub const COIN_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "coin_type",
+            json_name: "coinType",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(TypeTag::FIELDS),
+        };
+        pub const AMOUNT_FIELD: &'static MessageField = &MessageField {
+            name: "amount",
+            json_name: "amount",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl MessageFields for BalanceChange {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::OWNER_FIELD,
+            Self::COIN_TYPE_FIELD,
+            Self::AMOUNT_FIELD,
+        ];
+    }
+    impl BalanceChange {
+        pub fn path_builder() -> BalanceChangeFieldPathBuilder {
+            BalanceChangeFieldPathBuilder::new()
+        }
+    }
+    pub struct BalanceChangeFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl BalanceChangeFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn owner(mut self) -> OwnerFieldPathBuilder {
+            self.path.push(BalanceChange::OWNER_FIELD.name);
+            OwnerFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn coin_type(mut self) -> TypeTagFieldPathBuilder {
+            self.path.push(BalanceChange::COIN_TYPE_FIELD.name);
+            TypeTagFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn amount(mut self) -> String {
+            self.path.push(BalanceChange::AMOUNT_FIELD.name);
+            self.finish()
+        }
+    }
+    impl BalanceChanges {
+        pub const BALANCE_CHANGES_FIELD: &'static MessageField = &MessageField {
+            name: "balance_changes",
+            json_name: "balanceChanges",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(BalanceChange::FIELDS),
+        };
+    }
+    impl MessageFields for BalanceChanges {
+        const FIELDS: &'static [&'static MessageField] = &[Self::BALANCE_CHANGES_FIELD];
+    }
+    impl BalanceChanges {
+        pub fn path_builder() -> BalanceChangesFieldPathBuilder {
+            BalanceChangesFieldPathBuilder::new()
+        }
+    }
+    pub struct BalanceChangesFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl BalanceChangesFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn balance_changes(mut self) -> BalanceChangeFieldPathBuilder {
+            self.path.push(BalanceChanges::BALANCE_CHANGES_FIELD.name);
+            BalanceChangeFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ObjectChangePublished {
+        pub const PACKAGE_ID_FIELD: &'static MessageField = &MessageField {
+            name: "package_id",
+            json_name: "packageId",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const DIGEST_FIELD: &'static MessageField = &MessageField {
+            name: "digest",
+            json_name: "digest",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Digest::FIELDS),
+        };
+        pub const MODULES_FIELD: &'static MessageField = &MessageField {
+            name: "modules",
+            json_name: "modules",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl MessageFields for ObjectChangePublished {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::PACKAGE_ID_FIELD,
+            Self::VERSION_FIELD,
+            Self::DIGEST_FIELD,
+            Self::MODULES_FIELD,
+        ];
+    }
+    impl ObjectChangePublished {
+        pub fn path_builder() -> ObjectChangePublishedFieldPathBuilder {
+            ObjectChangePublishedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangePublishedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangePublishedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn package_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangePublished::PACKAGE_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangePublished::VERSION_FIELD.name);
+            self.finish()
+        }
+        pub fn digest(mut self) -> DigestFieldPathBuilder {
+            self.path.push(ObjectChangePublished::DIGEST_FIELD.name);
+            DigestFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn modules(mut self) -> String {
+            self.path.push(ObjectChangePublished::MODULES_FIELD.name);
+            self.finish()
+        }
+    }
+    impl ObjectChangeMutated {
+        pub const SENDER_FIELD: &'static MessageField = &MessageField {
+            name: "sender",
+            json_name: "sender",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "owner",
+            json_name: "owner",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Owner::FIELDS),
+        };
+        pub const OBJECT_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "object_type",
+            json_name: "objectType",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
+            name: "object_id",
+            json_name: "objectId",
+            number: 4i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 5i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const PREVIOUS_VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "previous_version",
+            json_name: "previousVersion",
+            number: 6i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const DIGEST_FIELD: &'static MessageField = &MessageField {
+            name: "digest",
+            json_name: "digest",
+            number: 7i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Digest::FIELDS),
+        };
+    }
+    impl MessageFields for ObjectChangeMutated {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::SENDER_FIELD,
+            Self::OWNER_FIELD,
+            Self::OBJECT_TYPE_FIELD,
+            Self::OBJECT_ID_FIELD,
+            Self::VERSION_FIELD,
+            Self::PREVIOUS_VERSION_FIELD,
+            Self::DIGEST_FIELD,
+        ];
+    }
+    impl ObjectChangeMutated {
+        pub fn path_builder() -> ObjectChangeMutatedFieldPathBuilder {
+            ObjectChangeMutatedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeMutatedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeMutatedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn sender(mut self) -> AddressFieldPathBuilder {
+            self.path.push(ObjectChangeMutated::SENDER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn owner(mut self) -> OwnerFieldPathBuilder {
+            self.path.push(ObjectChangeMutated::OWNER_FIELD.name);
+            OwnerFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_type(mut self) -> String {
+            self.path.push(ObjectChangeMutated::OBJECT_TYPE_FIELD.name);
+            self.finish()
+        }
+        pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangeMutated::OBJECT_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangeMutated::VERSION_FIELD.name);
+            self.finish()
+        }
+        pub fn previous_version(mut self) -> String {
+            self.path.push(ObjectChangeMutated::PREVIOUS_VERSION_FIELD.name);
+            self.finish()
+        }
+        pub fn digest(mut self) -> DigestFieldPathBuilder {
+            self.path.push(ObjectChangeMutated::DIGEST_FIELD.name);
+            DigestFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ObjectChangeDeleted {
+        pub const SENDER_FIELD: &'static MessageField = &MessageField {
+            name: "sender",
+            json_name: "sender",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OBJECT_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "object_type",
+            json_name: "objectType",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
+            name: "object_id",
+            json_name: "objectId",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 4i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl MessageFields for ObjectChangeDeleted {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::SENDER_FIELD,
+            Self::OBJECT_TYPE_FIELD,
+            Self::OBJECT_ID_FIELD,
+            Self::VERSION_FIELD,
+        ];
+    }
+    impl ObjectChangeDeleted {
+        pub fn path_builder() -> ObjectChangeDeletedFieldPathBuilder {
+            ObjectChangeDeletedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeDeletedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeDeletedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn sender(mut self) -> AddressFieldPathBuilder {
+            self.path.push(ObjectChangeDeleted::SENDER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_type(mut self) -> String {
+            self.path.push(ObjectChangeDeleted::OBJECT_TYPE_FIELD.name);
+            self.finish()
+        }
+        pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangeDeleted::OBJECT_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangeDeleted::VERSION_FIELD.name);
+            self.finish()
+        }
+    }
+    impl ObjectChangeWrapped {
+        pub const SENDER_FIELD: &'static MessageField = &MessageField {
+            name: "sender",
+            json_name: "sender",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OBJECT_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "object_type",
+            json_name: "objectType",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
+            name: "object_id",
+            json_name: "objectId",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 4i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl MessageFields for ObjectChangeWrapped {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::SENDER_FIELD,
+            Self::OBJECT_TYPE_FIELD,
+            Self::OBJECT_ID_FIELD,
+            Self::VERSION_FIELD,
+        ];
+    }
+    impl ObjectChangeWrapped {
+        pub fn path_builder() -> ObjectChangeWrappedFieldPathBuilder {
+            ObjectChangeWrappedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeWrappedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeWrappedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn sender(mut self) -> AddressFieldPathBuilder {
+            self.path.push(ObjectChangeWrapped::SENDER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_type(mut self) -> String {
+            self.path.push(ObjectChangeWrapped::OBJECT_TYPE_FIELD.name);
+            self.finish()
+        }
+        pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangeWrapped::OBJECT_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangeWrapped::VERSION_FIELD.name);
+            self.finish()
+        }
+    }
+    impl ObjectChangeUnwrapped {
+        pub const SENDER_FIELD: &'static MessageField = &MessageField {
+            name: "sender",
+            json_name: "sender",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "owner",
+            json_name: "owner",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Owner::FIELDS),
+        };
+        pub const OBJECT_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "object_type",
+            json_name: "objectType",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
+            name: "object_id",
+            json_name: "objectId",
+            number: 4i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 5i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const DIGEST_FIELD: &'static MessageField = &MessageField {
+            name: "digest",
+            json_name: "digest",
+            number: 6i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Digest::FIELDS),
+        };
+    }
+    impl MessageFields for ObjectChangeUnwrapped {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::SENDER_FIELD,
+            Self::OWNER_FIELD,
+            Self::OBJECT_TYPE_FIELD,
+            Self::OBJECT_ID_FIELD,
+            Self::VERSION_FIELD,
+            Self::DIGEST_FIELD,
+        ];
+    }
+    impl ObjectChangeUnwrapped {
+        pub fn path_builder() -> ObjectChangeUnwrappedFieldPathBuilder {
+            ObjectChangeUnwrappedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeUnwrappedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeUnwrappedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn sender(mut self) -> AddressFieldPathBuilder {
+            self.path.push(ObjectChangeUnwrapped::SENDER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn owner(mut self) -> OwnerFieldPathBuilder {
+            self.path.push(ObjectChangeUnwrapped::OWNER_FIELD.name);
+            OwnerFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_type(mut self) -> String {
+            self.path.push(ObjectChangeUnwrapped::OBJECT_TYPE_FIELD.name);
+            self.finish()
+        }
+        pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangeUnwrapped::OBJECT_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangeUnwrapped::VERSION_FIELD.name);
+            self.finish()
+        }
+        pub fn digest(mut self) -> DigestFieldPathBuilder {
+            self.path.push(ObjectChangeUnwrapped::DIGEST_FIELD.name);
+            DigestFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ObjectChangeCreated {
+        pub const SENDER_FIELD: &'static MessageField = &MessageField {
+            name: "sender",
+            json_name: "sender",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "owner",
+            json_name: "owner",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Owner::FIELDS),
+        };
+        pub const OBJECT_TYPE_FIELD: &'static MessageField = &MessageField {
+            name: "object_type",
+            json_name: "objectType",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const OBJECT_ID_FIELD: &'static MessageField = &MessageField {
+            name: "object_id",
+            json_name: "objectId",
+            number: 4i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const VERSION_FIELD: &'static MessageField = &MessageField {
+            name: "version",
+            json_name: "version",
+            number: 5i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const DIGEST_FIELD: &'static MessageField = &MessageField {
+            name: "digest",
+            json_name: "digest",
+            number: 6i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Digest::FIELDS),
+        };
+    }
+    impl MessageFields for ObjectChangeCreated {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::SENDER_FIELD,
+            Self::OWNER_FIELD,
+            Self::OBJECT_TYPE_FIELD,
+            Self::OBJECT_ID_FIELD,
+            Self::VERSION_FIELD,
+            Self::DIGEST_FIELD,
+        ];
+    }
+    impl ObjectChangeCreated {
+        pub fn path_builder() -> ObjectChangeCreatedFieldPathBuilder {
+            ObjectChangeCreatedFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeCreatedFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeCreatedFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn sender(mut self) -> AddressFieldPathBuilder {
+            self.path.push(ObjectChangeCreated::SENDER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn owner(mut self) -> OwnerFieldPathBuilder {
+            self.path.push(ObjectChangeCreated::OWNER_FIELD.name);
+            OwnerFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_type(mut self) -> String {
+            self.path.push(ObjectChangeCreated::OBJECT_TYPE_FIELD.name);
+            self.finish()
+        }
+        pub fn object_id(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(ObjectChangeCreated::OBJECT_ID_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn version(mut self) -> String {
+            self.path.push(ObjectChangeCreated::VERSION_FIELD.name);
+            self.finish()
+        }
+        pub fn digest(mut self) -> DigestFieldPathBuilder {
+            self.path.push(ObjectChangeCreated::DIGEST_FIELD.name);
+            DigestFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ObjectChange {
+        pub const PUBLISHED_FIELD: &'static MessageField = &MessageField {
+            name: "published",
+            json_name: "published",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangePublished::FIELDS),
+        };
+        pub const MUTATED_FIELD: &'static MessageField = &MessageField {
+            name: "mutated",
+            json_name: "mutated",
+            number: 2i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangeMutated::FIELDS),
+        };
+        pub const DELETED_FIELD: &'static MessageField = &MessageField {
+            name: "deleted",
+            json_name: "deleted",
+            number: 3i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangeDeleted::FIELDS),
+        };
+        pub const WRAPPED_FIELD: &'static MessageField = &MessageField {
+            name: "wrapped",
+            json_name: "wrapped",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangeWrapped::FIELDS),
+        };
+        pub const UNWRAPPED_FIELD: &'static MessageField = &MessageField {
+            name: "unwrapped",
+            json_name: "unwrapped",
+            number: 5i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangeUnwrapped::FIELDS),
+        };
+        pub const CREATED_FIELD: &'static MessageField = &MessageField {
+            name: "created",
+            json_name: "created",
+            number: 6i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChangeCreated::FIELDS),
+        };
+    }
+    impl ObjectChange {
+        pub const KIND_ONEOF: &'static str = "kind";
+    }
+    impl MessageFields for ObjectChange {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::PUBLISHED_FIELD,
+            Self::MUTATED_FIELD,
+            Self::DELETED_FIELD,
+            Self::WRAPPED_FIELD,
+            Self::UNWRAPPED_FIELD,
+            Self::CREATED_FIELD,
+        ];
+        const ONEOFS: &'static [&'static str] = &["kind"];
+    }
+    impl ObjectChange {
+        pub fn path_builder() -> ObjectChangeFieldPathBuilder {
+            ObjectChangeFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangeFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangeFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn published(mut self) -> ObjectChangePublishedFieldPathBuilder {
+            self.path.push(ObjectChange::PUBLISHED_FIELD.name);
+            ObjectChangePublishedFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn mutated(mut self) -> ObjectChangeMutatedFieldPathBuilder {
+            self.path.push(ObjectChange::MUTATED_FIELD.name);
+            ObjectChangeMutatedFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn deleted(mut self) -> ObjectChangeDeletedFieldPathBuilder {
+            self.path.push(ObjectChange::DELETED_FIELD.name);
+            ObjectChangeDeletedFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn wrapped(mut self) -> ObjectChangeWrappedFieldPathBuilder {
+            self.path.push(ObjectChange::WRAPPED_FIELD.name);
+            ObjectChangeWrappedFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn unwrapped(mut self) -> ObjectChangeUnwrappedFieldPathBuilder {
+            self.path.push(ObjectChange::UNWRAPPED_FIELD.name);
+            ObjectChangeUnwrappedFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn created(mut self) -> ObjectChangeCreatedFieldPathBuilder {
+            self.path.push(ObjectChange::CREATED_FIELD.name);
+            ObjectChangeCreatedFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl ObjectChanges {
+        pub const OBJECT_CHANGES_FIELD: &'static MessageField = &MessageField {
+            name: "object_changes",
+            json_name: "objectChanges",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectChange::FIELDS),
+        };
+    }
+    impl MessageFields for ObjectChanges {
+        const FIELDS: &'static [&'static MessageField] = &[Self::OBJECT_CHANGES_FIELD];
+    }
+    impl ObjectChanges {
+        pub fn path_builder() -> ObjectChangesFieldPathBuilder {
+            ObjectChangesFieldPathBuilder::new()
+        }
+    }
+    pub struct ObjectChangesFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl ObjectChangesFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn object_changes(mut self) -> ObjectChangeFieldPathBuilder {
+            self.path.push(ObjectChanges::OBJECT_CHANGES_FIELD.name);
+            ObjectChangeFieldPathBuilder::new_with_base(self.path)
         }
     }
     impl ExecutedTransactions {

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.rs
@@ -65,11 +65,218 @@ pub struct ExecutedTransaction {
     #[prost(message, optional, tag = "6")]
     pub timestamp: ::core::option::Option<::prost_types::Timestamp>,
     /// Set of input objects used by this transaction.
+    ///
+    /// The returned set is always complete: if the serving node no longer has
+    /// one of the objects (e.g. pruned), requesting this field fails with
+    /// `FAILED_PRECONDITION` instead of returning a silently shortened list.
+    /// Narrow the read mask, or fetch objects individually via `GetObjects`
+    /// for best-effort retrieval.
     #[prost(message, optional, tag = "7")]
     pub input_objects: ::core::option::Option<super::object::Objects>,
     /// Set of output objects produced by this transaction.
+    ///
+    /// The returned set is always complete: if the serving node no longer has
+    /// one of the objects (e.g. pruned), requesting this field fails with
+    /// `FAILED_PRECONDITION` instead of returning a silently shortened list.
+    /// Narrow the read mask, or fetch objects individually via `GetObjects`
+    /// for best-effort retrieval.
     #[prost(message, optional, tag = "8")]
     pub output_objects: ::core::option::Option<super::object::Objects>,
+    /// The balance changes caused by this transaction.
+    ///
+    /// Derived from the transaction's effects and input/output objects. If the
+    /// serving node no longer has a required object (e.g. pruned), requesting
+    /// this field fails with `FAILED_PRECONDITION` instead of returning a
+    /// silently wrong result; retry without this field in the read mask.
+    #[prost(message, optional, tag = "9")]
+    pub balance_changes: ::core::option::Option<BalanceChanges>,
+    /// The object changes caused by this transaction.
+    ///
+    /// Derived from the transaction's effects and input/output objects. If the
+    /// serving node no longer has a required object (e.g. pruned), requesting
+    /// this field fails with `FAILED_PRECONDITION` instead of returning a
+    /// silently incomplete result; retry without this field in the read mask.
+    #[prost(message, optional, tag = "10")]
+    pub object_changes: ::core::option::Option<ObjectChanges>,
+}
+/// The delta, or change, in balance of a particular coin type for an owner.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BalanceChange {
+    /// The owner whose balance changed.
+    #[prost(message, optional, tag = "1")]
+    pub owner: ::core::option::Option<super::types::Owner>,
+    /// The type of the coin, e.g. `0x2::iota::IOTA`.
+    #[prost(message, optional, tag = "2")]
+    pub coin_type: ::core::option::Option<super::types::TypeTag>,
+    /// The amount the balance changed by, encoded as a decimal string
+    /// (128-bit signed integer). A negative amount means the net flow of
+    /// value is away from the owner.
+    #[prost(string, optional, tag = "3")]
+    pub amount: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// A list of balance changes.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BalanceChanges {
+    #[prost(message, repeated, tag = "1")]
+    pub balance_changes: ::prost::alloc::vec::Vec<BalanceChange>,
+}
+/// A package was published.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangePublished {
+    /// The ID of the published package.
+    #[prost(message, optional, tag = "1")]
+    pub package_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version of the published package.
+    #[prost(uint64, optional, tag = "2")]
+    pub version: ::core::option::Option<u64>,
+    /// The digest of the published package.
+    #[prost(message, optional, tag = "3")]
+    pub digest: ::core::option::Option<super::types::Digest>,
+    /// The set of modules in the published package.
+    #[prost(string, repeated, tag = "4")]
+    pub modules: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// An object was mutated.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangeMutated {
+    /// The sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender: ::core::option::Option<super::types::Address>,
+    /// The owner of the object.
+    #[prost(message, optional, tag = "2")]
+    pub owner: ::core::option::Option<super::types::Owner>,
+    /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+    #[prost(string, optional, tag = "3")]
+    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// The ID of the object.
+    #[prost(message, optional, tag = "4")]
+    pub object_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version of the object.
+    #[prost(uint64, optional, tag = "5")]
+    pub version: ::core::option::Option<u64>,
+    /// The version of the object before it was mutated.
+    #[prost(uint64, optional, tag = "6")]
+    pub previous_version: ::core::option::Option<u64>,
+    /// The digest of the object.
+    #[prost(message, optional, tag = "7")]
+    pub digest: ::core::option::Option<super::types::Digest>,
+}
+/// An object was deleted.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangeDeleted {
+    /// The sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender: ::core::option::Option<super::types::Address>,
+    /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+    #[prost(string, optional, tag = "2")]
+    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// The ID of the object.
+    #[prost(message, optional, tag = "3")]
+    pub object_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version the object was deleted at.
+    #[prost(uint64, optional, tag = "4")]
+    pub version: ::core::option::Option<u64>,
+}
+/// An object was wrapped inside another object.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangeWrapped {
+    /// The sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender: ::core::option::Option<super::types::Address>,
+    /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+    #[prost(string, optional, tag = "2")]
+    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// The ID of the object.
+    #[prost(message, optional, tag = "3")]
+    pub object_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version the object was wrapped at.
+    #[prost(uint64, optional, tag = "4")]
+    pub version: ::core::option::Option<u64>,
+}
+/// An object was unwrapped from inside another object.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangeUnwrapped {
+    /// The sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender: ::core::option::Option<super::types::Address>,
+    /// The owner of the object.
+    #[prost(message, optional, tag = "2")]
+    pub owner: ::core::option::Option<super::types::Owner>,
+    /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+    #[prost(string, optional, tag = "3")]
+    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// The ID of the object.
+    #[prost(message, optional, tag = "4")]
+    pub object_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version of the object.
+    #[prost(uint64, optional, tag = "5")]
+    pub version: ::core::option::Option<u64>,
+    /// The digest of the object.
+    #[prost(message, optional, tag = "6")]
+    pub digest: ::core::option::Option<super::types::Digest>,
+}
+/// A new object was created.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChangeCreated {
+    /// The sender of the transaction.
+    #[prost(message, optional, tag = "1")]
+    pub sender: ::core::option::Option<super::types::Address>,
+    /// The owner of the object.
+    #[prost(message, optional, tag = "2")]
+    pub owner: ::core::option::Option<super::types::Owner>,
+    /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
+    #[prost(string, optional, tag = "3")]
+    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    /// The ID of the object.
+    #[prost(message, optional, tag = "4")]
+    pub object_id: ::core::option::Option<super::types::ObjectId>,
+    /// The version of the object.
+    #[prost(uint64, optional, tag = "5")]
+    pub version: ::core::option::Option<u64>,
+    /// The digest of the object.
+    #[prost(message, optional, tag = "6")]
+    pub digest: ::core::option::Option<super::types::Digest>,
+}
+/// A change to an object caused by executing a transaction.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectChange {
+    #[prost(oneof = "object_change::Kind", tags = "1, 2, 3, 4, 5, 6")]
+    pub kind: ::core::option::Option<object_change::Kind>,
+}
+/// Nested message and enum types in `ObjectChange`.
+pub mod object_change {
+    #[non_exhaustive]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Kind {
+        #[prost(message, tag = "1")]
+        Published(super::ObjectChangePublished),
+        #[prost(message, tag = "2")]
+        Mutated(super::ObjectChangeMutated),
+        #[prost(message, tag = "3")]
+        Deleted(super::ObjectChangeDeleted),
+        #[prost(message, tag = "4")]
+        Wrapped(super::ObjectChangeWrapped),
+        #[prost(message, tag = "5")]
+        Unwrapped(super::ObjectChangeUnwrapped),
+        #[prost(message, tag = "6")]
+        Created(super::ObjectChangeCreated),
+    }
+}
+/// A list of object changes.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ObjectChanges {
+    #[prost(message, repeated, tag = "1")]
+    pub object_changes: ::prost::alloc::vec::Vec<ObjectChange>,
 }
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.transaction.rs
@@ -109,11 +109,12 @@ pub struct BalanceChange {
     /// The type of the coin, e.g. `0x2::iota::IOTA`.
     #[prost(message, optional, tag = "2")]
     pub coin_type: ::core::option::Option<super::types::TypeTag>,
-    /// The amount the balance changed by, encoded as a decimal string
-    /// (128-bit signed integer). A negative amount means the net flow of
-    /// value is away from the owner.
-    #[prost(string, optional, tag = "3")]
-    pub amount: ::core::option::Option<::prost::alloc::string::String>,
+    /// The amount the balance changed by: a 128-bit signed integer in
+    /// big-endian two's-complement encoding (exactly 16 bytes,
+    /// `i128::to_be_bytes`). A negative amount means the net flow of value is
+    /// away from the owner.
+    #[prost(bytes = "bytes", optional, tag = "3")]
+    pub amount: ::core::option::Option<::prost::bytes::Bytes>,
 }
 /// A list of balance changes.
 #[non_exhaustive]
@@ -141,7 +142,7 @@ pub struct ObjectChangePublished {
 }
 /// An object was mutated.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChangeMutated {
     /// The sender of the transaction.
     #[prost(message, optional, tag = "1")]
@@ -150,8 +151,8 @@ pub struct ObjectChangeMutated {
     #[prost(message, optional, tag = "2")]
     pub owner: ::core::option::Option<super::types::Owner>,
     /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-    #[prost(string, optional, tag = "3")]
-    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "3")]
+    pub object_type: ::core::option::Option<super::types::TypeTag>,
     /// The ID of the object.
     #[prost(message, optional, tag = "4")]
     pub object_id: ::core::option::Option<super::types::ObjectId>,
@@ -167,14 +168,14 @@ pub struct ObjectChangeMutated {
 }
 /// An object was deleted.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChangeDeleted {
     /// The sender of the transaction.
     #[prost(message, optional, tag = "1")]
     pub sender: ::core::option::Option<super::types::Address>,
     /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-    #[prost(string, optional, tag = "2")]
-    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "2")]
+    pub object_type: ::core::option::Option<super::types::TypeTag>,
     /// The ID of the object.
     #[prost(message, optional, tag = "3")]
     pub object_id: ::core::option::Option<super::types::ObjectId>,
@@ -184,14 +185,14 @@ pub struct ObjectChangeDeleted {
 }
 /// An object was wrapped inside another object.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChangeWrapped {
     /// The sender of the transaction.
     #[prost(message, optional, tag = "1")]
     pub sender: ::core::option::Option<super::types::Address>,
     /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-    #[prost(string, optional, tag = "2")]
-    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "2")]
+    pub object_type: ::core::option::Option<super::types::TypeTag>,
     /// The ID of the object.
     #[prost(message, optional, tag = "3")]
     pub object_id: ::core::option::Option<super::types::ObjectId>,
@@ -201,7 +202,7 @@ pub struct ObjectChangeWrapped {
 }
 /// An object was unwrapped from inside another object.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChangeUnwrapped {
     /// The sender of the transaction.
     #[prost(message, optional, tag = "1")]
@@ -210,8 +211,8 @@ pub struct ObjectChangeUnwrapped {
     #[prost(message, optional, tag = "2")]
     pub owner: ::core::option::Option<super::types::Owner>,
     /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-    #[prost(string, optional, tag = "3")]
-    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "3")]
+    pub object_type: ::core::option::Option<super::types::TypeTag>,
     /// The ID of the object.
     #[prost(message, optional, tag = "4")]
     pub object_id: ::core::option::Option<super::types::ObjectId>,
@@ -224,7 +225,7 @@ pub struct ObjectChangeUnwrapped {
 }
 /// A new object was created.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChangeCreated {
     /// The sender of the transaction.
     #[prost(message, optional, tag = "1")]
@@ -233,8 +234,8 @@ pub struct ObjectChangeCreated {
     #[prost(message, optional, tag = "2")]
     pub owner: ::core::option::Option<super::types::Owner>,
     /// The type of the object, e.g. `0x2::coin::Coin<0x2::iota::IOTA>`.
-    #[prost(string, optional, tag = "3")]
-    pub object_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag = "3")]
+    pub object_type: ::core::option::Option<super::types::TypeTag>,
     /// The ID of the object.
     #[prost(message, optional, tag = "4")]
     pub object_id: ::core::option::Option<super::types::ObjectId>,
@@ -247,7 +248,7 @@ pub struct ObjectChangeCreated {
 }
 /// A change to an object caused by executing a transaction.
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectChange {
     #[prost(oneof = "object_change::Kind", tags = "1, 2, 3, 4, 5, 6")]
     pub kind: ::core::option::Option<object_change::Kind>,
@@ -255,7 +256,7 @@ pub struct ObjectChange {
 /// Nested message and enum types in `ObjectChange`.
 pub mod object_change {
     #[non_exhaustive]
-    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         #[prost(message, tag = "1")]
         Published(super::ObjectChangePublished),

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.accessors.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.accessors.rs
@@ -45,4 +45,30 @@ mod _accessor_impls {
             self
         }
     }
+    impl super::Owner {
+        /// Sets `address_owner` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_address_owner<T: Into<super::Address>>(mut self, field: T) -> Self {
+            self.kind = Some(super::owner::Kind::AddressOwner(field.into()));
+            self
+        }
+        /// Sets `object_owner` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_object_owner<T: Into<super::ObjectId>>(mut self, field: T) -> Self {
+            self.kind = Some(super::owner::Kind::ObjectOwner(field.into()));
+            self
+        }
+        /// Sets `shared` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_shared(mut self, field: u64) -> Self {
+            self.kind = Some(super::owner::Kind::Shared(field));
+            self
+        }
+        /// Sets `immutable` with the provided value.
+        /// If any other oneof field in the same oneof is set, it will be cleared.
+        pub fn with_immutable(mut self, field: bool) -> Self {
+            self.kind = Some(super::owner::Kind::Immutable(field));
+            self
+        }
+    }
 }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.field_info.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.field_info.rs
@@ -187,6 +187,89 @@ mod _field_impls {
             DigestFieldPathBuilder::new_with_base(self.path)
         }
     }
+    impl Owner {
+        pub const ADDRESS_OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "address_owner",
+            json_name: "addressOwner",
+            number: 1i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(Address::FIELDS),
+        };
+        pub const OBJECT_OWNER_FIELD: &'static MessageField = &MessageField {
+            name: "object_owner",
+            json_name: "objectOwner",
+            number: 2i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(ObjectId::FIELDS),
+        };
+        pub const SHARED_FIELD: &'static MessageField = &MessageField {
+            name: "shared",
+            json_name: "shared",
+            number: 3i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: None,
+        };
+        pub const IMMUTABLE_FIELD: &'static MessageField = &MessageField {
+            name: "immutable",
+            json_name: "immutable",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: None,
+        };
+    }
+    impl Owner {
+        pub const KIND_ONEOF: &'static str = "kind";
+    }
+    impl MessageFields for Owner {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::ADDRESS_OWNER_FIELD,
+            Self::OBJECT_OWNER_FIELD,
+            Self::SHARED_FIELD,
+            Self::IMMUTABLE_FIELD,
+        ];
+        const ONEOFS: &'static [&'static str] = &["kind"];
+    }
+    impl Owner {
+        pub fn path_builder() -> OwnerFieldPathBuilder {
+            OwnerFieldPathBuilder::new()
+        }
+    }
+    pub struct OwnerFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl OwnerFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn address_owner(mut self) -> AddressFieldPathBuilder {
+            self.path.push(Owner::ADDRESS_OWNER_FIELD.name);
+            AddressFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn object_owner(mut self) -> ObjectIdFieldPathBuilder {
+            self.path.push(Owner::OBJECT_OWNER_FIELD.name);
+            ObjectIdFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn shared(mut self) -> String {
+            self.path.push(Owner::SHARED_FIELD.name);
+            self.finish()
+        }
+        pub fn immutable(mut self) -> String {
+            self.path.push(Owner::IMMUTABLE_FIELD.name);
+            self.finish()
+        }
+    }
     impl TypeTagVector {
         pub const INNER_TYPE_FIELD: &'static MessageField = &MessageField {
             name: "inner_type",

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.types.rs
@@ -38,6 +38,33 @@ pub struct ObjectReference {
     #[prost(message, optional, tag = "3")]
     pub digest: ::core::option::Option<Digest>,
 }
+/// Ownership information for an object.
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct Owner {
+    #[prost(oneof = "owner::Kind", tags = "1, 2, 3, 4")]
+    pub kind: ::core::option::Option<owner::Kind>,
+}
+/// Nested message and enum types in `Owner`.
+pub mod owner {
+    #[non_exhaustive]
+    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Kind {
+        /// Object is exclusively owned by a single address, and is mutable.
+        #[prost(message, tag = "1")]
+        AddressOwner(super::Address),
+        /// Object is exclusively owned by a single object, and is mutable.
+        #[prost(message, tag = "2")]
+        ObjectOwner(super::ObjectId),
+        /// Object is shared and can be used by any address. The value is the
+        /// version at which the object became shared.
+        #[prost(uint64, tag = "3")]
+        Shared(u64),
+        /// Object is immutable, and hence ownership doesn't matter.
+        #[prost(bool, tag = "4")]
+        Immutable(bool),
+    }
+}
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TypeTagVector {

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/event.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/event.rs
@@ -63,8 +63,11 @@ impl Event {
             .as_deref()
             .ok_or_else(|| TryFromProtoError::missing(Self::MODULE_FIELD.name))?
             .parse()
-            .map_err(|_e: iota_types::TypeParseError| {
-                TryFromProtoError::invalid(Self::MODULE_FIELD.name, "invalid identifier format")
+            .map_err(|e: iota_types::TypeParseError| {
+                TryFromProtoError::invalid(
+                    Self::MODULE_FIELD.name,
+                    format!("invalid identifier format {e}"),
+                )
             })
     }
 
@@ -88,8 +91,11 @@ impl Event {
             .as_deref()
             .ok_or_else(|| TryFromProtoError::missing(Self::EVENT_TYPE_FIELD.name))?
             .parse()
-            .map_err(|_e: iota_types::TypeParseError| {
-                TryFromProtoError::invalid(Self::EVENT_TYPE_FIELD.name, "invalid struct tag format")
+            .map_err(|e: iota_types::TypeParseError| {
+                TryFromProtoError::invalid(
+                    Self::EVENT_TYPE_FIELD.name,
+                    format!("invalid struct tag format {e}"),
+                )
             })
     }
 

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/transaction.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/transaction.rs
@@ -6,7 +6,7 @@ include!("../../../generated/iota.grpc.v1.transaction.rs");
 include!("../../../generated/iota.grpc.v1.transaction.field_info.rs");
 include!("../../../generated/iota.grpc.v1.transaction.accessors.rs");
 
-use crate::proto::TryFromProtoError;
+use crate::proto::{TryFromProtoError, get_inner_field};
 
 // TryFrom implementations for TransactionEffects
 impl TryFrom<&TransactionEffects> for iota_types::TransactionEffects {
@@ -242,6 +242,11 @@ impl ExecutedTransaction {
     /// [`EXECUTED_TRANSACTION_INPUT_OBJECTS`]).
     /// For checkpoint context use `"transactions.input_objects"`.
     ///
+    /// The set is always complete: if the serving node no longer has one of
+    /// the objects (e.g. pruned), `get_transactions` requests including this
+    /// field fail with `FAILED_PRECONDITION`. Narrow the read mask, or fetch
+    /// objects individually via `get_objects` for best-effort retrieval.
+    ///
     /// [`EXECUTED_TRANSACTION_INPUT_OBJECTS`]: crate::read_masks::EXECUTED_TRANSACTION_INPUT_OBJECTS
     pub fn input_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
         self.input_objects
@@ -258,11 +263,56 @@ impl ExecutedTransaction {
     /// [`EXECUTED_TRANSACTION_OUTPUT_OBJECTS`]).
     /// For checkpoint context use `"transactions.output_objects"`.
     ///
+    /// The set is always complete: if the serving node no longer has one of
+    /// the objects (e.g. pruned), `get_transactions` requests including this
+    /// field fail with `FAILED_PRECONDITION`. Narrow the read mask, or fetch
+    /// objects individually via `get_objects` for best-effort retrieval.
+    ///
     /// [`EXECUTED_TRANSACTION_OUTPUT_OBJECTS`]: crate::read_masks::EXECUTED_TRANSACTION_OUTPUT_OBJECTS
     pub fn output_objects(&self) -> Result<&super::object::Objects, TryFromProtoError> {
         self.output_objects
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::OUTPUT_OBJECTS_FIELD.name))
+    }
+
+    /// Get balance changes.
+    ///
+    /// Returns proto [`BalanceChanges`] containing the balance changes derived
+    /// from the transaction's effects.
+    ///
+    /// **Read mask:** `"balance_changes"` (see
+    /// [`EXECUTED_TRANSACTION_BALANCE_CHANGES`]).
+    /// For checkpoint context use `"transactions.balance_changes"`.
+    ///
+    /// If the serving node no longer has a required object (e.g. pruned),
+    /// `get_transactions` requests including this field fail with
+    /// `FAILED_PRECONDITION`; retry without it in the read mask.
+    ///
+    /// [`EXECUTED_TRANSACTION_BALANCE_CHANGES`]: crate::read_masks::EXECUTED_TRANSACTION_BALANCE_CHANGES
+    pub fn balance_changes(&self) -> Result<&BalanceChanges, TryFromProtoError> {
+        self.balance_changes
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::BALANCE_CHANGES_FIELD.name))
+    }
+
+    /// Get object changes.
+    ///
+    /// Returns proto [`ObjectChanges`] containing the object changes derived
+    /// from the transaction's effects.
+    ///
+    /// **Read mask:** `"object_changes"` (see
+    /// [`EXECUTED_TRANSACTION_OBJECT_CHANGES`]).
+    /// For checkpoint context use `"transactions.object_changes"`.
+    ///
+    /// If the serving node no longer has a required object (e.g. pruned),
+    /// `get_transactions` requests including this field fail with
+    /// `FAILED_PRECONDITION`; retry without it in the read mask.
+    ///
+    /// [`EXECUTED_TRANSACTION_OBJECT_CHANGES`]: crate::read_masks::EXECUTED_TRANSACTION_OBJECT_CHANGES
+    pub fn object_changes(&self) -> Result<&ObjectChanges, TryFromProtoError> {
+        self.object_changes
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::OBJECT_CHANGES_FIELD.name))
     }
 }
 
@@ -354,3 +404,121 @@ impl Transaction {
         self.try_into()
     }
 }
+
+impl BalanceChange {
+    /// Get the owner whose balance changed, parsed as SDK type.
+    pub fn owner(&self) -> Result<iota_types::Owner, TryFromProtoError> {
+        self.owner
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::OWNER_FIELD.name))?
+            .owner()
+            .map_err(|e| e.nested(Self::OWNER_FIELD.name))
+    }
+
+    /// Get the coin type of the balance change, parsed as SDK type.
+    pub fn coin_type(&self) -> Result<iota_types::TypeTag, TryFromProtoError> {
+        self.coin_type
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::COIN_TYPE_FIELD.name))?
+            .type_tag()
+            .map_err(|e| e.nested(Self::COIN_TYPE_FIELD.name))
+    }
+
+    /// Get the signed amount the balance changed by, parsed from its decimal
+    /// string encoding.
+    pub fn amount_i128(&self) -> Result<i128, TryFromProtoError> {
+        self.amount
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::AMOUNT_FIELD.name))?
+            .parse()
+            .map_err(|e| TryFromProtoError::invalid(Self::AMOUNT_FIELD.name, e))
+    }
+}
+
+/// The `ObjectChange` variant messages share the same field shapes; this
+/// generates the getters that parse those fields into SDK types.
+macro_rules! impl_object_change_variant_accessors {
+    ($type:ty { $($field:ident),* $(,)? }) => {
+        impl $type {
+            $(impl_object_change_variant_accessors!(@getter $field);)*
+        }
+    };
+    (@getter sender) => {
+        /// Get the sender address of the transaction, parsed as SDK type.
+        pub fn sender(&self) -> Result<iota_types::Address, TryFromProtoError> {
+            get_inner_field!(self.sender, Self::SENDER_FIELD, try_into)
+        }
+    };
+    (@getter owner) => {
+        /// Get the owner of the object, parsed as SDK type.
+        pub fn owner(&self) -> Result<iota_types::Owner, TryFromProtoError> {
+            get_inner_field!(self.owner, Self::OWNER_FIELD, owner)
+        }
+    };
+    (@getter object_type) => {
+        /// Get the type of the object, parsed as SDK type.
+        pub fn object_type_name(&self) -> Result<iota_types::StructTag, TryFromProtoError> {
+            self.object_type
+                .as_deref()
+                .ok_or_else(|| TryFromProtoError::missing(Self::OBJECT_TYPE_FIELD.name))?
+                .parse()
+                .map_err(|_e: iota_types::TypeParseError| {
+                    TryFromProtoError::invalid(
+                        Self::OBJECT_TYPE_FIELD.name,
+                        "invalid struct tag format",
+                    )
+                })
+        }
+    };
+    (@getter object_id) => {
+        /// Get the ID of the object, parsed as SDK type.
+        pub fn object_id(&self) -> Result<iota_types::ObjectId, TryFromProtoError> {
+            get_inner_field!(self.object_id, Self::OBJECT_ID_FIELD, object_id)
+        }
+    };
+    (@getter package_id) => {
+        /// Get the ID of the published package, parsed as SDK type.
+        pub fn package_id(&self) -> Result<iota_types::ObjectId, TryFromProtoError> {
+            get_inner_field!(self.package_id, Self::PACKAGE_ID_FIELD, object_id)
+        }
+    };
+    (@getter digest) => {
+        /// Get the digest of the object, parsed as SDK type.
+        pub fn digest(&self) -> Result<iota_types::ObjectDigest, TryFromProtoError> {
+            get_inner_field!(self.digest, Self::DIGEST_FIELD, try_into)
+        }
+    };
+}
+
+impl_object_change_variant_accessors!(ObjectChangePublished { package_id, digest });
+impl_object_change_variant_accessors!(ObjectChangeMutated {
+    sender,
+    owner,
+    object_type,
+    object_id,
+    digest,
+});
+impl_object_change_variant_accessors!(ObjectChangeDeleted {
+    sender,
+    object_type,
+    object_id
+});
+impl_object_change_variant_accessors!(ObjectChangeWrapped {
+    sender,
+    object_type,
+    object_id
+});
+impl_object_change_variant_accessors!(ObjectChangeUnwrapped {
+    sender,
+    owner,
+    object_type,
+    object_id,
+    digest,
+});
+impl_object_change_variant_accessors!(ObjectChangeCreated {
+    sender,
+    owner,
+    object_type,
+    object_id,
+    digest,
+});

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/transaction.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/transaction.rs
@@ -424,14 +424,19 @@ impl BalanceChange {
             .map_err(|e| e.nested(Self::COIN_TYPE_FIELD.name))
     }
 
-    /// Get the signed amount the balance changed by, parsed from its decimal
-    /// string encoding.
+    /// Get the signed amount the balance changed by, decoded from its 16-byte
+    /// big-endian two's-complement encoding.
     pub fn amount_i128(&self) -> Result<i128, TryFromProtoError> {
-        self.amount
+        let bytes: [u8; 16] = self
+            .amount
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::AMOUNT_FIELD.name))?
-            .parse()
-            .map_err(|e| TryFromProtoError::invalid(Self::AMOUNT_FIELD.name, e))
+            .as_ref()
+            .try_into()
+            .map_err(|_| {
+                TryFromProtoError::invalid(Self::AMOUNT_FIELD.name, "expected 16 bytes")
+            })?;
+        Ok(i128::from_be_bytes(bytes))
     }
 }
 
@@ -457,17 +462,8 @@ macro_rules! impl_object_change_variant_accessors {
     };
     (@getter object_type) => {
         /// Get the type of the object, parsed as SDK type.
-        pub fn object_type_name(&self) -> Result<iota_types::StructTag, TryFromProtoError> {
-            self.object_type
-                .as_deref()
-                .ok_or_else(|| TryFromProtoError::missing(Self::OBJECT_TYPE_FIELD.name))?
-                .parse()
-                .map_err(|_e: iota_types::TypeParseError| {
-                    TryFromProtoError::invalid(
-                        Self::OBJECT_TYPE_FIELD.name,
-                        "invalid struct tag format",
-                    )
-                })
+        pub fn object_type(&self) -> Result<iota_types::TypeTag, TryFromProtoError> {
+            get_inner_field!(self.object_type, Self::OBJECT_TYPE_FIELD, type_tag)
         }
     };
     (@getter object_id) => {

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/types.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/types.rs
@@ -186,6 +186,54 @@ impl ObjectReference {
     }
 }
 
+// Owner conversions
+impl From<iota_types::Owner> for Owner {
+    fn from(value: iota_types::Owner) -> Self {
+        let kind = match value {
+            iota_types::Owner::Address(address) => Some(owner::Kind::AddressOwner(address.into())),
+            iota_types::Owner::Object(object_id) => {
+                Some(owner::Kind::ObjectOwner(object_id.into()))
+            }
+            iota_types::Owner::Shared(version) => Some(owner::Kind::Shared(version.as_u64())),
+            iota_types::Owner::Immutable => Some(owner::Kind::Immutable(true)),
+            // `iota_types::Owner` is `#[non_exhaustive]`; an unknown future
+            // variant maps to an unset oneof ("unspecified ownership kind").
+            _ => None,
+        };
+
+        Self { kind }
+    }
+}
+
+impl TryFrom<&Owner> for iota_types::Owner {
+    type Error = TryFromProtoError;
+
+    fn try_from(value: &Owner) -> Result<Self, Self::Error> {
+        match &value.kind {
+            Some(owner::Kind::AddressOwner(address)) => Ok(iota_types::Owner::Address(
+                address
+                    .address()
+                    .map_err(|e| e.nested(Owner::ADDRESS_OWNER_FIELD.name))?,
+            )),
+            Some(owner::Kind::ObjectOwner(object_id)) => Ok(iota_types::Owner::Object(
+                object_id
+                    .object_id()
+                    .map_err(|e| e.nested(Owner::OBJECT_OWNER_FIELD.name))?,
+            )),
+            Some(owner::Kind::Shared(version)) => Ok(iota_types::Owner::Shared((*version).into())),
+            Some(owner::Kind::Immutable(_)) => Ok(iota_types::Owner::Immutable),
+            None => Err(TryFromProtoError::missing("kind")),
+        }
+    }
+}
+
+impl Owner {
+    /// Deserialize the owner to SDK type.
+    pub fn owner(&self) -> Result<iota_types::Owner, TryFromProtoError> {
+        self.try_into()
+    }
+}
+
 impl From<&iota_types::TypeTag> for TypeTag {
     fn from(ty: &iota_types::TypeTag) -> Self {
         let type_tag = match ty {

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -141,6 +141,28 @@ impl TransactionField {
     pub const OUTPUT_OBJECTS_REFERENCE_DIGEST: &str = "output_objects.reference.digest";
     /// The full BCS-encoded output object.
     pub const OUTPUT_OBJECTS_BCS: &str = "output_objects.bcs";
+    /// Balance changes (all sub-fields).
+    pub const BALANCE_CHANGES: &str = "balance_changes";
+    /// The owner whose balance changed.
+    pub const BALANCE_CHANGES_OWNER: &str = "balance_changes.owner";
+    /// The coin type of the balance change.
+    pub const BALANCE_CHANGES_COIN_TYPE: &str = "balance_changes.coin_type";
+    /// The signed amount of the balance change.
+    pub const BALANCE_CHANGES_AMOUNT: &str = "balance_changes.amount";
+    /// Object changes (all sub-fields).
+    pub const OBJECT_CHANGES: &str = "object_changes";
+    /// Published-package object changes.
+    pub const OBJECT_CHANGES_PUBLISHED: &str = "object_changes.published";
+    /// Mutated-object changes.
+    pub const OBJECT_CHANGES_MUTATED: &str = "object_changes.mutated";
+    /// Deleted-object changes.
+    pub const OBJECT_CHANGES_DELETED: &str = "object_changes.deleted";
+    /// Wrapped-object changes.
+    pub const OBJECT_CHANGES_WRAPPED: &str = "object_changes.wrapped";
+    /// Unwrapped-object changes.
+    pub const OBJECT_CHANGES_UNWRAPPED: &str = "object_changes.unwrapped";
+    /// Created-object changes.
+    pub const OBJECT_CHANGES_CREATED: &str = "object_changes.created";
 }
 
 // =============================================================================
@@ -187,6 +209,10 @@ impl CheckpointTransactionField {
     pub const OUTPUT_OBJECTS: &str = "transactions.output_objects";
     /// The full BCS-encoded output object.
     pub const OUTPUT_OBJECTS_BCS: &str = "transactions.output_objects.bcs";
+    /// Balance changes (all sub-fields).
+    pub const BALANCE_CHANGES: &str = "transactions.balance_changes";
+    /// Object changes (all sub-fields).
+    pub const OBJECT_CHANGES: &str = "transactions.object_changes";
 }
 
 // =============================================================================
@@ -235,6 +261,10 @@ impl SimulateExecutedTransactionField {
     pub const OUTPUT_OBJECTS: &str = "executed_transaction.output_objects";
     /// The full BCS-encoded output object.
     pub const OUTPUT_OBJECTS_BCS: &str = "executed_transaction.output_objects.bcs";
+    /// Balance changes (all sub-fields).
+    pub const BALANCE_CHANGES: &str = "executed_transaction.balance_changes";
+    /// Object changes (all sub-fields).
+    pub const OBJECT_CHANGES: &str = "executed_transaction.object_changes";
 }
 
 // =============================================================================
@@ -482,6 +512,16 @@ mod tests {
         assert_eq!(TransactionField::CHECKPOINT, "checkpoint");
         assert_eq!(TransactionField::INPUT_OBJECTS_BCS, "input_objects.bcs");
         assert_eq!(TransactionField::OUTPUT_OBJECTS_BCS, "output_objects.bcs");
+        assert_eq!(TransactionField::BALANCE_CHANGES, "balance_changes");
+        assert_eq!(
+            TransactionField::BALANCE_CHANGES_AMOUNT,
+            "balance_changes.amount"
+        );
+        assert_eq!(TransactionField::OBJECT_CHANGES, "object_changes");
+        assert_eq!(
+            TransactionField::OBJECT_CHANGES_CREATED,
+            "object_changes.created"
+        );
     }
 
     #[test]
@@ -494,6 +534,14 @@ mod tests {
         assert_eq!(
             CheckpointTransactionField::EFFECTS_BCS,
             "transactions.effects.bcs"
+        );
+        assert_eq!(
+            CheckpointTransactionField::BALANCE_CHANGES,
+            "transactions.balance_changes"
+        );
+        assert_eq!(
+            CheckpointTransactionField::OBJECT_CHANGES,
+            "transactions.object_changes"
         );
     }
 
@@ -510,6 +558,14 @@ mod tests {
         assert_eq!(
             SimulateExecutedTransactionField::EFFECTS_BCS,
             "executed_transaction.effects.bcs"
+        );
+        assert_eq!(
+            SimulateExecutedTransactionField::BALANCE_CHANGES,
+            "executed_transaction.balance_changes"
+        );
+        assert_eq!(
+            SimulateExecutedTransactionField::OBJECT_CHANGES,
+            "executed_transaction.object_changes"
         );
     }
 

--- a/crates/iota-sdk-grpc-types/src/read_masks.rs
+++ b/crates/iota-sdk-grpc-types/src/read_masks.rs
@@ -231,13 +231,43 @@ pub const EXECUTED_TRANSACTION_TIMESTAMP: &str = "timestamp";
 /// [`ExecutedTransaction::input_objects()`](crate::v1::transaction::ExecutedTransaction::input_objects).
 ///
 /// Includes object references and BCS for all input objects.
+///
+/// If the serving node no longer has one of the objects (e.g. pruned),
+/// `get_transactions` requests including this field fail with
+/// `FAILED_PRECONDITION`; narrow the read mask, or fetch objects individually
+/// via `get_objects` for best-effort retrieval.
 pub const EXECUTED_TRANSACTION_INPUT_OBJECTS: &str = "input_objects";
 
 /// Read mask for
 /// [`ExecutedTransaction::output_objects()`](crate::v1::transaction::ExecutedTransaction::output_objects).
 ///
 /// Includes object references and BCS for all output objects.
+///
+/// If the serving node no longer has one of the objects (e.g. pruned),
+/// `get_transactions` requests including this field fail with
+/// `FAILED_PRECONDITION`; narrow the read mask, or fetch objects individually
+/// via `get_objects` for best-effort retrieval.
 pub const EXECUTED_TRANSACTION_OUTPUT_OBJECTS: &str = "output_objects";
+
+/// Read mask for
+/// [`ExecutedTransaction::balance_changes()`](crate::v1::transaction::ExecutedTransaction::balance_changes).
+///
+/// Not included in any default read mask; must be requested explicitly.
+///
+/// If the serving node no longer has a required object (e.g. pruned),
+/// `get_transactions` requests including this field fail with
+/// `FAILED_PRECONDITION`; retry without it in the read mask.
+pub const EXECUTED_TRANSACTION_BALANCE_CHANGES: &str = "balance_changes";
+
+/// Read mask for
+/// [`ExecutedTransaction::object_changes()`](crate::v1::transaction::ExecutedTransaction::object_changes).
+///
+/// Not included in any default read mask; must be requested explicitly.
+///
+/// If the serving node no longer has a required object (e.g. pruned),
+/// `get_transactions` requests including this field fail with
+/// `FAILED_PRECONDITION`; retry without it in the read mask.
+pub const EXECUTED_TRANSACTION_OBJECT_CHANGES: &str = "object_changes";
 
 // ---------------------------------------------------------------------------
 // Transaction — sub-field constants (relative to ExecutedTransaction)


### PR DESCRIPTION
# Description of change

Adds `balance_changes` and `object_changes` to the gRPC `ExecutedTransaction` message, so nodes can return the equivalent of the JSON-RPC `showBalanceChanges` / `showObjectChanges` response options over gRPC. Both fields are strictly opt-in: they must be requested explicitly via the read mask and are not part of any default read mask.

## Proto changes (`iota-sdk-grpc-types`)

- New `Owner` message in `types.proto` (oneof `address_owner` / `object_owner` / `shared` / `immutable`), mirroring `iota_sdk_types::Owner`.
- New messages in `transaction.proto`:
  - `BalanceChange { owner, coin_type, amount }` — `amount` is a decimal-string encoded `i128`; negative means net outflow.
  - `ObjectChange` — a oneof mirroring the JSON-RPC `ObjectChange` enum with one message per variant (`Published`, `Mutated`, `Deleted`, `Wrapped`, `Unwrapped`, `Created`). The JSON-RPC enum's never-emitted `Transferred` variant is deliberately not carried over; the oneof is generated as `#[non_exhaustive]` and adding oneof members is wire-compatible, so variants can be added later without breaking clients.
  - Transparent list wrappers `BalanceChanges` / `ObjectChanges` following the existing `Objects` / `Events` pattern, so read-mask paths address the inner fields directly (e.g. `balance_changes.amount`, `object_changes.created`).
- `ExecutedTransaction` gains `optional BalanceChanges balance_changes = 9` and `optional ObjectChanges object_changes = 10`; generated code regenerated and committed.

## Conversions and accessors

- `Owner`: `From<iota_sdk_types::Owner>` / `TryFrom<&Owner>` plus an `owner()` convenience method, following the existing `TypeTag` pattern.
- `ExecutedTransaction::balance_changes()` / `object_changes()` accessors.
- `BalanceChange`: `owner()`, `coin_type()`, `amount_i128()` getters returning SDK types.
- All `ObjectChange` variant messages: per-field getters in the usual lazy-conversion style (like `Event`) — `sender()`, `owner()`, `object_id()` / `package_id()`, `digest()`, and `object_type_name()` parsing the canonical type string into a `StructTag`. There is deliberately no whole-message conversion target: `BalanceChange` was removed from `iota-sdk-types` (#563) and `ObjectChange` never existed there, so the proto messages plus these getters are the client surface.

## Read masks and docs

- New field-path constants in `read_mask_fields.rs` (`TransactionField`, `CheckpointTransactionField`, `SimulateExecutedTransactionField`) and per-method constants in `read_masks.rs`. Default read masks are unchanged.
- Documented the node's completeness contract on the proto fields, the accessors, the read-mask constants, and `Client::get_transactions`: if the serving node no longer has a transaction's objects (e.g. pruned), requests including `input_objects` / `output_objects` / `balance_changes` / `object_changes` fail with `FAILED_PRECONDITION` instead of returning silently incomplete or wrong data — narrow the read mask or use `get_objects` for best-effort per-object retrieval.

The server-side implementation (derivation from effects + input/output objects, no new lookup tables) is in iotaledger/iota#12183.

## Links to any relevant issues

Companion server-side PR: iotaledger/iota#12183.

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

`make grpc` regenerates cleanly with no drift; `make clippy`, `cargo +nightly fmt`, 44 unit tests and 22 doc tests pass. Read-mask path tests extended for the new constants. End-to-end behavior (including read-mask gating and field-mask validation of nested oneof paths like `object_changes.created.object_id`) is exercised by the companion PR's (iotaledger/iota#12183) e2e tests against this branch.

### Release Notes

- [ ] Protocol:
- [ ] Nodes (Validators and Full nodes):
- [ ] Indexer:
- [ ] JSON-RPC:
- [ ] GraphQL:
- [ ] CLI:
- [x] Rust SDK: Added `Owner`, `BalanceChange(s)` and `ObjectChange(s)` gRPC proto messages with SDK-type conversions/getters and read-mask constants.
- [x] gRPC: `ExecutedTransaction` gains opt-in `balance_changes` and `object_changes` fields (requires a node that populates them).

#### Breaking Changes Rollout

No breaking changes — the new proto fields and messages are purely additive, and default read masks are unchanged.


