### PR TITLE
feat: add FromStr parsing to SignatureScheme

### DIFF
--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -255,7 +255,9 @@ impl SimpleSignature {
 /// Flag `%d05` is reserved: it was formerly used for the now-removed zklogin
 /// authenticator (which was never enabled on chain) and is intentionally
 /// skipped.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, strum::Display)]
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, strum::Display, strum::EnumString,
+)]
 #[strum(serialize_all = "lowercase")]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[repr(u8)]
@@ -957,6 +959,33 @@ mod serialization {
                 SignatureScheme::from_byte(0x05).is_err(),
                 "0x05 (deprecated zklogin) must be rejected"
             );
+        }
+
+        /// `FromStr` must accept exactly the lowercase strings produced by
+        /// `Display`.
+        #[test]
+        fn signature_scheme_string_roundtrip() {
+            use std::str::FromStr as _;
+
+            for scheme in [
+                SignatureScheme::Ed25519,
+                SignatureScheme::Secp256k1,
+                SignatureScheme::Secp256r1,
+                SignatureScheme::Multisig,
+                SignatureScheme::Bls12381,
+                SignatureScheme::PasskeyAuthenticator,
+                SignatureScheme::MoveAuthenticator,
+            ] {
+                assert_eq!(
+                    SignatureScheme::from_str(&scheme.to_string()),
+                    Ok(scheme),
+                    "{scheme} must parse back to itself"
+                );
+            }
+
+            assert_eq!(SignatureScheme::from_str("ed25519").unwrap().to_u8(), 0x00);
+            assert!(SignatureScheme::from_str("Ed25519").is_err());
+            assert!(SignatureScheme::from_str("zklogin").is_err());
         }
 
         /// A bare `0x05` flag previously decoded to the (removed) zklogin


### PR DESCRIPTION
# Description of change

Derives `strum::EnumString` (lowercase, matching the existing `Display`) on `SignatureScheme` so schemes can be parsed from strings.

This is a prerequisite for replacing the node's `SignatureScheme` enum with the SDK one (iotaledger/iota#11590) — the node CLI parses schemes from strings via `FromStr`.

## How the change has been tested

- `cargo test -p iota-sdk-types --all-features` — includes a new `Display`/`FromStr` round-trip test.
- `cargo clippy -p iota-sdk-types --all-features --all-targets` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_