### PR TITLE
chore: make transaction data/effects tests localnet-stable

### DIFF
--- a/bindings/csharp/examples/GetTransaction/Program.cs
+++ b/bindings/csharp/examples/GetTransaction/Program.cs
@@ -7,8 +7,14 @@ class Program
 {
     static async Task Main(string[] args)
     {
-        var client = GraphQlClient.NewTestnet();
-        var digest = TransactionDigest.FromBase58("3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh");
+        var client = GraphQlClient.NewLocalnet();
+
+        var transactions = await client.Transactions();
+        if (transactions.Data.Length == 0)
+        {
+            throw new Exception("No transactions found");
+        }
+        var digest = transactions.Data[0].Transaction.Digest();
 
         var signedTransaction = await client.Transaction(digest);
         Console.WriteLine($"Signed Transaction: `{signedTransaction}`\n");

--- a/bindings/go/examples/get_transaction/main.go
+++ b/bindings/go/examples/get_transaction/main.go
@@ -11,11 +11,16 @@ import (
 )
 
 func main() {
-	client := iota_sdk.GraphQlClientNewTestnet()
-	digest, err := iota_sdk.TransactionDigestFromBase58("3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh")
+	client := iota_sdk.GraphQlClientNewLocalnet()
+
+	transactions, err := client.Transactions(nil, nil)
 	if err != nil {
-		log.Fatalf("Failed to parse digest: %v", err)
+		log.Fatalf("Failed to fetch transactions: %v", err)
 	}
+	if len(transactions.Data) == 0 {
+		log.Fatal("No transactions found")
+	}
+	digest := transactions.Data[0].Transaction.Digest()
 
 	signed_transaction, err := client.Transaction(digest)
 	if err != nil {

--- a/bindings/kotlin/examples/GetTransaction.kt
+++ b/bindings/kotlin/examples/GetTransaction.kt
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import iota_sdk.GraphQlClient
-import iota_sdk.TransactionDigest
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
     try {
-        val client = GraphQlClient.newTestnet()
-        val digest = TransactionDigest.fromBase58("3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh")
+        val client = GraphQlClient.newLocalnet()
+
+        val transactions = client.transactions()
+        if (transactions.data.isEmpty()) {
+            throw Exception("No transactions found")
+        }
+        val digest = transactions.data[0].transaction.digest()
 
         val signedTransaction = client.transaction(digest)
         println("Signed Transaction: ${signedTransaction?.toString()}\n")

--- a/bindings/python/examples/get_transaction.py
+++ b/bindings/python/examples/get_transaction.py
@@ -7,9 +7,12 @@ import asyncio
 
 
 async def main():
-    client = GraphQlClient.new_testnet()
-    digest = TransactionDigest.from_base58(
-        "3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh")
+    client = GraphQlClient.new_localnet()
+
+    transactions = await client.transactions()
+    if not transactions.data:
+        raise Exception("No transactions found")
+    digest = transactions.data[0].transaction.digest()
 
     signed_transaction = await client.transaction(digest)
     print(f"Signed Transaction: `{signed_transaction}`\n")

--- a/bindings/swift/examples/GetTransaction.swift
+++ b/bindings/swift/examples/GetTransaction.swift
@@ -6,9 +6,12 @@ import IotaSDK
 @main
 struct GetTransactionExample {
   static func main() async throws {
-    let client = GraphQlClient.newTestnet()
-    let digest = try TransactionDigest.fromBase58(
-      base58: "3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh")
+    let client = GraphQlClient.newLocalnet()
+
+    let transactions = try await client.transactions()
+    guard let digest = transactions.data.first?.transaction.digest() else {
+      fatalError("No transactions found")
+    }
 
     let signedTransaction = try await client.transaction(digest: digest)
     print("Signed Transaction: `\(String(describing: signedTransaction))`\n")

--- a/bindings/wasm/examples/get_transaction.mjs
+++ b/bindings/wasm/examples/get_transaction.mjs
@@ -1,14 +1,17 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-import { GraphQlClient, initAsync, TransactionDigest } from "@iota/sdk-wasm";
+import { GraphQlClient, initAsync } from "@iota/sdk-wasm";
 
 await initAsync();
 
-const client = GraphQlClient.newTestnet();
-const digest = TransactionDigest.fromBase58(
-  "3wN9oLKfvCjCd7uFW1D6fp1uSEsD3wJ2cU61YULNKzFh",
-);
+const client = GraphQlClient.newLocalnet();
+
+const transactions = await client.transactions();
+if (transactions.data.length === 0) {
+  throw new Error("No transactions found");
+}
+const digest = transactions.data[0].transaction.digest();
 
 const signedTransaction = await client.transaction(digest);
 console.log(`Signed Transaction: \`${signedTransaction}\`\n`);

--- a/crates/iota-sdk-graphql-client/src/api/transactions.rs
+++ b/crates/iota-sdk-graphql-client/src/api/transactions.rs
@@ -311,11 +311,7 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use iota_types::TransactionDigest;
-
-    use crate::{
-        Client, PaginationFilter, query_types::TransactionsFilter, test_utils::test_client,
-    };
+    use crate::{PaginationFilter, query_types::TransactionsFilter, test_utils::test_client};
 
     #[tokio::test]
     async fn test_transaction_effects_query() {
@@ -370,13 +366,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_transaction_data_effects() {
-        let client = Client::new_testnet();
+        let client = test_client();
+        let transactions = client
+            .transactions(None, PaginationFilter::default())
+            .await
+            .unwrap();
+        let digest = transactions.data()[0].transaction.digest();
 
         client
-            .transaction_data_effects(
-                TransactionDigest::from_base58("FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj")
-                    .unwrap(),
-            )
+            .transaction_data_effects(digest)
             .await
             .unwrap()
             .unwrap();
@@ -384,14 +382,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_transactions_data_effects() {
-        let client = Client::new_testnet();
+        let client = test_client();
+        let transactions = client
+            .transactions(None, PaginationFilter::default())
+            .await
+            .unwrap();
+        let digest = transactions.data()[0].transaction.digest();
 
         client
             .transactions_data_effects(
                 TransactionsFilter {
-                    transaction_ids: Some(vec![
-                        "FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj".to_string(),
-                    ]),
+                    transaction_ids: Some(vec![digest.to_string()]),
                     ..Default::default()
                 },
                 PaginationFilter::default(),

--- a/crates/iota-sdk/examples/get_transaction.rs
+++ b/crates/iota-sdk/examples/get_transaction.rs
@@ -7,8 +7,6 @@ use iota_sdk::graphql_client::{Client, error::Result, pagination::PaginationFilt
 async fn main() -> Result<()> {
     let client = Client::new_localnet();
 
-    // Fetch a recent transaction from the network so the example does not
-    // depend on a specific digest that may have been pruned.
     let transactions = client
         .transactions(None, PaginationFilter::default())
         .await?;

--- a/crates/iota-sdk/examples/get_transaction.rs
+++ b/crates/iota-sdk/examples/get_transaction.rs
@@ -1,15 +1,23 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-use iota_sdk::{
-    graphql_client::{Client, error::Result},
-    types::TransactionDigest,
-};
+use iota_sdk::graphql_client::{Client, error::Result, pagination::PaginationFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let client = Client::new_testnet();
-    let digest = TransactionDigest::from_base58("FczF9bnUpcizyZscYV2djwSqKMWaKngiGA5bUdGjAroj")?;
+    let client = Client::new_localnet();
+
+    // Fetch a recent transaction from the network so the example does not
+    // depend on a specific digest that may have been pruned.
+    let transactions = client
+        .transactions(None, PaginationFilter::default())
+        .await?;
+    let digest = transactions
+        .data()
+        .first()
+        .expect("no transactions found")
+        .transaction
+        .digest();
 
     let signed_transaction = client.transaction(digest).await?.expect("tx not found");
     println!("Signed Transaction: {signed_transaction:#?}\n");


### PR DESCRIPTION
## Why

`test_transaction_data_effects` and `test_transactions_data_effects` pinned a hardcoded testnet transaction digest. Testnet prunes transactions after 30 days, so the tests started failing once that digest aged out.

## What

- Run both tests against localnet via `test_client()`, matching the other network-backed tests in the crate.
- Fetch a live transaction digest from the network first (`transactions(...)`) instead of hardcoding one, so the tests stay stable regardless of pruning.

## Test plan

- `make test-with-localnet` (CI `tests-with-network` job) runs these against a fresh localnet.

---
_Generated by [Claude Code](https://claude.ai/code/session_014RN4txUu4NxCkwDC8uT9Rx)_