### PR TITLE
fix: remove redundant borrows flagged by clippy 1.97

### DIFF
--- a/crates/iota-sdk-graphql-client/src/output_types/mod.rs
+++ b/crates/iota-sdk-graphql-client/src/output_types/mod.rs
@@ -228,7 +228,7 @@ impl DynamicFieldOutput {
         assert_eq!(
             expected_type, &self.name.type_,
             "Expected type {expected_type}, but got {}",
-            &self.name.type_
+            self.name.type_
         );
 
         let bcs = &self.name.bcs;

--- a/crates/iota-sdk-grpc-proto-build/src/message_graph.rs
+++ b/crates/iota-sdk-grpc-proto-build/src/message_graph.rs
@@ -137,7 +137,7 @@ impl<'a> FileParser<'a> {
                     assert_eq!("key", key.name());
                     assert_eq!("value", value.name());
 
-                    let name = format!("{}.{}", type_name, nested_type.name());
+                    let name = format!("{type_name}.{}", nested_type.name());
                     Either::Right((name, (key, value)))
                 } else {
                     Either::Left((nested_type.clone(), idx))

--- a/crates/iota-sdk-grpc-proto-build/src/message_graph.rs
+++ b/crates/iota-sdk-grpc-proto-build/src/message_graph.rs
@@ -137,7 +137,7 @@ impl<'a> FileParser<'a> {
                     assert_eq!("key", key.name());
                     assert_eq!("value", value.name());
 
-                    let name = format!("{}.{}", &type_name, nested_type.name());
+                    let name = format!("{}.{}", type_name, nested_type.name());
                     Either::Right((name, (key, value)))
                 } else {
                     Either::Left((nested_type.clone(), idx))


### PR DESCRIPTION
CI runners moved to Rust 1.97.0, whose new `useless_borrows_in_formatting` clippy lint fails the workspace lint job. This removes the two redundant `&`s it flags, verified locally with a full `cargo +1.97.0 clippy --all-features --all-targets` sweep.

Unblocks the lint check on currently open PRs (e.g. #1247).

🤖 Generated with [Claude Code](https://claude.com/claude-code)