### PR TITLE
feat(gRPC): add `epoch_close_proof` field to `Epoch`

### DIFF
--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/epoch.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/epoch.proto
@@ -10,6 +10,8 @@ import "google/protobuf/timestamp.proto";
 
 import "iota/grpc/options.proto";
 import "iota/grpc/v1/bcs.proto";
+import "iota/grpc/v1/checkpoint.proto";
+import "iota/grpc/v1/transaction.proto";
 
 // A member of a validator committee.
 message ValidatorCommitteeMember {
@@ -84,4 +86,33 @@ message Epoch {
   optional uint64 reference_gas_price = 8;
 
   optional ProtocolConfig protocol_config = 9;
+
+  // Proof of how this epoch closed: the certified closing checkpoint, the
+  // epoch-change transaction's effects and events, and the system-state
+  // objects it wrote for the next epoch's start state.
+  //
+  // Absent until the epoch closes.
+  optional EpochCloseProof epoch_close_proof = 10;
+}
+
+message EpochCloseProof {
+  option (iota.grpc.message_accessors) = "with";
+
+  // The certified checkpoint that closed the epoch.
+  optional iota.grpc.v1.checkpoint.Checkpoint checkpoint = 1;
+
+  // Effects of the epoch-change transaction (the last transaction of the
+  // closing checkpoint).
+  optional iota.grpc.v1.transaction.TransactionEffects end_of_epoch_transaction_effects = 2;
+
+  // Events emitted by the epoch-change transaction. Empty on safe-mode
+  // boundaries, which mutate the system state without emitting events.
+  optional iota.grpc.v1.transaction.TransactionEvents end_of_epoch_transaction_events = 3;
+
+  // Raw BCS bytes of the system-state wrapper object (`0x5`) and its inner
+  // state object, as written by this epoch boundary — byte-for-byte as
+  // originally written (not wrapped, unlike `Object.bcs` elsewhere in this
+  // API), so their digests can be verified against the written-object
+  // digests in `end_of_epoch_transaction_effects`.
+  repeated iota.grpc.v1.bcs.BcsData bcs_next_epoch_system_state_objects = 4;
 }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.accessors.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.accessors.rs
@@ -62,6 +62,46 @@ mod _accessor_impls {
             self.protocol_config = Some(field.into());
             self
         }
+        /// Sets `epoch_close_proof` with the provided value.
+        pub fn with_epoch_close_proof<T: Into<super::EpochCloseProof>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.epoch_close_proof = Some(field.into());
+            self
+        }
+    }
+    impl super::EpochCloseProof {
+        /// Sets `checkpoint` with the provided value.
+        pub fn with_checkpoint<T: Into<super::super::checkpoint::Checkpoint>>(
+            mut self,
+            field: T,
+        ) -> Self {
+            self.checkpoint = Some(field.into());
+            self
+        }
+        /// Sets `end_of_epoch_transaction_effects` with the provided value.
+        pub fn with_end_of_epoch_transaction_effects<
+            T: Into<super::super::transaction::TransactionEffects>,
+        >(mut self, field: T) -> Self {
+            self.end_of_epoch_transaction_effects = Some(field.into());
+            self
+        }
+        /// Sets `end_of_epoch_transaction_events` with the provided value.
+        pub fn with_end_of_epoch_transaction_events<
+            T: Into<super::super::transaction::TransactionEvents>,
+        >(mut self, field: T) -> Self {
+            self.end_of_epoch_transaction_events = Some(field.into());
+            self
+        }
+        /// Sets `bcs_next_epoch_system_state_objects` with the provided value.
+        pub fn with_bcs_next_epoch_system_state_objects(
+            mut self,
+            field: Vec<super::super::bcs::BcsData>,
+        ) -> Self {
+            self.bcs_next_epoch_system_state_objects = field;
+            self
+        }
     }
     impl super::ProtocolAttributes {
         /// Sets `attributes` with the provided value.

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.field_info.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.field_info.rs
@@ -11,6 +11,18 @@ mod _field_impls {
     use crate::v1::bcs::BcsData;
     #[allow(unused_imports)]
     use crate::v1::bcs::BcsDataFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::checkpoint::Checkpoint;
+    #[allow(unused_imports)]
+    use crate::v1::checkpoint::CheckpointFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::transaction::TransactionEffects;
+    #[allow(unused_imports)]
+    use crate::v1::transaction::TransactionEffectsFieldPathBuilder;
+    #[allow(unused_imports)]
+    use crate::v1::transaction::TransactionEvents;
+    #[allow(unused_imports)]
+    use crate::v1::transaction::TransactionEventsFieldPathBuilder;
     impl ValidatorCommitteeMember {
         pub const PUBLIC_KEY_FIELD: &'static MessageField = &MessageField {
             name: "public_key",
@@ -370,6 +382,14 @@ mod _field_impls {
             is_map: false,
             message_fields: Some(ProtocolConfig::FIELDS),
         };
+        pub const EPOCH_CLOSE_PROOF_FIELD: &'static MessageField = &MessageField {
+            name: "epoch_close_proof",
+            json_name: "epochCloseProof",
+            number: 10i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(EpochCloseProof::FIELDS),
+        };
     }
     impl MessageFields for Epoch {
         const FIELDS: &'static [&'static MessageField] = &[
@@ -382,6 +402,7 @@ mod _field_impls {
             Self::END_FIELD,
             Self::REFERENCE_GAS_PRICE_FIELD,
             Self::PROTOCOL_CONFIG_FIELD,
+            Self::EPOCH_CLOSE_PROOF_FIELD,
         ];
     }
     impl Epoch {
@@ -439,6 +460,94 @@ mod _field_impls {
         pub fn protocol_config(mut self) -> ProtocolConfigFieldPathBuilder {
             self.path.push(Epoch::PROTOCOL_CONFIG_FIELD.name);
             ProtocolConfigFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn epoch_close_proof(mut self) -> EpochCloseProofFieldPathBuilder {
+            self.path.push(Epoch::EPOCH_CLOSE_PROOF_FIELD.name);
+            EpochCloseProofFieldPathBuilder::new_with_base(self.path)
+        }
+    }
+    impl EpochCloseProof {
+        pub const CHECKPOINT_FIELD: &'static MessageField = &MessageField {
+            name: "checkpoint",
+            json_name: "checkpoint",
+            number: 1i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(Checkpoint::FIELDS),
+        };
+        pub const END_OF_EPOCH_TRANSACTION_EFFECTS_FIELD: &'static MessageField = &MessageField {
+            name: "end_of_epoch_transaction_effects",
+            json_name: "endOfEpochTransactionEffects",
+            number: 2i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(TransactionEffects::FIELDS),
+        };
+        pub const END_OF_EPOCH_TRANSACTION_EVENTS_FIELD: &'static MessageField = &MessageField {
+            name: "end_of_epoch_transaction_events",
+            json_name: "endOfEpochTransactionEvents",
+            number: 3i32,
+            is_optional: true,
+            is_map: false,
+            message_fields: Some(TransactionEvents::FIELDS),
+        };
+        pub const BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS_FIELD: &'static MessageField = &MessageField {
+            name: "bcs_next_epoch_system_state_objects",
+            json_name: "bcsNextEpochSystemStateObjects",
+            number: 4i32,
+            is_optional: false,
+            is_map: false,
+            message_fields: Some(BcsData::FIELDS),
+        };
+    }
+    impl MessageFields for EpochCloseProof {
+        const FIELDS: &'static [&'static MessageField] = &[
+            Self::CHECKPOINT_FIELD,
+            Self::END_OF_EPOCH_TRANSACTION_EFFECTS_FIELD,
+            Self::END_OF_EPOCH_TRANSACTION_EVENTS_FIELD,
+            Self::BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS_FIELD,
+        ];
+    }
+    impl EpochCloseProof {
+        pub fn path_builder() -> EpochCloseProofFieldPathBuilder {
+            EpochCloseProofFieldPathBuilder::new()
+        }
+    }
+    pub struct EpochCloseProofFieldPathBuilder {
+        path: Vec<&'static str>,
+    }
+    impl EpochCloseProofFieldPathBuilder {
+        #[allow(clippy::new_without_default)]
+        pub fn new() -> Self {
+            Self { path: Default::default() }
+        }
+        #[doc(hidden)]
+        pub fn new_with_base(base: Vec<&'static str>) -> Self {
+            Self { path: base }
+        }
+        pub fn finish(self) -> String {
+            self.path.join(".")
+        }
+        pub fn checkpoint(mut self) -> CheckpointFieldPathBuilder {
+            self.path.push(EpochCloseProof::CHECKPOINT_FIELD.name);
+            CheckpointFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn end_of_epoch_transaction_effects(
+            mut self,
+        ) -> TransactionEffectsFieldPathBuilder {
+            self.path.push(EpochCloseProof::END_OF_EPOCH_TRANSACTION_EFFECTS_FIELD.name);
+            TransactionEffectsFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn end_of_epoch_transaction_events(
+            mut self,
+        ) -> TransactionEventsFieldPathBuilder {
+            self.path.push(EpochCloseProof::END_OF_EPOCH_TRANSACTION_EVENTS_FIELD.name);
+            TransactionEventsFieldPathBuilder::new_with_base(self.path)
+        }
+        pub fn bcs_next_epoch_system_state_objects(mut self) -> BcsDataFieldPathBuilder {
+            self.path
+                .push(EpochCloseProof::BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS_FIELD.name);
+            BcsDataFieldPathBuilder::new_with_base(self.path)
         }
     }
 }

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.epoch.rs
@@ -85,4 +85,39 @@ pub struct Epoch {
     pub reference_gas_price: ::core::option::Option<u64>,
     #[prost(message, optional, tag = "9")]
     pub protocol_config: ::core::option::Option<ProtocolConfig>,
+    /// Proof of how this epoch closed: the certified closing checkpoint, the
+    /// epoch-change transaction's effects and events, and the system-state
+    /// objects it wrote for the next epoch's start state.
+    ///
+    /// Absent until the epoch closes.
+    #[prost(message, optional, tag = "10")]
+    pub epoch_close_proof: ::core::option::Option<EpochCloseProof>,
+}
+#[non_exhaustive]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EpochCloseProof {
+    /// The certified checkpoint that closed the epoch.
+    #[prost(message, optional, tag = "1")]
+    pub checkpoint: ::core::option::Option<super::checkpoint::Checkpoint>,
+    /// Effects of the epoch-change transaction (the last transaction of the
+    /// closing checkpoint).
+    #[prost(message, optional, tag = "2")]
+    pub end_of_epoch_transaction_effects: ::core::option::Option<
+        super::transaction::TransactionEffects,
+    >,
+    /// Events emitted by the epoch-change transaction. Empty on safe-mode
+    /// boundaries, which mutate the system state without emitting events.
+    #[prost(message, optional, tag = "3")]
+    pub end_of_epoch_transaction_events: ::core::option::Option<
+        super::transaction::TransactionEvents,
+    >,
+    /// Raw BCS bytes of the system-state wrapper object (`0x5`) and its inner
+    /// state object, as written by this epoch boundary — byte-for-byte as
+    /// originally written (not wrapped, unlike `Object.bcs` elsewhere in this
+    /// API), so their digests can be verified against the written-object
+    /// digests in `end_of_epoch_transaction_effects`.
+    #[prost(message, repeated, tag = "4")]
+    pub bcs_next_epoch_system_state_objects: ::prost::alloc::vec::Vec<
+        super::bcs::BcsData,
+    >,
 }

--- a/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/epoch.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/iota/grpc/v1/epoch.rs
@@ -8,7 +8,14 @@ include!("../../../generated/iota.grpc.v1.epoch.accessors.rs");
 
 use tap::Pipe;
 
-use crate::{proto::TryFromProtoError, v1::bcs::BcsData};
+use crate::{
+    proto::TryFromProtoError,
+    v1::{
+        bcs::BcsData,
+        checkpoint::Checkpoint,
+        transaction::{TransactionEffects, TransactionEvents},
+    },
+};
 
 // ValidatorCommitteeMember
 
@@ -177,6 +184,73 @@ impl Epoch {
         self.protocol_config
             .as_ref()
             .ok_or_else(|| TryFromProtoError::missing(Self::PROTOCOL_CONFIG_FIELD.name))
+    }
+
+    /// Get the proof of how this epoch closed.
+    ///
+    /// Returns `Ok(None)` for the current in-progress epoch (field not yet
+    /// set).
+    ///
+    /// Requires `epoch_close_proof` in the read_mask.
+    pub fn epoch_close_proof(&self) -> Result<Option<&EpochCloseProof>, TryFromProtoError> {
+        Ok(self.epoch_close_proof.as_ref())
+    }
+}
+
+// EpochCloseProof
+
+impl EpochCloseProof {
+    /// Get the certified checkpoint that closed the epoch.
+    ///
+    /// Requires `epoch_close_proof.checkpoint` in the read_mask.
+    pub fn checkpoint(&self) -> Result<&Checkpoint, TryFromProtoError> {
+        self.checkpoint
+            .as_ref()
+            .ok_or_else(|| TryFromProtoError::missing(Self::CHECKPOINT_FIELD.name))
+    }
+
+    /// Get the effects of the epoch-change transaction.
+    ///
+    /// Requires `epoch_close_proof.end_of_epoch_transaction_effects` in the
+    /// read_mask.
+    pub fn end_of_epoch_transaction_effects(
+        &self,
+    ) -> Result<&TransactionEffects, TryFromProtoError> {
+        self.end_of_epoch_transaction_effects
+            .as_ref()
+            .ok_or_else(|| {
+                TryFromProtoError::missing(Self::END_OF_EPOCH_TRANSACTION_EFFECTS_FIELD.name)
+            })
+    }
+
+    /// Get the events emitted by the epoch-change transaction.
+    ///
+    /// May be empty on safe-mode boundaries, which mutate the system state
+    /// without emitting events.
+    ///
+    /// Requires `epoch_close_proof.end_of_epoch_transaction_events` in the
+    /// read_mask.
+    pub fn end_of_epoch_transaction_events(&self) -> Result<&TransactionEvents, TryFromProtoError> {
+        self.end_of_epoch_transaction_events
+            .as_ref()
+            .ok_or_else(|| {
+                TryFromProtoError::missing(Self::END_OF_EPOCH_TRANSACTION_EVENTS_FIELD.name)
+            })
+    }
+
+    /// Get the raw BCS bytes of the system-state wrapper object (`0x5`) and
+    /// its inner state object, as written by this epoch boundary for the
+    /// next epoch's start state.
+    ///
+    /// Each entry is preserved byte-for-byte as originally written (not
+    /// wrapped, unlike `Object.bcs` elsewhere in this API), so their digests
+    /// can be verified against the written-object digests in
+    /// `end_of_epoch_transaction_effects`.
+    ///
+    /// Requires `epoch_close_proof.bcs_next_epoch_system_state_objects` in
+    /// the read_mask.
+    pub fn bcs_next_epoch_system_state_objects(&self) -> &[BcsData] {
+        &self.bcs_next_epoch_system_state_objects
     }
 }
 

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -329,6 +329,19 @@ impl EpochField {
     pub const PROTOCOL_CONFIG_FEATURE_FLAGS: &str = "protocol_config.feature_flags";
     /// All protocol attributes.
     pub const PROTOCOL_CONFIG_ATTRIBUTES: &str = "protocol_config.attributes";
+    /// All epoch-close-proof fields.
+    pub const EPOCH_CLOSE_PROOF: &str = "epoch_close_proof";
+    /// The certified checkpoint that closed the epoch.
+    pub const EPOCH_CLOSE_PROOF_CHECKPOINT: &str = "epoch_close_proof.checkpoint";
+    /// Effects of the epoch-change transaction.
+    pub const EPOCH_CLOSE_PROOF_END_OF_EPOCH_TRANSACTION_EFFECTS: &str =
+        "epoch_close_proof.end_of_epoch_transaction_effects";
+    /// Events emitted by the epoch-change transaction.
+    pub const EPOCH_CLOSE_PROOF_END_OF_EPOCH_TRANSACTION_EVENTS: &str =
+        "epoch_close_proof.end_of_epoch_transaction_events";
+    /// Raw BCS of the next epoch's start-of-epoch system-state objects.
+    pub const EPOCH_CLOSE_PROOF_BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS: &str =
+        "epoch_close_proof.bcs_next_epoch_system_state_objects";
 
     /// Field path for a specific feature flag by key.
     ///
@@ -588,6 +601,23 @@ mod tests {
         assert_eq!(
             EpochField::PROTOCOL_CONFIG_FEATURE_FLAGS,
             "protocol_config.feature_flags"
+        );
+        assert_eq!(EpochField::EPOCH_CLOSE_PROOF, "epoch_close_proof");
+        assert_eq!(
+            EpochField::EPOCH_CLOSE_PROOF_CHECKPOINT,
+            "epoch_close_proof.checkpoint"
+        );
+        assert_eq!(
+            EpochField::EPOCH_CLOSE_PROOF_END_OF_EPOCH_TRANSACTION_EFFECTS,
+            "epoch_close_proof.end_of_epoch_transaction_effects"
+        );
+        assert_eq!(
+            EpochField::EPOCH_CLOSE_PROOF_END_OF_EPOCH_TRANSACTION_EVENTS,
+            "epoch_close_proof.end_of_epoch_transaction_events"
+        );
+        assert_eq!(
+            EpochField::EPOCH_CLOSE_PROOF_BCS_NEXT_EPOCH_SYSTEM_STATE_OBJECTS,
+            "epoch_close_proof.bcs_next_epoch_system_state_objects"
         );
     }
 


### PR DESCRIPTION
## Summary
- Adds an `epoch_close_proof` field to `Epoch`, exposing the certified closing checkpoint, the epoch-change transaction's effects/events, and the next epoch's start-of-epoch system-state objects.
- New `EpochCloseProof` message reuses the existing `Checkpoint`, `TransactionEffects`, `TransactionEvents`, and `Object` message shapes rather than introducing a new wire format.
- Each sub-field (`checkpoint`, `end_of_epoch_transaction_effects`, `end_of_epoch_transaction_events`, `next_epoch_system_state_objects`) has independent read-mask subtree granularity, mirroring the existing `protocol_config` pattern.
- Excluded from the default `GET_EPOCH_READ_MASK` (opt-in only, like `committee`/`bcs_system_state`).
- `epoch_close_proof` is absent (not an error) for the current, still-open epoch, or any epoch whose closing boundary hasn't been indexed yet.

## Context
The node's `epoch_info` storage keeps this proof material available forever (unlike checkpoints/transactions/objects, which get pruned), so it's the only reliable way to fetch epoch-closing proof material for arbitrarily old epochs. This unblocks a proof-of-inclusion client built purely on gRPC + these SDK types. Server-side population logic lands in a follow-up iota monorepo PR once this merges.

## Test plan
- [x] `cargo check -p iota-sdk-grpc-types`
- [x] `cargo test -p iota-sdk-grpc-types` (unit + doc tests)
- [x] Verified end-to-end against the iota monorepo's `get_epoch` gRPC endpoint via a temporary local path override (e2e tests covering absence for the open epoch, presence for a closed epoch, and independent subtree gating)