### PR TITLE
fix(ci): build cargo-udeps from source to avoid musl binary segfault

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -96,14 +96,13 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install cargo-udeps
-        uses: taiki-e/install-action@7a79fe8c3a13344501c80d99cae481c1c9085912 # v2.81.10
+        # Built from source (cached) because the prebuilt musl-static binary
+        # intermittently segfaults while unpacking the large iota monorepo
+        # git dependency.
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: cargo-udeps
+          tool: cargo-udeps@0.1.61
       - name: Run Cargo Udeps
-        # The prebuilt cargo-udeps binary is statically linked against musl and
-        # intermittently segfaults in its in-process git fetch of large git
-        # dependencies (the iota monorepo). Shelling out to the system git
-        # avoids that code path.
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
         run: cargo +nightly-2026-06-29 udeps ${{ matrix.flags }}


### PR DESCRIPTION
The udeps segfault persists after #1260: the git CLI fetch now succeeds, but the prebuilt musl-static cargo-udeps binary still crashes right after, while unpacking the iota monorepo git dependency (see [this run](https://github.com/iotaledger/iota-rust-sdk/actions/runs/29484855225/job/87576801136)).

Replace the prebuilt binary with a source build via `taiki-e/cache-cargo-install-action` (pinned to v3.0.7). The compiled binary is cached keyed on the pinned `cargo-udeps@0.1.61`, so only the first run after a cache miss pays the compile cost.

Verified: the [Lints workflow](https://github.com/iotaledger/iota-rust-sdk/actions/runs/29486975700) was run 6 times on this branch (initial run + 5 re-runs); both `Check Unused Dependencies` jobs passed on every attempt, no segfaults. Cold-cache run took ~9 min (one-time compile), cached runs ~5.5 min — same as before the change, since the udeps jobs are not the workflow's critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mS85f8pmhupUF4VsoemMj