### PR TITLE
fix(ci): avoid cargo-udeps segfault by fetching git deps with the git CLI

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           tool: cargo-udeps
       - name: Run Cargo Udeps
+        # The prebuilt cargo-udeps binary is statically linked against musl and
+        # intermittently segfaults in its in-process git fetch of large git
+        # dependencies (the iota monorepo). Shelling out to the system git
+        # avoids that code path.
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: cargo +nightly-2026-06-29 udeps ${{ matrix.flags }}
 
   proto-build:


### PR DESCRIPTION
The "Check Unused Dependencies" job intermittently dies with a segfault (exit 139) while cargo-udeps fetches the iota monorepo git dependency. The prebuilt cargo-udeps binary from `taiki-e/install-action` is statically linked against musl, and its in-process git fetch crashes on the large repo some fraction of the time (known failure mode of musl-static cargo builds, e.g. est31/cargo-udeps#89).

Setting `CARGO_NET_GIT_FETCH_WITH_CLI=true` on the udeps step makes cargo shell out to the system git for the fetch, avoiding the crashing code path. No change to what udeps checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mS85f8pmhupUF4VsoemMj

---
_Generated by [Claude Code](https://claude.ai/code/session_013mS85f8pmhupUF4VsoemMj)_