### PR TITLE
feat: add InvalidAttestation variant

### DIFF
--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -279,6 +279,10 @@ pub enum ExecutionError {
     /// wrapped error is the failure produced by the authenticator's
     /// execution.
     MoveAuthenticationError { error: Arc<ExecutionErrorWrapper> },
+    /// The transaction's attestation was invalid: the attestor vouched for a
+    /// transaction it should have rejected. The attestor is accountable, so the
+    /// issuer's owned objects and gas are left untouched.
+    InvalidAttestation,
 }
 
 /// Holds an [`ExecutionError`] so it can be nested inside another
@@ -438,6 +442,7 @@ impl From<iota_sdk::types::ExecutionError> for ExecutionError {
                     error: Arc::new(ExecutionErrorWrapper(*error)),
                 }
             }
+            iota_sdk::types::ExecutionError::InvalidAttestation => Self::InvalidAttestation,
             _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
@@ -560,6 +565,7 @@ impl From<ExecutionError> for iota_sdk::types::ExecutionError {
             ExecutionError::MoveAuthenticationError { error } => Self::MoveAuthenticationError {
                 error: Box::new(error.0.clone()),
             },
+            ExecutionError::InvalidAttestation => Self::InvalidAttestation,
         }
     }
 }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -206,6 +206,7 @@ execution-error = %d00                               ; InsufficientGas
                 / %d37 (size *object-id) u64         ; ExecutionCancelledDueToSharedObjectCongestionV2
                 / %d38                               ; InvalidLinkage
                 / %d39 execution-error               ; MoveAuthenticationError
+                / %d40                               ; InvalidAttestation
 
 execution-status = %d00                                     ; Success
                  / %d01 execution-error (%d00 / %d01 u64)   ; Failure

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -161,6 +161,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 ///                 =/ execution-cancelled-due-to-shared-object-congestion-v2
 ///                 =/ invalid-linkage
 ///                 =/ move-authentication-error
+///                 =/ invalid-attestation
 ///
 /// insufficient-gas                                       = %d00
 /// invalid-gas-object                                     = %d01
@@ -202,6 +203,7 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 /// execution-cancelled-due-to-shared-object-congestion-v2 = %d37 (vector object-id) u64
 /// invalid-linkage                                        = %d38
 /// move-authentication-error                              = %d39 execution-error
+/// invalid-attestation                                    = %d40
 /// ```
 // WARNING: The variant order of this enum is protocol-significant. Each variant's position
 // determines its BCS discriminant (the integer sent over the wire).
@@ -416,6 +418,11 @@ pub enum ExecutionError {
     #[error("Move authentication failed: {error}")]
     #[cfg_attr(feature = "proptest", weight(0))]
     MoveAuthenticationError { error: Box<ExecutionError> },
+    /// The transaction's attestation was invalid: the attestor vouched for a
+    /// transaction it should have rejected. The attestor is accountable, so the
+    /// issuer's owned objects and gas are left untouched.
+    #[error("The transaction attestation is invalid")]
+    InvalidAttestation,
 }
 
 impl ExecutionError {
@@ -460,6 +467,7 @@ impl ExecutionError {
         ExecutionCancelledDueToSharedObjectCongestionV2,
         InvalidLinkage,
         MoveAuthenticationError,
+        InvalidAttestation,
     );
 
     pub fn command_argument_error(kind: CommandArgumentError, argument: u16) -> Self {


### PR DESCRIPTION
Adds `InvalidAttestation` to `ExecutionError`, plus its FFI mirror.

It marks a transaction whose attestation was found invalid, so the attestor is accountable rather than the issuer. Consumed by the node's upcoming validator-attestation failure handling.