### PR TITLE
feat: add Serialize, Hash, and conversions to SenderSignedTransaction

### DIFF
--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -372,7 +372,7 @@ mod type_digest {
         ///
         /// Unlike the other type digests, this hashes the BCS bytes directly,
         /// without a salt prefix.
-        pub fn digest(&self) -> SenderSignedDataDigest {
+        pub fn full_message_digest(&self) -> SenderSignedDataDigest {
             let mut hasher = Hasher::new();
             bcs::serialize_into(&mut hasher, self).expect("bcs serialization failed");
             hasher.finalize().into()

--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -272,6 +272,18 @@ impl From<crate::UserSignature> for Address {
     }
 }
 
+/// Error returned when no signature in a
+/// [`SignedTransaction`](crate::SignedTransaction) commits to an expected
+/// signer address.
+#[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("no signature found for address {address}")]
+pub struct MissingSignatureError {
+    /// The address no signature commits to.
+    pub address: Address,
+}
+
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod type_digest {
@@ -397,6 +409,57 @@ mod type_digest {
         pub fn digest(&self) -> Digest {
             const SALT: &str = "MoveAuthenticator::";
             type_digest(SALT, self)
+        }
+    }
+
+    impl crate::UserSignature {
+        /// Calculate the auth digest for this signature.
+        ///
+        /// For [`MoveAuthenticator`](crate::MoveAuthenticator) signatures this
+        /// equals
+        /// [`MoveAuthenticator::digest()`](crate::MoveAuthenticator::digest).
+        /// For all other signature types it is the Blake2b256 of the
+        /// serialized (flag-prefixed) signature bytes.
+        pub fn auth_digest(&self) -> Digest {
+            match self {
+                Self::MoveAuthenticator(authenticator) => authenticator.digest(),
+                Self::Simple(_) | Self::Multisig(_) | Self::PasskeyAuthenticator(_) => {
+                    Hasher::digest(self.to_bytes())
+                }
+            }
+        }
+    }
+
+    impl crate::SignedTransaction {
+        /// Computes the auth digest for the sender and, if sponsored, for the
+        /// sponsor. See
+        /// [`UserSignature::auth_digest`](crate::UserSignature::auth_digest)
+        /// for the per-signature logic.
+        ///
+        /// Returns an error if no signature commits to the sender or sponsor
+        /// address.
+        pub fn compute_auth_digests(
+            &self,
+        ) -> Result<(Digest, Option<Digest>), super::MissingSignatureError> {
+            let crate::Transaction::V1(transaction) = &self.transaction;
+
+            let digest_for_address = |address| {
+                self.signatures
+                    .iter()
+                    .find(|signature| signature.derive_address() == address)
+                    .map(crate::UserSignature::auth_digest)
+                    .ok_or(super::MissingSignatureError { address })
+            };
+
+            let sender_auth_digest = digest_for_address(transaction.sender)?;
+            let gas_owner = transaction.gas_payment.owner;
+            let sponsor_auth_digest = if gas_owner != transaction.sender {
+                Some(digest_for_address(gas_owner)?)
+            } else {
+                None
+            };
+
+            Ok((sender_auth_digest, sponsor_auth_digest))
         }
     }
 

--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -279,8 +279,8 @@ mod type_digest {
 
     use super::Hasher;
     use crate::{
-        CheckpointContentsDigest, CheckpointDigest, Digest, ObjectDigest, TransactionDigest,
-        TransactionEffectsDigest, TransactionEventsDigest,
+        CheckpointContentsDigest, CheckpointDigest, Digest, ObjectDigest, SenderSignedDataDigest,
+        TransactionDigest, TransactionEffectsDigest, TransactionEventsDigest,
     };
 
     impl crate::Object {
@@ -363,6 +363,19 @@ mod type_digest {
             let decoded = base64ct::Base64::decode_vec(bytes)
                 .map_err(|e| bcs::Error::Custom(e.to_string()))?;
             Self::from_bcs(&decoded)
+        }
+    }
+
+    impl crate::SenderSignedTransaction {
+        /// Calculate the digest of the full message, committing to the signing
+        /// intent, the transaction, and all signatures.
+        ///
+        /// Unlike the other type digests, this hashes the BCS bytes directly,
+        /// without a salt prefix.
+        pub fn digest(&self) -> SenderSignedDataDigest {
+            let mut hasher = Hasher::new();
+            bcs::serialize_into(&mut hasher, self).expect("bcs serialization failed");
+            hasher.finalize().into()
         }
     }
 

--- a/crates/iota-sdk-types/src/serialization_proptests.rs
+++ b/crates/iota-sdk-types/src/serialization_proptests.rs
@@ -141,6 +141,7 @@ serialization_test!(ProgrammableTransaction);
 serialization_test!(Publish);
 serialization_test!(RandomnessStateUpdate);
 serialization_test!(SignedTransaction);
+serialization_test!(SenderSignedTransaction);
 serialization_test!(SplitCoins);
 serialization_test!(SystemPackage);
 serialization_test!(Transaction);

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -136,7 +136,6 @@ pub struct SignedTransaction {
     pub signatures: Vec<UserSignature>,
 }
 
-// `UserSignature` only implements `Hash` when the `serde` feature is enabled.
 #[cfg(feature = "serde")]
 impl std::hash::Hash for SignedTransaction {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -4,8 +4,8 @@
 
 use super::{
     Address, CheckpointTimestamp, ConsensusCommitDigest, EpochId, Event, GenesisObject, Identifier,
-    ObjectId, ObjectReference, ProtocolVersion, RandomnessRound, TransactionDigest, TypeTag,
-    UserSignature, Version,
+    Intent, IntentMessage, ObjectId, ObjectReference, ProtocolVersion, RandomnessRound,
+    TransactionDigest, TypeTag, UserSignature, Version,
 };
 use crate::utils::write_sep;
 
@@ -40,6 +40,12 @@ pub enum Transaction {
 
 impl Transaction {
     crate::def_is_as_into_opt!(V1(TransactionV1));
+
+    /// Wraps a reference to this transaction in the transaction signing
+    /// intent, producing the message that user signatures commit to.
+    pub fn intent_message(&self) -> IntentMessage<&Self> {
+        IntentMessage::new(Intent::iota_transaction(), self)
+    }
 }
 
 impl From<TransactionV1> for Transaction {
@@ -93,6 +99,12 @@ impl SenderSignedTransaction {
 
     pub fn signatures(&self) -> &[UserSignature] {
         &self.0.signatures
+    }
+
+    /// Wraps a reference to the transaction in the transaction signing
+    /// intent, producing the message that the signatures commit to.
+    pub fn intent_message(&self) -> IntentMessage<&Transaction> {
+        self.0.transaction.intent_message()
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -59,7 +59,18 @@ pub struct TransactionV1 {
     pub expiration: TransactionExpiration,
 }
 
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+/// A [`SignedTransaction`] in its intent-message serialized form.
+///
+/// # BCS
+///
+/// The BCS serialized form for this type is defined by the following ABNF:
+///
+/// ```text
+/// sender-signed-transaction = %d01 intent-signed-transaction
+/// ```
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SenderSignedTransaction(
     #[cfg_attr(
         feature = "serde",
@@ -68,6 +79,25 @@ pub struct SenderSignedTransaction(
     pub SignedTransaction,
 );
 
+impl From<SignedTransaction> for SenderSignedTransaction {
+    fn from(transaction: SignedTransaction) -> Self {
+        Self(transaction)
+    }
+}
+
+impl From<SenderSignedTransaction> for SignedTransaction {
+    fn from(transaction: SenderSignedTransaction) -> Self {
+        transaction.0
+    }
+}
+
+#[cfg(feature = "serde")]
+impl std::hash::Hash for SenderSignedTransaction {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
@@ -75,6 +105,15 @@ pub struct SenderSignedTransaction(
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub signatures: Vec<UserSignature>,
+}
+
+// `UserSignature` only implements `Hash` when the `serde` feature is enabled.
+#[cfg(feature = "serde")]
+impl std::hash::Hash for SignedTransaction {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.transaction.hash(state);
+        self.signatures.hash(state);
+    }
 }
 
 /// A TTL for a transaction

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -4,8 +4,8 @@
 
 use super::{
     Address, CheckpointTimestamp, ConsensusCommitDigest, EpochId, Event, GenesisObject, Identifier,
-    Intent, IntentMessage, ObjectId, ObjectReference, ProtocolVersion, RandomnessRound,
-    TransactionDigest, TypeTag, UserSignature, Version,
+    Intent, IntentMessage, MoveAuthenticator, ObjectId, ObjectReference, ProtocolVersion,
+    RandomnessRound, TransactionDigest, TypeTag, UserSignature, Version,
 };
 use crate::utils::write_sep;
 
@@ -135,6 +135,38 @@ impl SignedTransaction {
     /// intent, producing the message that the signatures commit to.
     pub fn intent_message(&self) -> IntentMessage<&Transaction> {
         self.transaction.intent_message()
+    }
+
+    /// Returns all [`MoveAuthenticator`] signatures.
+    pub fn move_authenticators(&self) -> Vec<&MoveAuthenticator> {
+        self.signatures
+            .iter()
+            .filter_map(|signature| signature.as_opt_move_authenticator())
+            .collect()
+    }
+
+    /// Returns the sender's [`MoveAuthenticator`], if the sender uses one.
+    pub fn sender_move_authenticator(&self) -> Option<&MoveAuthenticator> {
+        let Transaction::V1(transaction) = &self.transaction;
+
+        self.move_authenticators()
+            .into_iter()
+            .find(|authenticator| authenticator.address() == transaction.sender)
+    }
+
+    /// Returns the sponsor's [`MoveAuthenticator`], if the transaction is
+    /// sponsored and the sponsor uses one.
+    pub fn sponsor_move_authenticator(&self) -> Option<&MoveAuthenticator> {
+        let Transaction::V1(transaction) = &self.transaction;
+        let gas_owner = transaction.gas_payment.owner;
+
+        if gas_owner != transaction.sender {
+            self.move_authenticators()
+                .into_iter()
+                .find(|authenticator| authenticator.address() == gas_owner)
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -100,12 +100,6 @@ impl From<SignedTransaction> for SenderSignedTransaction {
     }
 }
 
-impl From<SenderSignedTransaction> for SignedTransaction {
-    fn from(transaction: SenderSignedTransaction) -> Self {
-        transaction.0
-    }
-}
-
 #[cfg(feature = "serde")]
 impl std::hash::Hash for SenderSignedTransaction {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -167,6 +161,12 @@ impl SignedTransaction {
         } else {
             None
         }
+    }
+}
+
+impl From<SenderSignedTransaction> for SignedTransaction {
+    fn from(transaction: SenderSignedTransaction) -> Self {
+        transaction.0
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -74,7 +74,7 @@ pub struct TransactionV1 {
 /// ```text
 /// sender-signed-transaction = %d01 intent-signed-transaction
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::Deref, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SenderSignedTransaction(
@@ -91,20 +91,6 @@ impl SenderSignedTransaction {
             transaction,
             signatures,
         })
-    }
-
-    pub fn transaction(&self) -> &Transaction {
-        &self.0.transaction
-    }
-
-    pub fn signatures(&self) -> &[UserSignature] {
-        &self.0.signatures
-    }
-
-    /// Wraps a reference to the transaction in the transaction signing
-    /// intent, producing the message that the signatures commit to.
-    pub fn intent_message(&self) -> IntentMessage<&Transaction> {
-        self.0.transaction.intent_message()
     }
 }
 
@@ -134,6 +120,22 @@ impl std::hash::Hash for SenderSignedTransaction {
 pub struct SignedTransaction {
     pub transaction: Transaction,
     pub signatures: Vec<UserSignature>,
+}
+
+impl SignedTransaction {
+    pub fn transaction(&self) -> &Transaction {
+        &self.transaction
+    }
+
+    pub fn signatures(&self) -> &[UserSignature] {
+        &self.signatures
+    }
+
+    /// Wraps a reference to the transaction in the transaction signing
+    /// intent, producing the message that the signatures commit to.
+    pub fn intent_message(&self) -> IntentMessage<&Transaction> {
+        self.transaction.intent_message()
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -79,6 +79,23 @@ pub struct SenderSignedTransaction(
     pub SignedTransaction,
 );
 
+impl SenderSignedTransaction {
+    pub fn new(transaction: Transaction, signatures: Vec<UserSignature>) -> Self {
+        Self(SignedTransaction {
+            transaction,
+            signatures,
+        })
+    }
+
+    pub fn transaction(&self) -> &Transaction {
+        &self.0.transaction
+    }
+
+    pub fn signatures(&self) -> &[UserSignature] {
+        &self.0.signatures
+    }
+}
+
 impl From<SignedTransaction> for SenderSignedTransaction {
     fn from(transaction: SignedTransaction) -> Self {
         Self(transaction)


### PR DESCRIPTION
## Description

Prepares `SenderSignedTransaction` to replace the node's `SenderSignedData` (iotaledger/iota#10724):

- derive `Clone`/`Debug`/`Eq`/`PartialEq` and `Serialize` (it was deserialize-only; the serialize-as wrapper already existed),
- serde-gated `Hash` for it and `SignedTransaction` (matching the `UserSignature` precedent),
- `From` conversions, a constructor, and `transaction()`/`signatures()` accessors on `SenderSignedTransaction`,
- `Transaction::intent_message` / `SenderSignedTransaction::intent_message` producing the signing message, so consumers stop hand-pairing `Intent::iota_transaction()` with transactions,
- BCS/JSON round-trip proptests for `SenderSignedTransaction`.

No wire-format change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
