### PR TITLE
feat: add SimpleSignature to_base64/from_base64

### DIFF
--- a/crates/iota-sdk-ffi/src/types/signature.rs
+++ b/crates/iota-sdk-ffi/src/types/signature.rs
@@ -269,6 +269,15 @@ impl SimpleSignature {
         self.0.to_bytes()
     }
 
+    pub fn to_base64(&self) -> String {
+        self.0.to_base64()
+    }
+
+    #[uniffi::constructor]
+    pub fn from_base64(base64: String) -> Result<Self> {
+        Ok(iota_sdk::types::SimpleSignature::from_base64(&base64).map(Self)?)
+    }
+
     /// The raw signature bytes, without the scheme flag or the public key.
     pub fn signature_bytes(&self) -> Vec<u8> {
         self.0.signature_bytes().to_vec()

--- a/crates/iota-sdk-ffi/src/types/signature.rs
+++ b/crates/iota-sdk-ffi/src/types/signature.rs
@@ -269,10 +269,13 @@ impl SimpleSignature {
         self.0.to_bytes()
     }
 
+    /// Base64-encode this signature as its `flag || sig || pubkey` bytes.
     pub fn to_base64(&self) -> String {
         self.0.to_base64()
     }
 
+    /// Decode a signature from the Base64 form produced by `to_base64`, i.e.
+    /// base64 over the `flag || sig || pubkey` bytes.
     #[uniffi::constructor]
     pub fn from_base64(base64: String) -> Result<Self> {
         Ok(iota_sdk::types::SimpleSignature::from_base64(&base64).map(Self)?)

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -508,12 +508,17 @@ mod serialization {
             }
         }
 
+        /// Base64-encode this signature as its `flag || sig || pubkey` bytes,
+        /// the same layout as [`to_bytes`](Self::to_bytes).
         pub fn to_base64(&self) -> String {
             use base64ct::Encoding;
 
             base64ct::Base64::encode_string(&self.to_bytes())
         }
 
+        /// Decode a signature from the Base64 form produced by
+        /// [`to_base64`](Self::to_base64), i.e. base64 over the
+        /// `flag || sig || pubkey` bytes.
         pub fn from_base64(s: &str) -> Result<Self, bcs::Error> {
             use base64ct::Encoding;
             use serde::de::Error;

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -507,6 +507,20 @@ mod serialization {
                 }
             }
         }
+
+        pub fn to_base64(&self) -> String {
+            use base64ct::Encoding;
+
+            base64ct::Base64::encode_string(&self.to_bytes())
+        }
+
+        pub fn from_base64(s: &str) -> Result<Self, bcs::Error> {
+            use base64ct::Encoding;
+            use serde::de::Error;
+
+            let bytes = base64ct::Base64::decode_vec(s).map_err(bcs::Error::custom)?;
+            Self::from_bytes(&bytes).map_err(serde::de::Error::custom)
+        }
     }
 
     impl serde::Serialize for SimpleSignature {
@@ -968,6 +982,33 @@ mod serialization {
                 let json = serde_json::to_string_pretty(&sig).unwrap();
                 println!("{json}");
                 assert_eq!(sig, serde_json::from_str(&json).unwrap());
+            }
+        }
+
+        #[test]
+        fn simple_signature_base64_roundtrip() {
+            const FIXTURES: &[&str] = &[
+                "YQDaeO4w2ULMy5eqHBzP0oalr1YhDX/9uJS9MntKnW3d55q4aqZYYnoEloaBmXKc6FoD5bTwONdwS9CwdMQGhIcPDX2rNYyNrapO+gBJp1sHQ2VVsQo2ghm7aA9wVxNJ13U=",
+                "YgErcT6WUSQXGD1DaIwls5rWq648akDMlvL41ugUUhyIPWnqURl+daQLG+ILNemARKHYVNOikKJJ8jqu+HzlRa5rAg4XzVk55GsZZkGWjNdZkQuiV34n+nP944dtub7FvOsr",
+                "YgLp1p4K9dSQTt2AeR05yK1MkXmtLm6Sieb9yfkpW1gOBiqnO9ZKZiWUrLJQav2Mxw64zM37g3IVdsB/To6qfl8IA0f7ryPwOKvEwwiicRF6Kkz/rt28X/gcdRe8bHSn7bQw",
+            ];
+
+            for fixture in FIXTURES {
+                let bcs = Base64::decode_vec(fixture).unwrap();
+                let UserSignature::Simple(simple) = bcs::from_bytes(&bcs).unwrap() else {
+                    panic!("fixture is not a simple signature");
+                };
+
+                // Base64 is over the same `flag || sig || pubkey` bytes.
+                assert_eq!(
+                    simple.to_base64(),
+                    Base64::encode_string(&simple.to_bytes())
+                );
+                // Round-trips through base64.
+                assert_eq!(
+                    simple,
+                    SimpleSignature::from_base64(&simple.to_base64()).unwrap()
+                );
             }
         }
 


### PR DESCRIPTION
Adds `SimpleSignature::to_base64()` / `from_base64()` (and the matching FFI wrappers), mirroring the existing `UserSignature` helpers — base64 over the `flag ‖ sig ‖ pubkey` bytes via `base64ct`.

Consumers holding a bare `SimpleSignature` (e.g. the node's ledger examples in iotaledger/iota#12034) currently have to reach for `to_bytes()` plus an external base64 encoder; this lets them encode/decode directly. Pure additive accessors — no type or serialization change.

Follows up on the reviewer suggestion in iotaledger/iota#12034.

## Test plan
- New `simple_signature_base64_roundtrip` unit test: `to_base64()` equals base64 of `to_bytes()`, and `from_base64` round-trips, across the ed25519/secp256k1/secp256r1 fixtures.
- `cargo clippy -p iota-sdk-types -p iota-sdk-ffi --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvqDfXkp38eHSkKKXvEedF)_