### PR TITLE
feat: add base64 helpers to the private key types

### DIFF
--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -26,10 +26,10 @@ rustdoc-args = [
 
 [features]
 default = []
-ed25519 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
-secp256r1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
+ed25519 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
+secp256r1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 passkey = ["secp256r1", "dep:sha2"]
-secp256k1 = ["dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
+secp256k1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 bech32 = ["dep:bech32", "signature/std"]
 # PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519, p256 and
 # k256 are pulled in purely as encoders/decoders here; the actual signing and
@@ -53,6 +53,8 @@ mnemonic = ["dep:bip32", "dep:bip39", "dep:slip10_ed25519"]
 
 [dependencies]
 # external dependencies
+# base64 encoding of private key bytes
+base64ct = { workspace = true, features = ["alloc"], optional = true }
 # bech32 encoding support
 bech32 = { version = "0.11.0", optional = true }
 # mnemonic support

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -440,4 +440,24 @@ mod tests {
             .verify_personal_message(&message, &signature)
             .unwrap();
     }
+
+    #[proptest]
+    fn base64_roundtrip(signer: Ed25519PrivateKey) {
+        use crate::{ToFromBase64, ToFromBytes};
+
+        let b64 = signer.to_base64();
+        let decoded = Ed25519PrivateKey::from_base64(&b64).unwrap();
+        assert_eq!(decoded.to_bytes(), signer.to_bytes());
+        assert_eq!(decoded.to_base64(), b64);
+    }
+
+    #[test]
+    fn from_base64_rejects_invalid_input() {
+        use crate::ToFromBase64;
+
+        // not base64
+        Ed25519PrivateKey::from_base64("not-base64!").unwrap_err();
+        // valid base64 but wrong length
+        Ed25519PrivateKey::from_base64("aGVsbG8=").unwrap_err();
+    }
 }

--- a/crates/iota-sdk-crypto/src/lib.rs
+++ b/crates/iota-sdk-crypto/src/lib.rs
@@ -17,6 +17,9 @@ pub enum PrivateKeyError {
     /// Invalid signature scheme
     #[error("invalid signature scheme: {0}")]
     InvalidScheme(String),
+    /// Base64 encoding/decoding error
+    #[error("base64 error: {0}")]
+    Base64(String),
     /// Bech32 encoding/decoding error
     #[error("bech32 error: {0}")]
     Bech32(String),
@@ -240,6 +243,50 @@ where
 
         let key_bytes = &bytes[1..];
         Self::from_bytes(key_bytes)
+    }
+}
+
+/// Defines a type which can be converted to and from a base64 string of its
+/// raw bytes
+#[cfg(any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1",))]
+#[cfg_attr(
+    doc_cfg,
+    doc(cfg(any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1",)))
+)]
+pub trait ToFromBase64 {
+    type Error;
+
+    /// Encode this private key as a base64 string of its raw bytes, without a
+    /// signature scheme flag
+    fn to_base64(&self) -> String;
+
+    /// Decode a private key from a base64 string of its raw bytes, without a
+    /// signature scheme flag
+    fn from_base64(value: &str) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+#[cfg(any(feature = "ed25519", feature = "secp256r1", feature = "secp256k1",))]
+impl<T: ToFromBytes<Error = PrivateKeyError>> ToFromBase64 for T
+where
+    T::ByteArray: AsRef<[u8]>,
+{
+    type Error = PrivateKeyError;
+
+    fn to_base64(&self) -> String {
+        use base64ct::Encoding;
+
+        base64ct::Base64::encode_string(self.to_bytes().as_ref())
+    }
+
+    fn from_base64(value: &str) -> Result<Self, Self::Error> {
+        use base64ct::Encoding;
+
+        let bytes = base64ct::Base64::decode_vec(value)
+            .map_err(|e| PrivateKeyError::Base64(format!("decoding failed: {e}")))?;
+
+        Self::from_bytes(bytes)
     }
 }
 

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -506,4 +506,14 @@ mod tests {
         // The high-S variant must be rejected even though it is algebraically valid.
         verifying_key.verify(message, &malleated).unwrap_err();
     }
+
+    #[proptest]
+    fn base64_roundtrip(signer: Secp256k1PrivateKey) {
+        use crate::{ToFromBase64, ToFromBytes};
+
+        let b64 = signer.to_base64();
+        let decoded = Secp256k1PrivateKey::from_base64(&b64).unwrap();
+        assert_eq!(decoded.to_bytes(), signer.to_bytes());
+        assert_eq!(decoded.to_base64(), b64);
+    }
 }

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -459,4 +459,14 @@ mod tests {
         let err = Secp256r1PrivateKey::from_bytes([0u8; Secp256r1PrivateKey::LENGTH]);
         assert!(err.is_err());
     }
+
+    #[proptest]
+    fn base64_roundtrip(signer: Secp256r1PrivateKey) {
+        use crate::{ToFromBase64, ToFromBytes};
+
+        let b64 = signer.to_base64();
+        let decoded = Secp256r1PrivateKey::from_base64(&b64).unwrap();
+        assert_eq!(decoded.to_bytes(), signer.to_bytes());
+        assert_eq!(decoded.to_base64(), b64);
+    }
 }


### PR DESCRIPTION
# Description of change

Adds a `ToFromBase64` trait (base64 of the raw private key bytes) with a blanket impl covering `Ed25519PrivateKey`, `Secp256k1PrivateKey`, and `Secp256r1PrivateKey`, mirroring the existing `ToFromBech32` structure. Lets callers replace hand-rolled `Base64::decode` + `from_bytes` (e.g. `read_key` in the monorepo's `iota-keys`).

`base64ct` is promoted from dev-dependency to optional dependency gated by the key features — no new dependency added.

## Links to any relevant issues

fixes #1286

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Proptest round-trips for the three key types plus invalid-input rejection; clippy clean under `--all-features` and per-feature combinations.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_