### PR TITLE
fix: remove FaucetClient::new_devnet() as the devnet faucet is web-only

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/faucet.rs
+++ b/crates/iota-sdk-ffi/src/graphql/faucet.rs
@@ -29,12 +29,6 @@ impl FaucetClient {
         ))
     }
 
-    /// Create a new Faucet client connected to the `devnet` faucet.
-    #[uniffi::constructor]
-    pub fn new_devnet() -> Self {
-        Self(iota_sdk::graphql_client::faucet::FaucetClient::new_devnet())
-    }
-
     /// Create a new Faucet client connected to a `localnet` faucet.
     #[uniffi::constructor]
     pub fn new_localnet() -> Self {

--- a/crates/iota-sdk-graphql-client/README.md
+++ b/crates/iota-sdk-graphql-client/README.md
@@ -69,7 +69,7 @@ async fn main() -> Result<()> {
 
 ### Example for custom faucet service.
 
-Note that this `FaucetClient` is explicitly designed to work with two endpoints: `v1/gas`, and `v1/status`. When passing in the custom faucet URL, skip the final endpoint and only pass in the top-level url (e.g., `https://faucet.example.com`).
+Note that this `FaucetClient` is explicitly designed to work with two endpoints: `v1/gas`, and `v1/status`. When passing in the custom faucet URL, skip the final endpoint and only pass in the top-level url (e.g., `http://localhost:9123`).
 
 ```rust, ignore
 use iota_graphql_client::faucet::FaucetClient;
@@ -82,7 +82,7 @@ use std::str::FromStr;
 async fn main() -> Result<()> {
     let address = Address::from_str("IOTA_ADDRESS_HERE")?;
     // Request gas from the faucet and wait until a coin is received
-    let faucet = FaucetClient::new("https://faucet.example.com").request_and_wait(address).await?;
+    let faucet = FaucetClient::new("http://localhost:9123").request_and_wait(address).await?;
     if let Some(resp) = faucet {
         let coins = resp.sent;
         for coin in coins {

--- a/crates/iota-sdk-graphql-client/README.md
+++ b/crates/iota-sdk-graphql-client/README.md
@@ -40,7 +40,9 @@ async fn main() -> Result<()> {
 
 The client provides an API to request gas from the faucet. The `request_and_wait` function sends a request to the faucet and waits until the transaction is confirmed. The function returns the transaction details if the request is successful.
 
-### Example for standard devnet/testnet/local networks.
+### Example for a local network.
+
+The testnet and devnet faucets are only available through the web interface, so `FaucetClient` can only be used with a local or custom faucet service.
 
 ```rust, ignore
 use iota_graphql_client::faucet::FaucetClient;
@@ -53,8 +55,7 @@ use std::str::FromStr;
 async fn main() -> Result<()> {
     let address = Address::from_str("IOTA_ADDRESS_HERE")?;
     // Request gas from the faucet and wait until a coin is received
-    // As the client is set to devnet, faucet will use the devnet faucet.
-    let faucet = FaucetClient::new_devnet().request_and_wait(address).await?;
+    let faucet = FaucetClient::new_localnet().request_and_wait(address).await?;
     if let Some(resp) = faucet {
         let coins = resp.sent;
         for coin in coins {
@@ -62,15 +63,13 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Request gas from the testnet faucet by explicitly setting the faucet to testnet
-    let faucet_testnet = FaucetClient::new_testnet().request_and_wait(address).await?;
     Ok(())
 }
 ```
 
 ### Example for custom faucet service.
 
-Note that this `FaucetClient` is explicitly designed to work with two endpoints: `v1/gas`, and `v1/status`. When passing in the custom faucet URL, skip the final endpoint and only pass in the top-level url (e.g., `https://faucet.devnet.iota.cafe`).
+Note that this `FaucetClient` is explicitly designed to work with two endpoints: `v1/gas`, and `v1/status`. When passing in the custom faucet URL, skip the final endpoint and only pass in the top-level url (e.g., `https://faucet.example.com`).
 
 ```rust, ignore
 use iota_graphql_client::faucet::FaucetClient;
@@ -83,8 +82,7 @@ use std::str::FromStr;
 async fn main() -> Result<()> {
     let address = Address::from_str("IOTA_ADDRESS_HERE")?;
     // Request gas from the faucet and wait until a coin is received
-    // As the client is set to devnet, faucet will use the devnet faucet.
-    let faucet = FaucetClient::new("https://myfaucet_testnet.com").request_and_wait(address).await?;
+    let faucet = FaucetClient::new("https://faucet.example.com").request_and_wait(address).await?;
     if let Some(resp) = faucet {
         let coins = resp.sent;
         for coin in coins {

--- a/crates/iota-sdk-graphql-client/src/api/coins.rs
+++ b/crates/iota-sdk-graphql-client/src/api/coins.rs
@@ -123,7 +123,7 @@ mod tests {
 
     use crate::{
         Direction, PaginationFilter,
-        client::{DEVNET_HOST, LOCAL_HOST},
+        client::LOCAL_HOST,
         faucet::FaucetClient,
         test_utils::{NUM_COINS_FROM_FAUCET, test_client},
     };
@@ -148,9 +148,9 @@ mod tests {
         let client = test_client();
         let faucet = match client.rpc_server().as_str() {
             LOCAL_HOST => FaucetClient::new_localnet(),
-            DEVNET_HOST => FaucetClient::new_devnet(),
-            // The testnet faucet is web-only and exposes no programmatic gas
-            // endpoint, so this test cannot fund an address on testnet.
+            // The testnet and devnet faucets are web-only and expose no
+            // programmatic gas endpoint, so this test can only fund an
+            // address on localnet.
             _ => return,
         };
         let key = Ed25519PublicKey::generate(rand::thread_rng());

--- a/crates/iota-sdk-graphql-client/src/faucet.rs
+++ b/crates/iota-sdk-graphql-client/src/faucet.rs
@@ -12,7 +12,6 @@ use tracing::{error, info};
 
 use crate::WaitForTx;
 
-pub const FAUCET_DEVNET_HOST: &str = "https://faucet.devnet.iota.cafe";
 pub const FAUCET_LOCAL_HOST: &str = "http://localhost:9123";
 
 const FAUCET_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
@@ -96,11 +95,6 @@ impl FaucetClient {
         let inner = reqwest::Client::new();
         let faucet_url = Url::parse(faucet_url).expect("Invalid faucet URL");
         FaucetClient { faucet_url, inner }
-    }
-
-    /// Create a new Faucet client connected to the `devnet` faucet.
-    pub fn new_devnet() -> Self {
-        Self::new(FAUCET_DEVNET_HOST)
     }
 
     /// Create a new Faucet client connected to a `localnet` faucet.


### PR DESCRIPTION
## Why

Like the testnet faucet (#1244), the devnet faucet is now web-only: `https://faucet.devnet.iota.cafe` serves the web UI and the programmatic `/v1/gas` endpoint is gone (POST returns 405, GET 404), so `FaucetClient::new_devnet()` can't work.

## What

- Remove `FaucetClient::new_devnet()` and `FAUCET_DEVNET_HOST` (graphql-client + FFI), mirroring #1244
- Coin-stream test now only funds on localnet
- Update the README faucet examples, including a stale `new_testnet()` reference left over from #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)