### PR TITLE
feat: add MoveAuthenticationError execution error

### DIFF
--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -282,9 +282,10 @@ pub enum ExecutionError {
 }
 
 /// Holds an [`ExecutionError`] so it can be nested inside another
-/// [`ExecutionError`]. A uniffi enum cannot contain itself by value, so a
-/// variant that carries a further execution error references it through this
-/// object and reads it back via [`ExecutionErrorWrapper::inner`].
+/// [`ExecutionError`].
+// Workaround for UniFFI <0.32: enums cannot contain themselves by value, so a
+// variant that carries another execution error stores it through this wrapper.
+// Access the wrapped value via [`ExecutionErrorWrapper::inner`].
 #[derive(Debug, uniffi::Object)]
 pub struct ExecutionErrorWrapper(iota_sdk::types::ExecutionError);
 

--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -108,6 +108,7 @@ impl From<ExecutionStatus> for iota_sdk::types::ExecutionStatus {
 ///                 =/ execution-cancelled-due-to-randomness-unavailable
 ///                 =/ execution-cancelled-due-to-shared-object-congestion-v2
 ///                 =/ invalid-linkage
+///                 =/ move-authentication-error
 ///
 /// insufficient-gas                                       = %d00
 /// invalid-gas-object                                     = %d01
@@ -148,6 +149,7 @@ impl From<ExecutionStatus> for iota_sdk::types::ExecutionStatus {
 /// execution-cancelled-due-to-randomness-unavailable      = %d36
 /// execution-cancelled-due-to-shared-object-congestion-v2 = %d37 (vector object-id) u64
 /// invalid-linkage                                        = %d38
+/// move-authentication-error                              = %d39 execution-error
 /// ```
 #[derive(uniffi::Enum)]
 pub enum ExecutionError {
@@ -272,6 +274,26 @@ pub enum ExecutionError {
     /// A valid linkage was unable to be determined for the transaction or one
     /// of its commands.
     InvalidLinkage,
+    /// The transaction's Move-based authentication failed while executing an
+    /// authenticator, before the programmable transaction was run. The
+    /// wrapped error is the failure produced by the authenticator's
+    /// execution.
+    MoveAuthenticationError { error: Arc<ExecutionErrorWrapper> },
+}
+
+/// Holds an [`ExecutionError`] so it can be nested inside another
+/// [`ExecutionError`]. A uniffi enum cannot contain itself by value, so a
+/// variant that carries a further execution error references it through this
+/// object and reads it back via [`ExecutionErrorWrapper::inner`].
+#[derive(Debug, uniffi::Object)]
+pub struct ExecutionErrorWrapper(iota_sdk::types::ExecutionError);
+
+#[uniffi::export]
+impl ExecutionErrorWrapper {
+    /// The wrapped execution error.
+    pub fn inner(&self) -> ExecutionError {
+        self.0.clone().into()
+    }
 }
 
 impl From<iota_sdk::types::ExecutionError> for ExecutionError {
@@ -410,6 +432,11 @@ impl From<iota_sdk::types::ExecutionError> for ExecutionError {
                 Self::ExecutionCancelledDueToRandomnessUnavailable
             }
             iota_sdk::types::ExecutionError::InvalidLinkage => Self::InvalidLinkage,
+            iota_sdk::types::ExecutionError::MoveAuthenticationError { error } => {
+                Self::MoveAuthenticationError {
+                    error: Arc::new(ExecutionErrorWrapper(*error)),
+                }
+            }
             _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
@@ -529,6 +556,9 @@ impl From<ExecutionError> for iota_sdk::types::ExecutionError {
                 Self::ExecutionCancelledDueToRandomnessUnavailable
             }
             ExecutionError::InvalidLinkage => Self::InvalidLinkage,
+            ExecutionError::MoveAuthenticationError { error } => Self::MoveAuthenticationError {
+                error: Box::new(error.0.clone()),
+            },
         }
     }
 }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -205,6 +205,7 @@ execution-error = %d00                               ; InsufficientGas
                 / %d36                               ; ExecutionCancelledDueToRandomnessUnavailable
                 / %d37 (size *object-id) u64         ; ExecutionCancelledDueToSharedObjectCongestionV2
                 / %d38                               ; InvalidLinkage
+                / %d39 execution-error               ; MoveAuthenticationError
 
 execution-status = %d00                                     ; Success
                  / %d01 execution-error (%d00 / %d01 u64)   ; Failure

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -160,6 +160,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 ///                 =/ execution-cancelled-due-to-randomness-unavailable
 ///                 =/ execution-cancelled-due-to-shared-object-congestion-v2
 ///                 =/ invalid-linkage
+///                 =/ move-authentication-error
 ///
 /// insufficient-gas                                       = %d00
 /// invalid-gas-object                                     = %d01
@@ -200,6 +201,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 /// execution-cancelled-due-to-randomness-unavailable      = %d36
 /// execution-cancelled-due-to-shared-object-congestion-v2 = %d37 (vector object-id) u64
 /// invalid-linkage                                        = %d38
+/// move-authentication-error                              = %d39 execution-error
 /// ```
 // WARNING: The variant order of this enum is protocol-significant. Each variant's position
 // determines its BCS discriminant (the integer sent over the wire).
@@ -407,6 +409,13 @@ pub enum ExecutionError {
     /// of its commands.
     #[error("A valid linkage was unable to be determined for the transaction")]
     InvalidLinkage,
+    /// The transaction's Move-based authentication failed while executing an
+    /// authenticator, before the programmable transaction was run. The
+    /// wrapped error is the failure produced by the authenticator's
+    /// execution.
+    #[error("Move authentication failed: {error}")]
+    #[cfg_attr(feature = "proptest", weight(0))]
+    MoveAuthenticationError { error: Box<ExecutionError> },
 }
 
 impl ExecutionError {
@@ -450,6 +459,7 @@ impl ExecutionError {
         ExecutionCancelledDueToRandomnessUnavailable,
         ExecutionCancelledDueToSharedObjectCongestionV2,
         InvalidLinkage,
+        MoveAuthenticationError,
     );
 
     pub fn command_argument_error(kind: CommandArgumentError, argument: u16) -> Self {


### PR DESCRIPTION
# Description of change

Adds a distinct execution error for Move-based authentication failures.

* New `ExecutionError::MoveAuthenticationError { error: Box<ExecutionError> }` variant (`%d39`), wrapping the underlying failure.
* FFI mirror via an `ExecutionErrorWrapper` object (uniffi enums can't nest by value).

## Links to any relevant issues

fixes [#11986 ](https://github.com/iotaledger/iota/issues/11986)
