### PR TITLE
chore(ci): point the drift check at the upstream commits behind the drift

### DIFF
--- a/.github/workflows/move_types_drift_nightly.yml
+++ b/.github/workflows/move_types_drift_nightly.yml
@@ -63,8 +63,9 @@ jobs:
             # Best-effort pointer at the drift sources: upstream commits in
             # pinned..develop that touched published_api.txt. May include
             # commits that only changed the function surface (which the type
-            # diff above ignores).
-            pinned="$(grep --only-matching --perl-regexp 'iotaledger/iota\.git", rev = "\K[0-9a-f]{40}' crates/iota-sdk-move-types/Cargo.toml || true)"
+            # diff above ignores). The fetch step above resolved the pin via
+            # `cargo metadata` and recorded it in `.fetched-ref`.
+            pinned="$(cat crates/iota-sdk-move-types/src/packages_compiled/.fetched-ref 2>/dev/null || true)"
             if [ -n "$pinned" ]; then
               echo "Upstream commits since the pinned rev that touched published_api.txt (likely drift sources):"
               gh api --paginate "repos/iotaledger/iota/compare/${pinned}...develop" --jq '.commits[].sha' > range_shas.txt || true

--- a/.github/workflows/move_types_drift_nightly.yml
+++ b/.github/workflows/move_types_drift_nightly.yml
@@ -53,11 +53,27 @@ jobs:
                 }' > head_published_api.txt
 
       - name: Diff pinned type surface against develop HEAD
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if ! diff -u \
             crates/iota-sdk-move-types/src/packages_compiled/published_api.txt \
             head_published_api.txt; then
             echo
+            # Best-effort pointer at the drift sources: upstream commits in
+            # pinned..develop that touched published_api.txt. May include
+            # commits that only changed the function surface (which the type
+            # diff above ignores).
+            pinned="$(grep --only-matching --perl-regexp 'iotaledger/iota\.git", rev = "\K[0-9a-f]{40}' crates/iota-sdk-move-types/Cargo.toml || true)"
+            if [ -n "$pinned" ]; then
+              echo "Upstream commits since the pinned rev that touched published_api.txt (likely drift sources):"
+              gh api --paginate "repos/iotaledger/iota/compare/${pinned}...develop" --jq '.commits[].sha' > range_shas.txt || true
+              gh api "repos/iotaledger/iota/commits?path=crates/iota-framework/published_api.txt&sha=develop&per_page=100" \
+                --jq '.[] | .sha + " " + (.commit.message | split("\n")[0])' \
+                | { grep --fixed-strings --file=range_shas.txt || true; } \
+                | sed 's|^|  https://github.com/iotaledger/iota/commit/|'
+              echo
+            fi
             echo "::error::Move framework type drift detected."
             echo "Upstream iotaledger/iota@develop changed the public type surface of crates/iota-framework since the pinned rev (the move-binary-format rev in crates/iota-sdk-move-types/Cargo.toml)."
             echo "Review the diff above, add/update the Rust mirrors, bump that rev to the new monorepo SHA, run 'make update-compiled-packages' + 'make test' locally, and open a PR."


### PR DESCRIPTION
On a drift failure, the nightly check now also prints linked upstream commits between the pinned rev and develop HEAD that touched `published_api.txt`. Best effort: the list can include commits that only changed the function surface, which the type diff ignores.

Verified the API pipeline locally against today's drift; it points at iotaledger/iota#11616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)