### PR TITLE
fix: silence clippy::question_mark in FieldMaskTree

### DIFF
--- a/crates/iota-sdk-grpc-types/src/field/field_mask_tree.rs
+++ b/crates/iota-sdk-grpc-types/src/field/field_mask_tree.rs
@@ -208,11 +208,7 @@ impl FieldMaskTree {
 
         let mut node = &self.root;
         for component in path.split(FIELD_SEPARATOR) {
-            if let Some(child) = node.children.get(component) {
-                node = child;
-            } else {
-                return None;
-            }
+            node = node.children.get(component)?;
         }
 
         if std::ptr::eq(node, &self.root) {


### PR DESCRIPTION
Fixes the `clippy::question_mark` failure in `make clippy`.

- Replaced the `if let Some(child) = ... else return None` block in `FieldMaskTree` path lookup with the `?` operator.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HVrhCfWGYof7QCKUshqtFd)_