### PR TITLE
feat(move-types): mirror the new package-metadata types and bump the pinned iota rev

### DIFF
--- a/crates/iota-sdk-ffi/src/move_types.rs
+++ b/crates/iota-sdk-ffi/src/move_types.rs
@@ -18,11 +18,11 @@
 //!   [`UpgradeCap`], [`Publisher`], [`Kiosk`], [`KioskOwnerCap`], [`DenyList`],
 //!   [`Random`], [`AuthenticatorState`], [`PackageMetadataV1`] (with its
 //!   [`ModuleMetadataV1`] and [`AuthenticatorMetadataV1`] records),
-//!   [`TreasuryCap`], [`RegulatedCoinMetadata`], [`DenyCapV1`], [`Display`],
-//!   [`CoinManager`], [`CoinManagerTreasuryCap`], [`CoinManagerMetadataCap`],
-//!   [`Token`], [`TokenPolicyCap`], [`TokenPolicy`], [`Config`],
-//!   [`TransferPolicy`], [`TransferPolicyCap`], [`LabelerCap`],
-//!   [`PurchaseCap`].
+//!   [`ModuleMetadata`], [`TreasuryCap`], [`RegulatedCoinMetadata`],
+//!   [`DenyCapV1`], [`Display`], [`CoinManager`], [`CoinManagerTreasuryCap`],
+//!   [`CoinManagerMetadataCap`], [`Token`], [`TokenPolicyCap`],
+//!   [`TokenPolicy`], [`Config`], [`TransferPolicy`], [`TransferPolicyCap`],
+//!   [`LabelerCap`], [`PurchaseCap`].
 //! - **Stardust types** (`0x107a`): [`Nft`], [`Irc27Metadata`],
 //!   [`BasicOutput`], [`NftOutput`], [`AliasOutput`], [`Alias`], plus the
 //!   unlock-condition records [`TimelockUnlockCondition`],
@@ -867,6 +867,20 @@ crate::ffi_move_object! {
                 .iter()
                 .map(|e| (ascii_to_string(&e.key), (&e.value).into()))
                 .collect()
+        }
+    }
+}
+
+crate::ffi_move_object! {
+    /// A typed view of an on-chain `0x2::module_metadata::ModuleMetadata`
+    /// object, the per-module key-value store owned by a package's
+    /// `PackageMetadataV1`.
+    ModuleMetadata(iota_sdk::move_types::iota_framework::module_metadata::ModuleMetadata) {
+        /// The number of key-value pairs stored in the metadata's dynamic
+        /// fields. The entries themselves (e.g. the view-function names) live
+        /// in dynamic fields, not in this object's contents.
+        pub fn size(&self) -> u64 {
+            self.0.size
         }
     }
 }

--- a/crates/iota-sdk-move-types/Cargo.toml
+++ b/crates/iota-sdk-move-types/Cargo.toml
@@ -44,7 +44,7 @@ iota-bcs-schema = { workspace = true, features = ["move-shape"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # `update_compiled_packages.sh` reads this rev via `cargo metadata` so the
 # parser matches the fetched blobs.
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", rev = "433865dc51241ebf738ca127d9fd6b4463e1ec60" }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", rev = "2e0ad64996fc65d9eec2aa64732a09609f76c7cb" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true

--- a/crates/iota-sdk-move-types/bcs-schema.abnf
+++ b/crates/iota-sdk-move-types/bcs-schema.abnf
@@ -155,7 +155,18 @@ lock = id   ; id
 
 metadata-ownership-renounced = string   ; coin-name
 
+module-metadata = uid   ; id
+                  u64   ; size
+
+module-metadata-key = string
+
 module-metadata-v1 = (size *authenticator-metadata-v1)   ; authenticator-metadata
+
+module-metadata-v1-field-name = bool   ; dummy-field
+
+module-name = string
+
+modules-metadata-field-name = bool   ; dummy-field
 
 nft = bool   ; dummy-field
 
@@ -163,6 +174,8 @@ object-bag = uid   ; id
              u64   ; size
 
 package-metadata-key = bool   ; dummy-field
+
+package-metadata-version-field-name = bool   ; dummy-field
 
 per-type-config-created = config-key   ; key
                           id           ; config-id
@@ -396,6 +409,8 @@ version-change-cap = id    ; versioned-id
 
 versioned = uid   ; id
             u64   ; version
+
+view-function-metadata-v1-field-name = bool   ; dummy-field
 
 voting-power-info-v1 = u64   ; validator-index
                        u64   ; voting-power

--- a/crates/iota-sdk-move-types/src/move_shape_compare.rs
+++ b/crates/iota-sdk-move-types/src/move_shape_compare.rs
@@ -234,6 +234,48 @@ fn expected_entries() -> Vec<Entry> {
         ),
         entry!(
             IotaFramework,
+            "package_metadata",
+            "PackageMetadataVersionFieldName",
+            iota_framework::package_metadata::PackageMetadataVersionFieldName
+        ),
+        entry!(
+            IotaFramework,
+            "package_metadata",
+            "ModuleMetadataV1FieldName",
+            iota_framework::package_metadata::ModuleMetadataV1FieldName
+        ),
+        entry!(
+            IotaFramework,
+            "package_metadata",
+            "ModulesMetadataFieldName",
+            iota_framework::package_metadata::ModulesMetadataFieldName
+        ),
+        entry!(
+            IotaFramework,
+            "package_metadata",
+            "ModuleName",
+            iota_framework::package_metadata::ModuleName
+        ),
+        entry!(
+            IotaFramework,
+            "module_metadata",
+            "ModuleMetadata",
+            iota_framework::module_metadata::ModuleMetadata
+        ),
+        entry!(
+            IotaFramework,
+            "module_metadata",
+            "ModuleMetadataKey",
+            iota_framework::module_metadata::ModuleMetadataKey
+        ),
+        entry!(
+            IotaFramework,
+            "module_metadata",
+            "ViewFunctionMetadataV1FieldName",
+            iota_framework::module_metadata::ViewFunctionMetadataV1FieldName
+        ),
+        entry!(
+            IotaFramework,
             "deny_list",
             "ConfigWriteCap",
             iota_framework::deny_list::ConfigWriteCap

--- a/crates/iota-sdk-move-types/src/packages/iota_framework.rs
+++ b/crates/iota-sdk-move-types/src/packages/iota_framework.rs
@@ -2258,6 +2258,67 @@ pub mod test_scenario {
     }
 }
 
+/// Types from `0x2::module_metadata`.
+pub mod module_metadata {
+    use super::object::UID;
+    use crate::move_stdlib::ascii;
+
+    /// Rust version of the Move `iota::module_metadata::ModuleMetadata`
+    /// type.
+    ///
+    /// On-chain metadata associated with a single module of a package: a
+    /// key-value store backed by dynamic fields, owned by the package's
+    /// [`PackageMetadataV1`](super::package_metadata::PackageMetadataV1)
+    /// object. Like the other dynamic-field containers, the mirror carries
+    /// only the handle and an entry count.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ModuleMetadata {
+        pub id: UID,
+        /// The number of key-value pairs stored in the metadata's dynamic
+        /// fields.
+        pub size: u64,
+    }
+
+    impl_try_from_object!(ModuleMetadata);
+
+    /// Rust version of the Move `iota::module_metadata::ModuleMetadataKey`
+    /// type.
+    ///
+    /// Key used to derive the address of a [`ModuleMetadata`] object from
+    /// the owning package ID and the module name.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ModuleMetadataKey(pub ascii::String);
+
+    /// Rust version of the Move
+    /// `iota::module_metadata::ViewFunctionMetadataV1FieldName` type.
+    ///
+    /// Dynamic-field key for the list of view function names of the module.
+    /// The Move struct is empty; the Rust mirror carries a `dummy_field` to
+    /// preserve the BCS wire format.
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ViewFunctionMetadataV1FieldName {
+        dummy_field: bool,
+    }
+}
+
 /// Types from `0x2::package_metadata`.
 pub mod package_metadata {
     use super::{
@@ -2283,6 +2344,65 @@ pub mod package_metadata {
     }
 
     /// Rust version of the Move
+    /// `iota::package_metadata::PackageMetadataVersionFieldName` type.
+    ///
+    /// Dynamic-field key for the package metadata version. Empty in Move;
+    /// the Rust mirror carries a `dummy_field` for BCS shape.
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct PackageMetadataVersionFieldName {
+        dummy_field: bool,
+    }
+
+    /// Rust version of the Move
+    /// `iota::package_metadata::ModuleMetadataV1FieldName` type.
+    ///
+    /// Dynamic-field key for a module's [`ModuleMetadataV1`]. Empty in Move;
+    /// the Rust mirror carries a `dummy_field` for BCS shape.
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ModuleMetadataV1FieldName {
+        dummy_field: bool,
+    }
+
+    /// Rust version of the Move
+    /// `iota::package_metadata::ModulesMetadataFieldName` type.
+    ///
+    /// Dynamic-field key for the map from module names to
+    /// [`ModuleMetadata`](super::module_metadata::ModuleMetadata) objects.
+    /// Empty in Move; the Rust mirror carries a `dummy_field` for BCS shape.
+    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ModulesMetadataFieldName {
+        dummy_field: bool,
+    }
+
+    /// Rust version of the Move `iota::package_metadata::ModuleName` type.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct ModuleName(pub ascii::String);
+
+    /// Rust version of the Move
     /// `iota::package_metadata::PackageMetadataV1` type.
     ///
     /// Represents the metadata of a Move package, including storage ID,
@@ -2300,6 +2420,10 @@ pub mod package_metadata {
         /// Runtime ID of the package — the storage ID of the first version.
         pub runtime_id: ID,
         pub package_version: u64,
+        /// Per-module metadata, keyed by module name. Deprecated upstream in
+        /// favor of a dynamic field attached to this object that maps module
+        /// names to [`ModuleMetadata`](super::module_metadata::ModuleMetadata)
+        /// objects.
         pub modules_metadata: VecMap<ascii::String, ModuleMetadataV1>,
     }
 
@@ -2308,7 +2432,9 @@ pub mod package_metadata {
     /// Rust version of the Move
     /// `iota::package_metadata::ModuleMetadataV1` type.
     ///
-    /// V1 includes only the authenticator function information.
+    /// V1 includes only the authenticator function information. Deprecated
+    /// upstream in favor of
+    /// [`ModuleMetadata`](super::module_metadata::ModuleMetadata).
     #[derive(Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
     #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]

--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -425,7 +425,8 @@ impl StructTag {
         object_bag::ObjectBag,
         tx_context::TxContext,
         deny_list::DenyList,
-        package_metadata::PackageMetadataV1
+        package_metadata::PackageMetadataV1,
+        module_metadata::ModuleMetadata
     );
     add_struct_tag_ctor!(@with_module FRAMEWORK, deny_list::ConfigKey, deny_list::AddressKey, deny_list::GlobalPauseKey);
     add_struct_tag_ctor!(


### PR DESCRIPTION
## Why

The nightly drift check flagged upstream changes to the framework's public type surface: iotaledger/iota#11616 moves package metadata toward dynamic fields (new `0x2::module_metadata` module plus dynamic-field name types in `0x2::package_metadata`).

## What

- Mirror the 7 new types; add deprecation notes on `modules_metadata` / `ModuleMetadataV1` (existing layouts are unchanged, so this is additive)
- Add the `module_metadata::ModuleMetadata` tag helpers in `iota-sdk-types`
- Bump the pinned rev to `2e0ad6499`, regenerate `bcs-schema.abnf`, register the new types in the shape-compare tests

Tests pass against the packages compiled at the new rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)