### PR TITLE
fix(ci): use recursive glob for changelog include-path

### DIFF
--- a/.github/gen_changelog.sh
+++ b/.github/gen_changelog.sh
@@ -20,7 +20,7 @@ echo "Commit from: $COMMIT_FROM" 1>&2
 
 echo "Commit to: $COMMIT_TO" 1>&2
 
-ENTRY=$(git-cliff $COMMIT_FROM..$COMMIT_TO --tag $VERSION --include-path $PACKAGE_ROOT)
+ENTRY=$(git-cliff "$COMMIT_FROM..$COMMIT_TO" --tag "$VERSION" --include-path "$PACKAGE_ROOT/**")
 echo "$ENTRY"
 
 if [ "$ADD" = "true" ]; then


### PR DESCRIPTION
## Why

`gen_changelog.sh` produced empty release notes (only the `## [version]` header) for the binding SDK releases.

## What

`git-cliff --include-path` expects a **glob**, not a plain directory. A bare `bindings/swift` matched no changed files (commits touch `bindings/swift/...`), so every commit was filtered out. Switched to `"$PACKAGE_ROOT/**"` and quoted the args.

Verified locally: with the glob, git-cliff emits the full Features/Bug Fixes/Other sections; without it, only the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)