### PR TITLE
fix(grpc-client)!: surface per-item errors in `get_objects`/`get_transactions`

### DIFF
--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -133,6 +133,11 @@ pub enum ProtocolError {
     /// Error during checkpoint data stream reassembly.
     #[error("checkpoint stream error: {0}")]
     CheckpointStream(#[from] CheckpointStreamError),
+
+    /// A batched read returned a number of results that does not match the
+    /// number of requested items.
+    #[error("expected {expected} results, got {actual}")]
+    UnexpectedResultCount { expected: usize, actual: usize },
 }
 
 /// Errors during checkpoint data stream reassembly.
@@ -265,6 +270,21 @@ pub trait ProtoResult {
 /// while one that tolerates gaps can inspect each slot.
 pub fn into_item_results<T: ProtoResult>(batch: Vec<T>) -> Vec<Result<T::Value>> {
     batch.into_iter().map(ProtoResult::into_result).collect()
+}
+
+/// Check that a batched read answered every requested item.
+///
+/// Callers pair results with requests by position, so a count that does not
+/// match the request leaves no way to tell which item each result belongs to.
+pub fn check_result_count<T>(results: &[T], expected: usize) -> Result<()> {
+    if results.len() == expected {
+        Ok(())
+    } else {
+        Err(Error::Protocol(ProtocolError::UnexpectedResultCount {
+            expected,
+            actual: results.len(),
+        }))
+    }
 }
 
 impl ProtoResult for ObjectResult {

--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -63,6 +63,27 @@ pub enum Error {
     Grpc(Box<tonic::Status>),
 }
 
+impl Error {
+    /// Returns `true` if the error carries a `NOT_FOUND` status, whether the
+    /// server reported it for the call or for a single item of a batched
+    /// request.
+    ///
+    /// **Warning:** do not test the outer error of a batched read to decide
+    /// that an item is absent. Those calls report an absent item against the
+    /// request that asked for it, so a `NOT_FOUND` for the call means the
+    /// endpoint is wrong; treating it as a missing item turns a misconfigured
+    /// endpoint into a normal "not there" answer. Test the per-item result
+    /// instead. Calls returning a single response, such as fetching a
+    /// checkpoint, do report absence at the call level.
+    pub fn is_not_found(&self) -> bool {
+        match self {
+            Error::Server(status) => status.code == i32::from(tonic::Code::NotFound),
+            Error::Grpc(status) => status.code() == tonic::Code::NotFound,
+            _ => false,
+        }
+    }
+}
+
 impl From<TryFromProtoError> for Error {
     fn from(err: TryFromProtoError) -> Self {
         Error::ProtoConversion(Box::new(err))
@@ -233,6 +254,17 @@ pub trait ProtoResult {
 
     /// Extract the result, converting to our error types.
     fn into_result(self) -> Result<Self::Value>;
+}
+
+/// Convert a batch of proto results into one result per requested item,
+/// preserving request order.
+///
+/// The batched RPCs report a failure for a single item as a `google.rpc.Status`
+/// in that item's slot, so the outcome for one item is independent of the
+/// others: a caller that needs every item can `collect::<Result<Vec<_>>>()`,
+/// while one that tolerates gaps can inspect each slot.
+pub fn into_item_results<T: ProtoResult>(batch: Vec<T>) -> Vec<Result<T::Value>> {
+    batch.into_iter().map(ProtoResult::into_result).collect()
 }
 
 impl ProtoResult for ObjectResult {
@@ -535,4 +567,61 @@ pub fn build_proto_transaction<T: Serialize>(
         .with_bcs(bcs);
 
     Ok(proto_transaction)
+}
+
+#[cfg(test)]
+mod tests {
+    use iota_grpc_types::{google::rpc::Status, v1::object::Object};
+
+    use super::{Error, ObjectResult, into_item_results};
+
+    #[test]
+    fn a_per_item_error_keeps_the_surrounding_items() {
+        let batch = vec![
+            ObjectResult::default().with_object(Object::default()),
+            ObjectResult::default().with_error(Status {
+                code: tonic::Code::NotFound.into(),
+                message: "Object 0x2 not found".to_owned(),
+                details: Vec::new(),
+            }),
+            ObjectResult::default().with_object(Object::default()),
+        ];
+
+        let items = into_item_results(batch);
+
+        assert_eq!(items.len(), 3);
+        assert!(items[0].is_ok());
+        assert!(matches!(items[1], Err(Error::Server(_))));
+        assert!(items[2].is_ok());
+    }
+
+    #[test]
+    fn an_all_error_batch_still_yields_one_item_per_request() {
+        let batch = vec![
+            ObjectResult::default().with_error(Status::default()),
+            ObjectResult::default().with_error(Status::default()),
+        ];
+
+        assert_eq!(into_item_results(batch).len(), 2);
+    }
+
+    #[test]
+    fn not_found_is_recognised_at_the_call_and_item_level() {
+        let item_level = Error::Server(Status {
+            code: tonic::Code::NotFound.into(),
+            message: String::new(),
+            details: Vec::new(),
+        });
+        let call_level = Error::from(tonic::Status::not_found("gone"));
+        let other = Error::Server(Status {
+            code: tonic::Code::Internal.into(),
+            message: String::new(),
+            details: Vec::new(),
+        });
+
+        assert!(item_level.is_not_found());
+        assert!(call_level.is_not_found());
+        assert!(!other.is_not_found());
+        assert!(!Error::EmptyRequest.is_not_found());
+    }
 }

--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -13,8 +13,8 @@ use iota_types::SignedTransaction;
 use crate::{
     Client,
     api::{
-        EXECUTE_TRANSACTIONS_READ_MASK, Error, MetadataEnvelope, ProtoResult, ProtocolError,
-        ReadMask, Result, build_proto_transaction, field_mask_with_default,
+        EXECUTE_TRANSACTIONS_READ_MASK, Error, MetadataEnvelope, ProtocolError, ReadMask, Result,
+        build_proto_transaction, field_mask_with_default, into_item_results,
     },
 };
 
@@ -154,12 +154,7 @@ impl Client {
             .execute_transactions(request)
             .await?;
 
-        MetadataEnvelope::from(response).try_map(|r| {
-            Ok(r.transaction_results
-                .into_iter()
-                .map(ProtoResult::into_result)
-                .collect())
-        })
+        Ok(MetadataEnvelope::from(response).map(|r| into_item_results(r.transaction_results)))
     }
 }
 

--- a/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/simulate.rs
@@ -12,8 +12,8 @@ use iota_types::Transaction;
 use crate::{
     Client,
     api::{
-        Error, MetadataEnvelope, ProtoResult, ProtocolError, ReadMask, Result,
-        SIMULATE_TRANSACTIONS_READ_MASK, build_proto_transaction, field_mask_with_default,
+        Error, MetadataEnvelope, ProtocolError, ReadMask, Result, SIMULATE_TRANSACTIONS_READ_MASK,
+        build_proto_transaction, field_mask_with_default, into_item_results,
     },
 };
 
@@ -149,12 +149,7 @@ impl Client {
             .simulate_transactions(request)
             .await?;
 
-        MetadataEnvelope::from(response).try_map(|r| {
-            Ok(r.transaction_results
-                .into_iter()
-                .map(ProtoResult::into_result)
-                .collect())
-        })
+        Ok(MetadataEnvelope::from(response).map(|r| into_item_results(r.transaction_results)))
     }
 }
 

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -53,21 +53,28 @@ impl Client {
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new("http://localhost:9000")?;
     /// let object_id: ObjectId = "0x2".parse()?;
+    /// let refs = [(object_id, None)];
     ///
     /// // Get objects with default mask
-    /// let objs = client.get_objects(&[(object_id, None)], None).await?;
+    /// let objs = client.get_objects(&refs, None).await?;
     ///
     /// // Get objects with field mask (only reference object ID, no BCS)
     /// let objs = client
     ///     .get_objects(
-    ///         &[(object_id, None)],
+    ///         &refs,
     ///         Some(ReadMask::from(ObjectField::REFERENCE_OBJECT_ID)),
     ///     )
     ///     .await?;
     ///
     /// for obj in objs.body() {
-    ///     // Skip the objects the node could not serve
-    ///     let Ok(obj) = obj else { continue };
+    ///     let obj = match obj {
+    ///         Ok(obj) => obj,
+    ///         // Only this ref failed; the remaining objects are still usable
+    ///         Err(e) => {
+    ///             eprintln!("could not read object: {e}");
+    ///             continue;
+    ///         }
+    ///     };
     ///
     ///     // Convert proto object to SDK type
     ///     let sdk_obj = obj.object()?;
@@ -75,6 +82,18 @@ impl Client {
     ///     let obj_ref = obj.object_reference()?;
     ///     println!("Object version: {:?}", obj_ref.version());
     /// }
+    ///
+    /// // Results line up with the requested refs, so pair them to find out
+    /// // which objects the node does not have
+    /// let missing: Vec<ObjectId> = refs
+    ///     .iter()
+    ///     .zip(objs.body())
+    ///     .filter_map(|((id, _), result)| match result {
+    ///         Err(e) if e.is_not_found() => Some(*id),
+    ///         _ => None,
+    ///     })
+    ///     .collect();
+    /// println!("Missing objects: {missing:?}");
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -13,8 +13,9 @@ use iota_types::{ObjectId, Version};
 use crate::{
     Client,
     api::{
-        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ReadMask, Result, collect_stream,
-        field_mask_with_default, into_item_results, proto_object_id, saturating_usize_to_u32,
+        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ReadMask, Result, check_result_count,
+        collect_stream, field_mask_with_default, into_item_results, proto_object_id,
+        saturating_usize_to_u32,
     },
 };
 
@@ -34,7 +35,12 @@ impl Client {
     /// existed, was deleted, or has been pruned by the serving node) yields
     /// [`Error::Server`] with code `NOT_FOUND` in that slot only, leaving the
     /// other objects intact. The outer `Result` is reserved for failures of the
-    /// call itself, such as a transport error.
+    /// call itself, such as a transport error, and for a server that answered
+    /// with a different number of results than refs requested
+    /// ([`UnexpectedResultCount`]), which leaves no way to tell which ref each
+    /// result belongs to.
+    ///
+    /// [`UnexpectedResultCount`]: crate::ProtocolError::UnexpectedResultCount
     ///
     /// # Read Mask
     ///
@@ -135,9 +141,12 @@ impl Client {
         let (stream, metadata) = MetadataEnvelope::from(response).into_parts();
 
         // Server guarantees results are returned in request order
-        collect_stream(stream, metadata, |msg| {
+        let response = collect_stream(stream, metadata, |msg| {
             Ok((msg.has_next, into_item_results(msg.objects)))
         })
-        .await
+        .await?;
+        check_result_count(response.body(), refs.len())?;
+
+        Ok(response)
     }
 }

--- a/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/objects.rs
@@ -13,8 +13,8 @@ use iota_types::{ObjectId, Version};
 use crate::{
     Client,
     api::{
-        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ProtoResult, ReadMask, Result,
-        collect_stream, field_mask_with_default, proto_object_id, saturating_usize_to_u32,
+        Error, GET_OBJECTS_READ_MASK, MetadataEnvelope, ReadMask, Result, collect_stream,
+        field_mask_with_default, into_item_results, proto_object_id, saturating_usize_to_u32,
     },
 };
 
@@ -24,12 +24,17 @@ impl Client {
     /// Returns proto `Object` types. Use `obj.object()` to convert to SDK
     /// type, or use `obj.object_reference()` to get the object reference.
     ///
-    /// Results are returned in the same order as the input refs.
-    /// If an object is not found, an error is returned.
+    /// Results are returned in the same order as the input refs, one per ref.
     ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `refs` is empty.
+    ///
+    /// Each ref gets its own result: an object that is not found (never
+    /// existed, was deleted, or has been pruned by the serving node) yields
+    /// [`Error::Server`] with code `NOT_FOUND` in that slot only, leaving the
+    /// other objects intact. The outer `Result` is reserved for failures of the
+    /// call itself, such as a transport error.
     ///
     /// # Read Mask
     ///
@@ -61,6 +66,9 @@ impl Client {
     ///     .await?;
     ///
     /// for obj in objs.body() {
+    ///     // Skip the objects the node could not serve
+    ///     let Ok(obj) = obj else { continue };
+    ///
     ///     // Convert proto object to SDK type
     ///     let sdk_obj = obj.object()?;
     ///     println!("Got object ID: {:?}", sdk_obj.id());
@@ -74,7 +82,7 @@ impl Client {
         &self,
         refs: &[(ObjectId, Option<Version>)],
         read_mask: Option<ReadMask<'_>>,
-    ) -> Result<MetadataEnvelope<Vec<Object>>> {
+    ) -> Result<MetadataEnvelope<Vec<Result<Object>>>> {
         if refs.is_empty() {
             return Err(Error::EmptyRequest);
         }
@@ -109,12 +117,7 @@ impl Client {
 
         // Server guarantees results are returned in request order
         collect_stream(stream, metadata, |msg| {
-            let items = msg
-                .objects
-                .into_iter()
-                .map(|r| r.into_result())
-                .collect::<Result<Vec<_>>>()?;
-            Ok((msg.has_next, items))
+            Ok((msg.has_next, into_item_results(msg.objects)))
         })
         .await
     }

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -12,8 +12,8 @@ use iota_types::TransactionDigest;
 use crate::{
     Client,
     api::{
-        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ProtoResult, ReadMask, Result,
-        collect_stream, field_mask_with_default, saturating_usize_to_u32,
+        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ReadMask, Result, collect_stream,
+        field_mask_with_default, into_item_results, saturating_usize_to_u32,
     },
 };
 
@@ -30,12 +30,20 @@ impl Client {
     /// - `tx.checkpoint_sequence_number()` - Get checkpoint number
     /// - `tx.timestamp_ms()` - Get timestamp
     ///
-    /// Results are returned in the same order as the input digests.
-    /// If a transaction is not found, an error is returned.
+    /// Results are returned in the same order as the input digests, one per
+    /// digest.
     ///
     /// # Errors
     ///
     /// Returns [`Error::EmptyRequest`] if `digests` is empty.
+    ///
+    /// Each digest gets its own result: a transaction the node does not have
+    /// (never executed, or pruned) yields [`Error::Server`] with code
+    /// `NOT_FOUND` in that slot only, leaving the other transactions intact. A
+    /// slot can also carry `FAILED_PRECONDITION` when the transaction itself is
+    /// present but an object a requested field needs is gone, as described
+    /// under Read Mask below. The outer `Result` is reserved for failures
+    /// of the call itself, such as a transport error.
     ///
     /// # Read Mask
     ///
@@ -78,6 +86,9 @@ impl Client {
     ///     .await?;
     ///
     /// for tx in txs.body() {
+    ///     // Skip the transactions the node could not serve
+    ///     let Ok(tx) = tx else { continue };
+    ///
     ///     // Lazy conversion - only deserialize what you need
     ///     let effects = tx.effects()?.effects()?;
     ///     println!("Status: {:?}", effects.as_v1().status);
@@ -93,7 +104,7 @@ impl Client {
         &self,
         digests: &[TransactionDigest],
         read_mask: Option<ReadMask<'_>>,
-    ) -> Result<MetadataEnvelope<Vec<ExecutedTransaction>>> {
+    ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
         if digests.is_empty() {
             return Err(Error::EmptyRequest);
         }
@@ -123,12 +134,7 @@ impl Client {
 
         // Server guarantees results are returned in request order
         collect_stream(stream, metadata, |msg| {
-            let items = msg
-                .transaction_results
-                .into_iter()
-                .map(|r| r.into_result())
-                .collect::<Result<Vec<_>>>()?;
-            Ok((msg.has_next, items))
+            Ok((msg.has_next, into_item_results(msg.transaction_results)))
         })
         .await
     }

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -86,8 +86,15 @@ impl Client {
     ///     .await?;
     ///
     /// for tx in txs.body() {
-    ///     // Skip the transactions the node could not serve
-    ///     let Ok(tx) = tx else { continue };
+    ///     let tx = match tx {
+    ///         Ok(tx) => tx,
+    ///         // Only this digest failed; the remaining transactions are still
+    ///         // usable
+    ///         Err(e) => {
+    ///             eprintln!("could not read transaction: {e}");
+    ///             continue;
+    ///         }
+    ///     };
     ///
     ///     // Lazy conversion - only deserialize what you need
     ///     let effects = tx.effects()?.effects()?;

--- a/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
+++ b/crates/iota-sdk-grpc-client/src/api/ledger/transactions.rs
@@ -12,8 +12,8 @@ use iota_types::TransactionDigest;
 use crate::{
     Client,
     api::{
-        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ReadMask, Result, collect_stream,
-        field_mask_with_default, into_item_results, saturating_usize_to_u32,
+        Error, GET_TRANSACTIONS_READ_MASK, MetadataEnvelope, ReadMask, Result, check_result_count,
+        collect_stream, field_mask_with_default, into_item_results, saturating_usize_to_u32,
     },
 };
 
@@ -43,7 +43,12 @@ impl Client {
     /// slot can also carry `FAILED_PRECONDITION` when the transaction itself is
     /// present but an object a requested field needs is gone, as described
     /// under Read Mask below. The outer `Result` is reserved for failures
-    /// of the call itself, such as a transport error.
+    /// of the call itself, such as a transport error, and for a server that
+    /// answered with a different number of results than digests requested
+    /// ([`UnexpectedResultCount`]), which leaves no way to tell which digest
+    /// each result belongs to.
+    ///
+    /// [`UnexpectedResultCount`]: crate::ProtocolError::UnexpectedResultCount
     ///
     /// # Read Mask
     ///
@@ -140,9 +145,12 @@ impl Client {
         let (stream, metadata) = MetadataEnvelope::from(response).into_parts();
 
         // Server guarantees results are returned in request order
-        collect_stream(stream, metadata, |msg| {
+        let response = collect_stream(stream, metadata, |msg| {
             Ok((msg.has_next, into_item_results(msg.transaction_results)))
         })
-        .await
+        .await?;
+        check_result_count(response.body(), digests.len())?;
+
+        Ok(response)
     }
 }

--- a/crates/iota-sdk-grpc-client/src/api/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/mod.rs
@@ -16,8 +16,9 @@ pub mod state;
 
 pub use common::{CheckpointStreamError, Error, Page, ProtocolError, ReadMask, Result, RpcStatus};
 pub(crate) use common::{
-    TryFromProtoError, build_proto_transaction, collect_stream, define_list_query,
-    field_mask_with_default, into_item_results, proto_object_id, saturating_usize_to_u32,
+    TryFromProtoError, build_proto_transaction, check_result_count, collect_stream,
+    define_list_query, field_mask_with_default, into_item_results, proto_object_id,
+    saturating_usize_to_u32,
 };
 pub use iota_grpc_types::read_masks::*;
 use iota_types::CheckpointSequenceNumber;

--- a/crates/iota-sdk-grpc-client/src/api/mod.rs
+++ b/crates/iota-sdk-grpc-client/src/api/mod.rs
@@ -16,8 +16,8 @@ pub mod state;
 
 pub use common::{CheckpointStreamError, Error, Page, ProtocolError, ReadMask, Result, RpcStatus};
 pub(crate) use common::{
-    ProtoResult, TryFromProtoError, build_proto_transaction, collect_stream, define_list_query,
-    field_mask_with_default, proto_object_id, saturating_usize_to_u32,
+    TryFromProtoError, build_proto_transaction, collect_stream, define_list_query,
+    field_mask_with_default, into_item_results, proto_object_id, saturating_usize_to_u32,
 };
 pub use iota_grpc_types::read_masks::*;
 use iota_types::CheckpointSequenceNumber;

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -21,15 +21,21 @@
 //! // node cannot serve fails only its own slot.
 //! let digest: TransactionDigest = todo!();
 //! let txs = client.get_transactions(&[digest], None).await?;
-//! if let Some(Ok(tx)) = txs.body().first() {
-//!     println!("Transaction digest: {:?}", tx.transaction()?.digest()?);
+//! for tx in txs.body() {
+//!     match tx {
+//!         Ok(tx) => println!("Transaction digest: {:?}", tx.transaction()?.digest()?),
+//!         Err(e) => eprintln!("could not read transaction: {e}"),
+//!     }
 //! }
 //!
 //! // Get an object (None = use default field mask)
 //! let object_id: ObjectId = "0x2".parse()?;
 //! let objects = client.get_objects(&[(object_id, None)], None).await?;
-//! if let Some(Ok(object)) = objects.body().first() {
-//!     println!("Object version: {:?}", object.object_reference()?.version());
+//! for object in objects.body() {
+//!     match object {
+//!         Ok(object) => println!("Object version: {:?}", object.object_reference()?.version()),
+//!         Err(e) => eprintln!("could not read object: {e}"),
+//!     }
 //! }
 //! # Ok(())
 //! # }

--- a/crates/iota-sdk-grpc-client/src/lib.rs
+++ b/crates/iota-sdk-grpc-client/src/lib.rs
@@ -16,17 +16,19 @@
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = Client::new("http://localhost:9000")?;
 //!
-//! // Get a transaction with full details (None = use default field mask)
+//! // Get a transaction with full details (None = use default field mask).
+//! // The batched reads return one result per request, so a transaction the
+//! // node cannot serve fails only its own slot.
 //! let digest: TransactionDigest = todo!();
 //! let txs = client.get_transactions(&[digest], None).await?;
-//! if let Some(tx) = txs.body().first() {
+//! if let Some(Ok(tx)) = txs.body().first() {
 //!     println!("Transaction digest: {:?}", tx.transaction()?.digest()?);
 //! }
 //!
 //! // Get an object (None = use default field mask)
 //! let object_id: ObjectId = "0x2".parse()?;
 //! let objects = client.get_objects(&[(object_id, None)], None).await?;
-//! if let Some(object) = objects.body().first() {
+//! if let Some(Ok(object)) = objects.body().first() {
 //!     println!("Object version: {:?}", object.object_reference()?.version());
 //! }
 //! # Ok(())

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -18,7 +18,7 @@ use crate::{
     Client,
     api::{
         EXECUTED_TRANSACTION_CHECKPOINT, EXECUTED_TRANSACTION_SIGNATURES,
-        EXECUTED_TRANSACTION_TRANSACTION, Error, ReadMask, TRANSACTION_DIGEST,
+        EXECUTED_TRANSACTION_TRANSACTION, Error, MetadataEnvelope, ReadMask, TRANSACTION_DIGEST,
         TRANSACTION_EFFECTS_BCS, saturating_usize_to_u32,
     },
 };
@@ -28,14 +28,20 @@ const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
 /// Interval between polls in [`TransactionBuilderClient::wait_for_tx`].
 const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-/// Returns `true` if the error represents a "not found" response from the
-/// server. Used to map a missing object/transaction to `Ok(None)` (and to keep
-/// polling while waiting for a transaction to be indexed).
-fn is_not_found(err: &Error) -> bool {
-    match err {
-        Error::Server(status) => status.code == tonic::Code::NotFound as i32,
-        Error::Grpc(status) => status.code() == tonic::Code::NotFound,
-        _ => false,
+/// Extract the result for the single item of a one-item batch request.
+///
+/// A `NOT_FOUND` for the item maps to `None`, since these callers treat a
+/// missing object or transaction as an absence rather than a failure. A failure
+/// of the call itself still propagates — including a `NOT_FOUND`, which says
+/// the endpoint is wrong rather than that the item is absent.
+fn single_item<T>(
+    response: Result<MetadataEnvelope<Vec<Result<T, Error>>>, Error>,
+) -> Result<Option<T>, Error> {
+    match response?.into_inner().into_iter().next() {
+        Some(Ok(item)) => Ok(Some(item)),
+        Some(Err(e)) if e.is_not_found() => Ok(None),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
     }
 }
 
@@ -50,13 +56,11 @@ impl TransactionBuilderClient for Client {
     ) -> Result<Option<Object>, Self::Error> {
         // Default read mask (`reference` + `bcs`) provides everything needed to
         // reconstruct the SDK object.
-        match self.get_objects(&[(object_id, version.into())], None).await {
-            Ok(envelope) => match envelope.into_inner().first() {
-                Some(obj) => Ok(Some(obj.object()?)),
-                None => Ok(None),
-            },
-            Err(e) if is_not_found(&e) => Ok(None),
-            Err(e) => Err(e),
+        let response = self.get_objects(&[(object_id, version.into())], None).await;
+
+        match single_item(response)? {
+            Some(obj) => Ok(Some(obj.object()?)),
+            None => Ok(None),
         }
     }
 
@@ -106,7 +110,7 @@ impl TransactionBuilderClient for Client {
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<SignedTransaction>, Self::Error> {
-        match self
+        let response = self
             .get_transactions(
                 &[digest],
                 Some(ReadMask::from(&[
@@ -114,21 +118,18 @@ impl TransactionBuilderClient for Client {
                     EXECUTED_TRANSACTION_SIGNATURES,
                 ])),
             )
-            .await
-        {
-            Ok(envelope) => match envelope.into_inner().into_iter().next() {
-                Some(tx) => {
-                    let transaction = tx.transaction()?.transaction()?;
-                    let signatures = Vec::<UserSignature>::try_from(tx.signatures()?)?;
-                    Ok(Some(SignedTransaction {
-                        transaction,
-                        signatures,
-                    }))
-                }
-                None => Ok(None),
-            },
-            Err(e) if is_not_found(&e) => Ok(None),
-            Err(e) => Err(e),
+            .await;
+
+        match single_item(response)? {
+            Some(tx) => {
+                let transaction = tx.transaction()?.transaction()?;
+                let signatures = Vec::<UserSignature>::try_from(tx.signatures()?)?;
+                Ok(Some(SignedTransaction {
+                    transaction,
+                    signatures,
+                }))
+            }
+            None => Ok(None),
         }
     }
 
@@ -136,16 +137,13 @@ impl TransactionBuilderClient for Client {
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
-        match self
+        let response = self
             .get_transactions(&[digest], Some(ReadMask::from(TRANSACTION_EFFECTS_BCS)))
-            .await
-        {
-            Ok(envelope) => match envelope.into_inner().into_iter().next() {
-                Some(tx) => Ok(Some(tx.effects()?.effects()?)),
-                None => Ok(None),
-            },
-            Err(e) if is_not_found(&e) => Ok(None),
-            Err(e) => Err(e),
+            .await;
+
+        match single_item(response)? {
+            Some(tx) => Ok(Some(tx.effects()?.effects()?)),
+            None => Ok(None),
         }
     }
 
@@ -236,22 +234,18 @@ impl TransactionBuilderClient for Client {
             let mut interval = tokio::time::interval(WAIT_FOR_TX_POLL_INTERVAL);
             loop {
                 interval.tick().await;
-                match self.get_transactions(&[digest], Some(mask.clone())).await {
-                    Ok(envelope) => {
-                        if let Some(tx) = envelope.into_inner().first() {
-                            let ready = match wait_for {
-                                WaitForTx::IndexedOnNode => true,
-                                WaitForTx::Finalized => tx.checkpoint_sequence_number().is_ok(),
-                                _ => unreachable!("checked above"),
-                            };
-                            if ready {
-                                return Ok(());
-                            }
-                        }
+                let response = self.get_transactions(&[digest], Some(mask.clone())).await;
+
+                // An absent transaction is not indexed yet — keep polling.
+                if let Some(tx) = single_item(response)? {
+                    let ready = match wait_for {
+                        WaitForTx::IndexedOnNode => true,
+                        WaitForTx::Finalized => tx.checkpoint_sequence_number().is_ok(),
+                        _ => unreachable!("checked above"),
+                    };
+                    if ready {
+                        return Ok(());
                     }
-                    // Not indexed yet — keep polling.
-                    Err(e) if is_not_found(&e) => {}
-                    Err(e) => return Err(e),
                 }
             }
         };
@@ -264,5 +258,44 @@ impl TransactionBuilderClient for Client {
                     WAIT_FOR_TX_TIMEOUT.as_secs()
                 )))
             })?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::metadata::MetadataMap;
+
+    use super::{Error, MetadataEnvelope, single_item};
+    use crate::api::RpcStatus;
+
+    fn not_found_status() -> RpcStatus {
+        RpcStatus {
+            code: tonic::Code::NotFound.into(),
+            message: String::new(),
+            details: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_not_found_for_the_call_itself_is_not_an_absent_item() {
+        let response: Result<MetadataEnvelope<Vec<Result<u32, Error>>>, Error> =
+            Err(Error::from(tonic::Status::not_found("no such route")));
+
+        assert!(
+            single_item(response).is_err(),
+            "a call-level not-found means the endpoint is wrong, not that the item is absent"
+        );
+    }
+
+    #[test]
+    fn a_not_found_for_the_item_is_an_absent_item() {
+        let items: Vec<Result<u32, Error>> = vec![Err(Error::Server(not_found_status()))];
+        let response = Ok(MetadataEnvelope::new(items, MetadataMap::new()));
+
+        assert!(
+            single_item(response)
+                .expect("an absent item is not an error")
+                .is_none()
+        );
     }
 }

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -19,7 +19,7 @@ use crate::{
     api::{
         EXECUTED_TRANSACTION_CHECKPOINT, EXECUTED_TRANSACTION_SIGNATURES,
         EXECUTED_TRANSACTION_TRANSACTION, Error, MetadataEnvelope, ReadMask, TRANSACTION_DIGEST,
-        TRANSACTION_EFFECTS_BCS, saturating_usize_to_u32,
+        TRANSACTION_EFFECTS_BCS, check_result_count, saturating_usize_to_u32,
     },
 };
 
@@ -34,14 +34,20 @@ const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// missing object or transaction as an absence rather than a failure. A failure
 /// of the call itself still propagates — including a `NOT_FOUND`, which says
 /// the endpoint is wrong rather than that the item is absent.
+///
+/// Anything other than exactly one result is a protocol error, not an absent
+/// item: the batched reads answer every request, so an empty batch says the
+/// server broke that promise rather than that the item is missing.
 fn single_item<T>(
     response: Result<MetadataEnvelope<Vec<Result<T, Error>>>, Error>,
 ) -> Result<Option<T>, Error> {
-    match response?.into_inner().into_iter().next() {
-        Some(Ok(item)) => Ok(Some(item)),
-        Some(Err(e)) if e.is_not_found() => Ok(None),
-        Some(Err(e)) => Err(e),
-        None => Ok(None),
+    let mut items = response?.into_inner();
+    check_result_count(&items, 1)?;
+
+    match items.pop().expect("count checked above") {
+        Ok(item) => Ok(Some(item)),
+        Err(e) if e.is_not_found() => Ok(None),
+        Err(e) => Err(e),
     }
 }
 
@@ -266,7 +272,7 @@ mod tests {
     use tonic::metadata::MetadataMap;
 
     use super::{Error, MetadataEnvelope, single_item};
-    use crate::api::RpcStatus;
+    use crate::api::{ProtocolError, RpcStatus};
 
     fn not_found_status() -> RpcStatus {
         RpcStatus {
@@ -296,6 +302,40 @@ mod tests {
             single_item(response)
                 .expect("an absent item is not an error")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn an_empty_batch_is_not_an_absent_item() {
+        let items: Vec<Result<u32, Error>> = Vec::new();
+        let response = Ok(MetadataEnvelope::new(items, MetadataMap::new()));
+
+        assert!(
+            matches!(
+                single_item(response),
+                Err(Error::Protocol(ProtocolError::UnexpectedResultCount {
+                    expected: 1,
+                    actual: 0
+                }))
+            ),
+            "a batch with no results means the server did not answer the request"
+        );
+    }
+
+    #[test]
+    fn a_batch_with_more_results_than_requested_is_an_error() {
+        let items: Vec<Result<u32, Error>> = vec![Ok(1), Ok(2)];
+        let response = Ok(MetadataEnvelope::new(items, MetadataMap::new()));
+
+        assert!(
+            matches!(
+                single_item(response),
+                Err(Error::Protocol(ProtocolError::UnexpectedResultCount {
+                    expected: 1,
+                    actual: 2
+                }))
+            ),
+            "results can no longer be paired with the request, so the first one is not usable"
         );
     }
 }

--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/ledger_service.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/ledger_service.proto
@@ -26,8 +26,26 @@ service LedgerService {
   // Query the service for general information about its current state.
   rpc GetServiceInfo(GetServiceInfoRequest) returns (GetServiceInfoResponse);
 
+  // Fetch objects by ID, each at a given version or the latest when no version
+  // is set.
+  //
+  // Concatenating `objects` across the response stream yields exactly one
+  // `ObjectResult` per `ObjectRequest`, in the order the requests were sent, so
+  // a client can pair a result with its request by position.
+  //
+  // A request the node cannot serve fails only its own result; the results for
+  // the other requests are unaffected.
   rpc GetObjects(GetObjectsRequest) returns (stream GetObjectsResponse);
 
+  // Fetch transactions by digest.
+  //
+  // Concatenating `transaction_results` across the response stream yields
+  // exactly one `TransactionResult` per `TransactionRequest`, in the order the
+  // requests were sent, so a client can pair a result with its request by
+  // position.
+  //
+  // A request the node cannot serve fails only its own result; the results for
+  // the other requests are unaffected.
   rpc GetTransactions(GetTransactionsRequest) returns (stream GetTransactionsResponse);
 
   // Checkpoint operations
@@ -131,6 +149,9 @@ message GetObjectsRequest {
 message ObjectResult {
   option (iota.grpc.message_accessors) = "with";
 
+  // The outcome for a single `ObjectRequest`: either the object, or the status
+  // saying why the node could not serve it — for example `NOT_FOUND` when the
+  // object never existed, was deleted, or has been pruned.
   oneof result {
     iota.grpc.v1.object.Object object = 1;
     google.rpc.Status error = 2;
@@ -141,6 +162,10 @@ message GetObjectsResponse {
   option (iota.grpc.message_accessors) = "with";
 
   repeated ObjectResult objects = 1;
+
+  // True when more stream messages follow because this batch reached the
+  // message size limit. It does not indicate that more data exists beyond the
+  // requested objects.
   bool has_next = 2;
 }
 
@@ -174,6 +199,10 @@ message GetTransactionsRequest {
 message TransactionResult {
   option (iota.grpc.message_accessors) = "with";
 
+  // The outcome for a single `TransactionRequest`: either the transaction, or
+  // the status saying why the node could not serve it — `NOT_FOUND` when the
+  // node does not have the transaction, or `FAILED_PRECONDITION` when it has the
+  // transaction but an object a requested field needs has been pruned.
   oneof result {
     iota.grpc.v1.transaction.ExecutedTransaction executed_transaction = 1;
     google.rpc.Status error = 2;
@@ -184,6 +213,10 @@ message GetTransactionsResponse {
   option (iota.grpc.message_accessors) = "with";
 
   repeated TransactionResult transaction_results = 1;
+
+  // True when more stream messages follow because this batch reached the
+  // message size limit. It does not indicate that more data exists beyond the
+  // requested transactions.
   bool has_next = 2;
 }
 

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.ledger_service.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.ledger_service.rs
@@ -97,11 +97,17 @@ pub struct GetObjectsRequest {
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ObjectResult {
+    /// The outcome for a single `ObjectRequest`: either the object, or the status
+    /// saying why the node could not serve it — for example `NOT_FOUND` when the
+    /// object never existed, was deleted, or has been pruned.
     #[prost(oneof = "object_result::Result", tags = "1, 2")]
     pub result: ::core::option::Option<object_result::Result>,
 }
 /// Nested message and enum types in `ObjectResult`.
 pub mod object_result {
+    /// The outcome for a single `ObjectRequest`: either the object, or the status
+    /// saying why the node could not serve it — for example `NOT_FOUND` when the
+    /// object never existed, was deleted, or has been pruned.
     #[non_exhaustive]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
@@ -116,6 +122,9 @@ pub mod object_result {
 pub struct GetObjectsResponse {
     #[prost(message, repeated, tag = "1")]
     pub objects: ::prost::alloc::vec::Vec<ObjectResult>,
+    /// True when more stream messages follow because this batch reached the
+    /// message size limit. It does not indicate that more data exists beyond the
+    /// requested objects.
     #[prost(bool, tag = "2")]
     pub has_next: bool,
 }
@@ -149,11 +158,19 @@ pub struct GetTransactionsRequest {
 #[non_exhaustive]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TransactionResult {
+    /// The outcome for a single `TransactionRequest`: either the transaction, or
+    /// the status saying why the node could not serve it — `NOT_FOUND` when the
+    /// node does not have the transaction, or `FAILED_PRECONDITION` when it has the
+    /// transaction but an object a requested field needs has been pruned.
     #[prost(oneof = "transaction_result::Result", tags = "1, 2")]
     pub result: ::core::option::Option<transaction_result::Result>,
 }
 /// Nested message and enum types in `TransactionResult`.
 pub mod transaction_result {
+    /// The outcome for a single `TransactionRequest`: either the transaction, or
+    /// the status saying why the node could not serve it — `NOT_FOUND` when the
+    /// node does not have the transaction, or `FAILED_PRECONDITION` when it has the
+    /// transaction but an object a requested field needs has been pruned.
     #[non_exhaustive]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Result {
@@ -168,6 +185,9 @@ pub mod transaction_result {
 pub struct GetTransactionsResponse {
     #[prost(message, repeated, tag = "1")]
     pub transaction_results: ::prost::alloc::vec::Vec<TransactionResult>,
+    /// True when more stream messages follow because this batch reached the
+    /// message size limit. It does not indicate that more data exists beyond the
+    /// requested transactions.
     #[prost(bool, tag = "2")]
     pub has_next: bool,
 }
@@ -446,6 +466,15 @@ pub mod ledger_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        /// Fetch objects by ID, each at a given version or the latest when no version
+        /// is set.
+        ///
+        /// Concatenating `objects` across the response stream yields exactly one
+        /// `ObjectResult` per `ObjectRequest`, in the order the requests were sent, so
+        /// a client can pair a result with its request by position.
+        ///
+        /// A request the node cannot serve fails only its own result; the results for
+        /// the other requests are unaffected.
         pub async fn get_objects(
             &mut self,
             request: impl tonic::IntoRequest<super::GetObjectsRequest>,
@@ -475,6 +504,15 @@ pub mod ledger_service_client {
                 );
             self.inner.server_streaming(req, path, codec).await
         }
+        /// Fetch transactions by digest.
+        ///
+        /// Concatenating `transaction_results` across the response stream yields
+        /// exactly one `TransactionResult` per `TransactionRequest`, in the order the
+        /// requests were sent, so a client can pair a result with its request by
+        /// position.
+        ///
+        /// A request the node cannot serve fails only its own result; the results for
+        /// the other requests are unaffected.
         pub async fn get_transactions(
             &mut self,
             request: impl tonic::IntoRequest<super::GetTransactionsRequest>,
@@ -629,6 +667,15 @@ pub mod ledger_service_server {
             >
             + std::marker::Send
             + 'static;
+        /// Fetch objects by ID, each at a given version or the latest when no version
+        /// is set.
+        ///
+        /// Concatenating `objects` across the response stream yields exactly one
+        /// `ObjectResult` per `ObjectRequest`, in the order the requests were sent, so
+        /// a client can pair a result with its request by position.
+        ///
+        /// A request the node cannot serve fails only its own result; the results for
+        /// the other requests are unaffected.
         async fn get_objects(
             &self,
             request: tonic::Request<super::GetObjectsRequest>,
@@ -639,6 +686,15 @@ pub mod ledger_service_server {
             >
             + std::marker::Send
             + 'static;
+        /// Fetch transactions by digest.
+        ///
+        /// Concatenating `transaction_results` across the response stream yields
+        /// exactly one `TransactionResult` per `TransactionRequest`, in the order the
+        /// requests were sent, so a client can pair a result with its request by
+        /// position.
+        ///
+        /// A request the node cannot serve fails only its own result; the results for
+        /// the other requests are unaffected.
         async fn get_transactions(
             &self,
             request: tonic::Request<super::GetTransactionsRequest>,


### PR DESCRIPTION
## Why

`get_objects` and `get_transactions` collapsed the server's per-item results with `collect::<Result<Vec<_>>>()`, so the first per-item error discarded every item already collected — and the caller could not tell which request failed.

A missing item is routine (coins get consumed or smashed, objects get pruned by the serving node), so one of them made the whole batch unusable. Callers were working around this by refetching one item at a time whenever a batch failed.

The node was always right here: `ObjectResult`/`TransactionResult` carry a per-item `google.rpc.Status` and the stream does not abort. Only the client threw that away.

## What

- `get_objects`/`get_transactions` now return `Vec<Result<T>>` — one result per request, in request order. This matches `execute_transactions`/`simulate_transactions`, which were already per-item.
- Adds `Error::is_not_found()`, replacing four hand-rolled copies of the same status-code check.

Callers that need every item can `collect::<Result<Vec<_>>>()`; callers that tolerate gaps inspect each slot.

**Breaking, deliberately.** The old signature cannot express "this item is missing, the rest are fine" — that *is* the bug — so a deprecation step would mean shipping a parallel method whose only purpose is to be correct.

## Test plan

- New unit tests for the per-item mapping and `Error::is_not_found()`.
- `cargo test -p iota-sdk-grpc-client` (7 lib + 22 doctests), clippy `-D warnings`, nightly fmt — all clean.
- Verified against a real node in the monorepo: 105/105 gRPC e2e tests pass. Their previous assertions encoded the old behaviour (`"Mixed valid/invalid should return an error"`).

Downstream: the monorepo needs a follow-up PR once the pinned `rev` is bumped — five call sites, mostly mechanical, plus removal of the one-at-a-time fallback in `iota-vm-sdk`.
