### PR TITLE
chore: Rename content_digest -> contents_digest

### DIFF
--- a/crates/iota-sdk-ffi/src/types/checkpoint.rs
+++ b/crates/iota-sdk-ffi/src/types/checkpoint.rs
@@ -51,7 +51,7 @@ pub type ProtocolVersion = u64;
 /// checkpoint-summary = u64                            ; epoch
 ///                      u64                            ; sequence_number
 ///                      u64                            ; network_total_transactions
-///                      digest                         ; content_digest
+///                      digest                         ; contents_digest
 ///                      (option digest)                ; previous_digest
 ///                      gas-cost-summary               ; epoch_rolling_gas_cost_summary
 ///                      u64                            ; timestamp_ms
@@ -70,7 +70,7 @@ impl CheckpointSummary {
         epoch: EpochId,
         sequence_number: CheckpointSequenceNumber,
         network_total_transactions: u64,
-        content_digest: &CheckpointContentsDigest,
+        contents_digest: &CheckpointContentsDigest,
         previous_digest: Option<Arc<CheckpointDigest>>,
         epoch_rolling_gas_cost_summary: GasCostSummary,
         timestamp_ms: CheckpointTimestamp,
@@ -82,7 +82,7 @@ impl CheckpointSummary {
             epoch,
             sequence_number,
             network_total_transactions,
-            **content_digest,
+            **contents_digest,
             previous_digest.map(|v| **v),
             epoch_rolling_gas_cost_summary,
             timestamp_ms,
@@ -112,8 +112,8 @@ impl CheckpointSummary {
     }
 
     /// The hash of the `CheckpointContents` for this checkpoint.
-    pub fn content_digest(&self) -> CheckpointContentsDigest {
-        self.0.content_digest.into()
+    pub fn contents_digest(&self) -> CheckpointContentsDigest {
+        self.0.contents_digest.into()
     }
 
     /// The hash of the previous `CheckpointSummary`.

--- a/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
+++ b/crates/iota-sdk-graphql-client/src/api/checkpoints.rs
@@ -267,7 +267,7 @@ mod tests {
             .unwrap();
 
         // TODO: https://github.com/iotaledger/iota-rust-sdk/issues/1211
-        let digest = chckp.content_digest.into_inner().into();
+        let digest = chckp.contents_digest.into_inner().into();
         let total_transaction_blocks_by_digest = client
             .total_transaction_blocks_by_digest(digest)
             .await

--- a/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/checkpoint.rs
@@ -124,7 +124,7 @@ impl TryInto<CheckpointSummary> for Checkpoint {
         let timestamp_ms = ChronoDT::parse_from_rfc3339(&self.timestamp.0)?
             .timestamp_millis()
             .try_into()?;
-        let content_digest = CheckpointContentsDigest::from_base58(&self.digest)?;
+        let contents_digest = CheckpointContentsDigest::from_base58(&self.digest)?;
         let previous_digest = self
             .previous_checkpoint_digest
             .map(|d| CheckpointDigest::from_base58(&d))
@@ -143,7 +143,7 @@ impl TryInto<CheckpointSummary> for Checkpoint {
             sequence_number,
             network_total_transactions,
             timestamp_ms,
-            content_digest,
+            contents_digest,
             previous_digest,
             epoch_rolling_gas_cost_summary,
             checkpoint_commitments: vec![],

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -91,7 +91,7 @@ checkpoint-digest = digest
 checkpoint-summary = u64                               ; epoch
                      u64                               ; sequence-number
                      u64                               ; network-total-transactions
-                     checkpoint-contents-digest        ; content-digest
+                     checkpoint-contents-digest        ; contents-digest
                      (%d00 / %d01 checkpoint-digest)   ; previous-digest
                      gas-cost-summary                  ; epoch-rolling-gas-cost-summary
                      u64                               ; timestamp-ms

--- a/crates/iota-sdk-types/src/checkpoint.rs
+++ b/crates/iota-sdk-types/src/checkpoint.rs
@@ -109,7 +109,7 @@ pub struct EndOfEpochData {
 /// checkpoint-summary = u64                            ; epoch
 ///                      u64                            ; sequence_number
 ///                      u64                            ; network_total_transactions
-///                      checkpoint-contents-digest     ; content_digest
+///                      checkpoint-contents-digest     ; contents_digest
 ///                      (option checkpoint-digest)     ; previous_digest
 ///                      gas-cost-summary               ; epoch_rolling_gas_cost_summary
 ///                      u64                            ; timestamp_ms
@@ -135,7 +135,7 @@ pub struct CheckpointSummary {
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub network_total_transactions: u64,
     /// The hash of the [`CheckpointContents`] for this checkpoint.
-    pub content_digest: CheckpointContentsDigest,
+    pub contents_digest: CheckpointContentsDigest,
     /// The hash of the previous `CheckpointSummary`.
     ///
     /// This will be only be `None` for the first, or genesis checkpoint.
@@ -180,7 +180,7 @@ impl CheckpointSummary {
         epoch: EpochId,
         sequence_number: CheckpointSequenceNumber,
         network_total_transactions: u64,
-        content_digest: CheckpointContentsDigest,
+        contents_digest: CheckpointContentsDigest,
         previous_digest: Option<CheckpointDigest>,
         epoch_rolling_gas_cost_summary: GasCostSummary,
         timestamp_ms: CheckpointTimestamp,
@@ -192,7 +192,7 @@ impl CheckpointSummary {
             epoch,
             sequence_number,
             network_total_transactions,
-            content_digest,
+            contents_digest,
             previous_digest,
             epoch_rolling_gas_cost_summary,
             timestamp_ms,
@@ -219,8 +219,8 @@ impl CheckpointSummary {
     }
 
     /// The hash of the [`CheckpointContents`] for this checkpoint.
-    pub fn content_digest(&self) -> CheckpointContentsDigest {
-        self.content_digest
+    pub fn contents_digest(&self) -> CheckpointContentsDigest {
+        self.contents_digest
     }
 
     /// The hash of the previous `CheckpointSummary`, or `None` for the genesis

--- a/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
+++ b/crates/iota-sdk/examples/polling-indexer/src/indexer.rs
@@ -315,7 +315,7 @@ impl Indexer {
             "#,
         )
         .bind(sequence as i64)
-        .bind(checkpoint.content_digest.to_string())
+        .bind(checkpoint.contents_digest.to_string())
         .bind(checkpoint.timestamp_ms as i64)
         .bind(serde_json::to_value(&checkpoint)?)
         .execute(&self.pool)


### PR DESCRIPTION
## Description

Renames the various `content_digest` fields to `contents_digest`.

https://github.com/iotaledger/iota/issues/12134