### PR TITLE
chore: make the writing guidance push back on diff-restating PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,15 @@ Write what a reviewer cannot get from the diff: the reasoning and the shape of t
 change. No per-file walkthroughs, no lists of renamed or added symbols, no prose
 restatement of the code.
 
+State only reasoning you know. Do not invent a motivation, or a justification for a
+dependency or design choice, to fill a section.
+
+Add a `## Trade-offs` section only if a real alternative was rejected, and a
+`## Review focus` section only if one part deserves more attention than the rest.
+Most changes need neither.
+
 Before submitting, check each sentence: if the reader could have learned it from
 the diff, delete it. Repeat until a pass deletes nothing.
-
-Drop any section that does not apply.
 -->
 
 ## Why
@@ -17,14 +22,6 @@ Drop any section that does not apply.
 
 <!-- The change at the level of concepts: behaviour that differs, invariants that now hold,
      the new shape. Not the symbols that moved. -->
-
-## Trade-offs
-
-<!-- Only if a real choice was made: what was rejected and why. -->
-
-## Review focus
-
-<!-- Only if some part deserves more attention than the rest. -->
 
 ## Test plan
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,8 @@ Write what a reviewer cannot get from the diff: the reasoning and the shape of t
 change. No per-file walkthroughs, no lists of renamed or added symbols, no prose
 restatement of the code.
 
-There is no length limit — a small change is a few sentences, a large one may need
-more. Before submitting, check each sentence: if the reader could have learned it
-from the diff, delete it.
+Before submitting, check each sentence: if the reader could have learned it from
+the diff, delete it. Repeat until a pass deletes nothing.
 
 Drop any section that does not apply.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,10 +6,6 @@ restatement of the code.
 State only reasoning you know. Do not invent a motivation, or a justification for a
 dependency or design choice, to fill a section.
 
-Add a `## Trade-offs` section only if a real alternative was rejected, and a
-`## Review focus` section only if one part deserves more attention than the rest.
-Most changes need neither.
-
 Before submitting, check each sentence: if the reader could have learned it from
 the diff, delete it. Repeat until a pass deletes nothing.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+<!--
+Write what a reviewer cannot get from the diff: the reasoning and the shape of the
+change. No per-file walkthroughs, no lists of renamed or added symbols, no prose
+restatement of the code.
+
+There is no length limit — a small change is a few sentences, a large one may need
+more. Before submitting, check each sentence: if the reader could have learned it
+from the diff, delete it.
+
+Drop any section that does not apply.
+-->
+
+## Why
+
+<!-- The problem, constraint or decision behind this change. Link the issue if there is one. -->
+
+## What changes
+
+<!-- The change at the level of concepts: behaviour that differs, invariants that now hold,
+     the new shape. Not the symbols that moved. -->
+
+## Trade-offs
+
+<!-- Only if a real choice was made: what was rejected and why. -->
+
+## Review focus
+
+<!-- Only if some part deserves more attention than the rest. -->
+
+## Test plan
+
+<!-- What you ran, or what a reviewer should run. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The **IOTA Rust SDK** is a modular software development kit for integrating with
 5. **Format and lint after every change** — `cargo +nightly fmt`, `dprint fmt`, and `make bindings-examples-format-check` for binding examples.
 6. **Keep pull requests small** — prefer small, focused PRs over large ones. A small diff is easier to review, easier to revert, and less likely to introduce regressions.
 7. **Split work into multiple PRs when possible** — if a change spans multiple concerns (e.g. a refactor plus a new feature, or changes across unrelated crates), split it into separate PRs. Land independent pieces incrementally rather than bundling them together. **Critically: when given multiple GitHub issues, ALWAYS create one PR per issue** — never bundle multiple issues into a single PR unless explicitly instructed or the issues are genuinely interdependent.
-8. **Keep PR descriptions short and skimmable** — write for a human reviewer who has 30 seconds. Cover the _why_ and the high-level _what_, and stop. Don't enumerate every line of the diff; reviewers can read the code. Avoid long wall-of-text summaries, exhaustive bullet lists of every renamed symbol, or restating what the diff obviously shows. A few crisp sentences (plus a test plan if relevant) is the goal.
+8. **Write only what the diff can't say** — PR descriptions, review comments and chat replies cover the reasoning and the high-level shape of a change, never a walkthrough of the diff. See [Writing style](#writing-style); this is the most frequently ignored rule in this file.
 9. **Feature flags matter** — the umbrella `iota-sdk` gates everything behind features. Check what's enabled for the code you're modifying before assuming an item exists.
 10. **NEVER hand-edit generated gRPC types** under `crates/iota-sdk-grpc-types/src/proto/` — they are build output. Changes go into the proto sources / `update_grpc_types.sh`.
 
@@ -114,7 +114,11 @@ cargo test --doc                 # Direct doc test invocation
 
 ## Writing style
 
-These rules cover everything you write: function and variable names, code comments, commit messages, and PR and issue descriptions.
+These rules cover everything you write: function and variable names, code comments, commit messages, PR and issue descriptions, review comments, and replies in a chat session.
+
+The rule they all follow: **write what the reader cannot get from the code or the diff.** Reasoning, constraints, trade-offs and the shape of a change are worth writing. Restating what the code already shows — which symbols were renamed, which files were touched, what each function now does — is not, no matter how well organised it is.
+
+There is no word limit anywhere in this section, and none should be added. Length follows scope: a one-concept change is a few sentences, a change spanning several concepts gets a paragraph or bullet per concept, and a genuinely large change is allowed to be long. What is never allowed is padding a description with material the reader can already see.
 
 ### Code comments
 
@@ -126,12 +130,38 @@ Write comments for a future reader of the code, and keep them concise and durabl
 
 ### PR and issue descriptions
 
-- Keep them compact and concise; bullet points over full paragraphs (see also **Keep PR descriptions short and skimmable** in the critical development notes).
-- Say at a high level _what_ the change does and _why_ — the code-level details belong in the diff, not the description.
+A PR description answers what a reviewer cannot get by reading the diff:
+
+- **Why** the change exists — the problem, the constraint, the decision behind it.
+- **What** it does at the level of concepts, not symbols: which behaviour changes, which invariant now holds, what the new shape is.
+- **Trade-offs and rejected alternatives**, where a real choice was made.
+- **What to look at hardest**, if some part of the change deserves more attention than the rest.
+
+Leave out the mechanics of the diff: per-file walkthroughs, lists of renamed or added symbols, "moved X to Y" inventories, and summaries that restate the code in prose. The reviewer has the diff.
+
+Issue descriptions follow the same split: the problem and why it matters, not a proposed patch written out in prose.
+
+Self-check before submitting — this replaces any notion of a length limit: take each sentence and ask _could the reader have learned this from the diff?_ If yes, delete it. What survives is the description. If that leaves two sentences, the description is two sentences.
+
+### Chat replies and reports
+
+The same rule applies when reporting work back in a session, not just on GitHub:
+
+- Say what changed and why, what is verified and what is not, and anything the user has to decide or act on.
+- Don't replay the work: no narration of each file edited, no summary of code the user can read, no listing of steps already visible in the session.
+- Don't restate the request back before answering it, and don't close with a recap of what was just said.
+- Where a table or bullet list is only reformatting the diff, drop it entirely rather than tidying it.
+
+Length follows the same principle as above: as long as the content genuinely requires, and no longer.
+
+### Review comments
+
+- Say what is wrong and why it matters. One point per comment.
+- Don't re-explain the author's own code back to them, and don't restate the same suggestion in several forms.
 
 ### Plain language, no coined terms
 
-Applies to all of the above, and to review comments and reports — all prose, not just code.
+Applies to all of the above — all prose, not just code.
 
 Use plain words and terms already used in the codebase or the established domain, so a reader can follow the text without terminology the project doesn't already use. Do not invent a label for a concept and then reuse it as if it were established vocabulary — this is a recurring problem, treat it as a hard rule. Before naming a concept, check whether the repo already has a word for it and reuse that. If a phrase wouldn't appear in the code or a standard reference, drop the label and describe the thing directly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ All prose — PR/issue descriptions, reviews, chat replies, comments, commit mes
 - No invented motives — never "X because Y" unless Y came from the issue or task.
 - No filler — no lead-ins, headings-for-show, verdict paragraphs, or notes about these rules. Reviews: start with the first finding, one point per comment.
 - Plain language — only terms already in the codebase or domain; never coin a label and reuse it as vocabulary.
+- Match the answer's shape to the question — an enumerable question gets a bullet list, one line per item; prose only where an item needs actual reasoning.
 
 Before posting: delete every sentence the reader could get from the diff; repeat until a pass cuts nothing.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,44 +114,15 @@ cargo test --doc                 # Direct doc test invocation
 
 ## Writing style
 
-Covers everything you write: names, code comments, commit messages, PR and issue descriptions, review comments, chat replies.
+All prose — PR/issue descriptions, reviews, chat replies, comments, commit messages:
 
-**Write what the reader cannot get from the code or the diff** — reasoning, constraints, trade-offs, the shape of a change. Not what the diff already shows: renamed symbols, touched files, what each function now does. Length follows scope; the rule constrains content, not size.
+- One sentence naming the change, then only what the reader can't get from the diff: the problem, the reasoning, real trade-offs. Usually that's a few sentences; long only when the change is genuinely large.
+- No diff inventory — no per-file bullets, no symbol lists, no restating code in prose. Applies to reasons too: a "why" whose content is visible in the diff is inventory.
+- No invented motives — never "X because Y" unless Y came from the issue or task.
+- No filler — no lead-ins, headings-for-show, verdict paragraphs, or notes about these rules. Reviews: start with the first finding, one point per comment.
+- Plain language — only terms already in the codebase or domain; never coin a label and reuse it as vocabulary.
 
-Never state a motive you do not have. A true fact about a dependency is not the reason it was picked: don't write "X because Y" unless Y came from the issue or the task. Where the reason isn't recoverable, say what the change does and link the issue.
-
-An example — the difference is not any single sentence, it is what the description is organised around. Not this, organised by file, where each bullet is true and the whole still restates the diff:
-
-> Extends the writing conventions beyond code comments to cover PR/issue descriptions, reviews, and reports.
->
-> - `RUST_CONVENTIONS.md`: new "Plain Language, No Coined Terms" rule under Comments — applies to all prose; use vocabulary already in the codebase/domain, don't invent-and-reuse labels, self-check before submitting.
-> - `AGENTS.md`: promote "Comment style" to a "Writing style" section covering code comments, PR/issue descriptions (compact, bullet points over prose, still state why), and the plain-language rule.
-> - `REVIEW.md`: review-output guidance now points to the plain-language rule.
-
-This, organised around the problem:
-
-> AI-generated comments and PR/issue text tend to be too long and lean on invented terminology. This extends the writing conventions to push back on that: keep prose concise, use plain language, and stick to terms already used in the project.
->
-> Applies to code comments (as before) plus PR/issue descriptions, reviews, and reports.
-
-### Per surface
-
-- **Code comments** — doc comments tell the caller what they need in order to call it correctly; inline comments give a non-obvious _why_, and default to none. No change history ("added for X", "as discussed", PR numbers).
-- **PR and issue descriptions** — why the change exists, what changes at the level of concepts, real trade-offs, and where to look hardest. For issues: the problem and why it matters, not a patch written out in prose.
-- **Review comments** — start with the first finding. No heading, no lead-in, and no "overall" paragraph describing the change back to the author; a verdict is allowed only if it is a judgement they don't already have. One point per comment; if it contains "also", it is two.
-- **Chat replies** — the change, and anything the user has to decide or act on. Mention verification only where it is informative: a routine `clippy`/`fmt`/`cargo check` pass is not, an unrun test suite or an unverified behaviour change is. Don't replay the session or restate the request.
-
-### Before posting
-
-1. Draft from the problem and the reasoning, not by reading back over the diff for material.
-2. Delete every sentence the reader could have got from the diff, except the one naming what the change is — every description needs that, however obvious, so the reasoning has something to attach to.
-3. Repeat step 2 until a pass cuts nothing.
-
-Being asked to make something shorter means step 2 was skipped.
-
-### Plain language
-
-Use words already in the codebase or the established domain. Don't coin a label for a concept and then reuse it as if it were vocabulary — describe the thing directly. Before submitting, scan for any noun phrase acting as a _name_ for an idea; if you coined it, delete the label and state the idea plainly.
+Before posting: delete every sentence the reader could get from the diff; repeat until a pass cuts nothing.
 
 ## Important Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,70 +114,38 @@ cargo test --doc                 # Direct doc test invocation
 
 ## Writing style
 
-These rules cover everything you write: function and variable names, code comments, commit messages, PR and issue descriptions, review comments, and replies in a chat session.
+Covers everything you write: names, code comments, commit messages, PR and issue descriptions, review comments, chat replies.
 
-The rule they all follow: **write what the reader cannot get from the code or the diff.** Reasoning, constraints, trade-offs and the shape of a change are worth writing. Restating what the code already shows — which symbols were renamed, which files were touched, what each function now does — is not, no matter how well organised it is.
+**Write what the reader cannot get from the code or the diff** — reasoning, constraints, trade-offs, the shape of a change. Not what the diff already shows: renamed symbols, touched files, what each function now does. Length follows scope; the rule constrains content, not size.
 
-Length follows scope, and there is no word limit — the rule constrains content, not size. A large change may need a long description; a small one is a few sentences.
+Never state a motive you do not have. A true fact about a dependency is not the reason it was picked: don't write "X because Y" unless Y came from the issue or the task. Where the reason isn't recoverable, say what the change does and link the issue.
 
-Filler counts as content the reader can't use, and is cut on the same grounds. Don't write sentences that state the absence of a rule, hedge about how long something should be, announce what you are about to say, or note that a section was skipped — leave it out instead.
+| Don't                                                                        | Do                                                             |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `base64ct` was chosen because it is constant-time                              | Base64 is pulled in by each key-scheme feature                   |
+| Renames `content_digest` to `contents_digest` across the crate                 | The field now matches the type it holds, `CheckpointContentsDigest` |
+| Adds `to_base64`/`from_base64` to `Ed25519PrivateKey`, `Secp256k1PrivateKey`, … | Any key type with byte conversions gets base64 for free          |
+| "Review comments on the diff:" / "Here is what I changed:"                     | delete it and start with the first point                         |
+| "There is no length limit — a small change is a few sentences"                 | delete it; don't write about the rules                           |
 
-### Code comments
+### Per surface
 
-Write comments for a future reader of the code, and keep them concise and durable — not a changelog of in-session edits.
+- **Code comments** — doc comments tell the caller what they need in order to call it correctly; inline comments give a non-obvious _why_, and default to none. No change history ("added for X", "as discussed", PR numbers).
+- **PR and issue descriptions** — why the change exists, what changes at the level of concepts, real trade-offs, and where to look hardest. For issues: the problem and why it matters, not a patch written out in prose.
+- **Review comments** — open with the problem, not a summary of the author's own code. One point per comment; if it contains "also", it is two.
+- **Chat replies** — what changed, what is verified and what is not, what the user has to decide. Don't replay the session or restate the request.
 
-- Doc comments are for the **caller** — what they need to know to call it correctly, not how it works inside.
-- Inline comments explain a non-obvious **why**, never a **what**; default to none.
-- Never embed conversational or change history ("added for X", "as discussed", PR/issue numbers), nor explain why a problem was fixed when that problem was only introduced within the same change — that belongs in the PR description or commit message, not the code.
+### Before posting
 
-### PR and issue descriptions
+1. Draft from the problem and the reasoning, not by reading back over the diff for material.
+2. Delete every sentence the reader could have got from the diff.
+3. Repeat step 2 until a pass cuts nothing.
 
-A PR description answers what a reviewer cannot get by reading the diff:
+Being asked to make something shorter means step 2 was skipped.
 
-- **Why** the change exists — the problem, the constraint, the decision behind it.
-- **What** it does at the level of concepts, not symbols: which behaviour changes, which invariant now holds, what the new shape is.
-- **Trade-offs and rejected alternatives**, where a real choice was made.
-- **What to look at hardest**, if some part of the change deserves more attention than the rest.
+### Plain language
 
-State only reasoning you actually know — from the issue, the task you were given, or the code itself. Do not infer a plausible motivation and present it as the reason: an invented rationale is harder for a reviewer to catch than a verbose description, because it reads exactly like a real one. Where the reason is not recoverable, say what the change does and link the issue instead of filling the gap.
-
-Knowing a fact about a dependency or an approach is not the same as knowing it was the reason for the choice. That a crate is constant-time or already in the tree may be true and still not be why it was picked — do not write "X was used because Y" unless Y came from the issue or the task. Where a property matters to the reader on its own, state the property, not the motive.
-
-Leave out the mechanics of the diff: per-file walkthroughs, lists of renamed or added symbols, "moved X to Y" inventories, and summaries that restate the code in prose. The reviewer has the diff.
-
-Issue descriptions follow the same split: the problem and why it matters, not a proposed patch written out in prose.
-
-How to write one:
-
-1. Write it from the problem and the reasoning, not by reading back over the diff for material. Consulting the diff to decide what to write produces an inventory.
-2. Then delete: take each sentence and ask _could the reader have learned this from the diff?_ If yes, cut it.
-3. Repeat step 2 until a pass cuts nothing. The first pass never catches everything.
-
-Do this before posting. Being asked to make a description shorter means step 2 was skipped.
-
-### Chat replies and reports
-
-The same rule applies when reporting work back in a session, not just on GitHub:
-
-- Say what changed and why, what is verified and what is not, and anything the user has to decide or act on.
-- Don't replay the work: no narration of each file edited, no summary of code the user can read, no listing of steps already visible in the session.
-- Don't restate the request back before answering it, and don't close with a recap of what was just said.
-- Where a table or bullet list is only reformatting the diff, drop it entirely rather than tidying it.
-- Run the same delete pass before replying.
-
-### Review comments
-
-- Say what is wrong and why it matters. Open with the problem, not with a summary of what the code does — the author knows what they wrote.
-- One point per comment. If a comment contains "also" or "additionally", it is two comments.
-- Don't restate the same suggestion in several forms, and don't introduce a set of comments with a line announcing that comments follow.
-
-### Plain language, no coined terms
-
-Applies to all of the above — all prose, not just code.
-
-Use plain words and terms already used in the codebase or the established domain, so a reader can follow the text without terminology the project doesn't already use. Do not invent a label for a concept and then reuse it as if it were established vocabulary — this is a recurring problem, treat it as a hard rule. Before naming a concept, check whether the repo already has a word for it and reuse that. If a phrase wouldn't appear in the code or a standard reference, drop the label and describe the thing directly.
-
-Self-check before submitting: scan for any noun phrase acting as a _name_ for an idea. If you coined it — not the codebase, not the domain — delete the label and state the idea in plain words.
+Use words already in the codebase or the established domain. Don't coin a label for a concept and then reuse it as if it were vocabulary — describe the thing directly. Before submitting, scan for any noun phrase acting as a _name_ for an idea; if you coined it, delete the label and state the idea plainly.
 
 ## Important Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ This, organised around the problem:
 - **Code comments** — doc comments tell the caller what they need in order to call it correctly; inline comments give a non-obvious _why_, and default to none. No change history ("added for X", "as discussed", PR numbers).
 - **PR and issue descriptions** — why the change exists, what changes at the level of concepts, real trade-offs, and where to look hardest. For issues: the problem and why it matters, not a patch written out in prose.
 - **Review comments** — start with the first finding. No heading, no lead-in, and no "overall" paragraph describing the change back to the author; a verdict is allowed only if it is a judgement they don't already have. One point per comment; if it contains "also", it is two.
-- **Chat replies** — what changed, what is verified and what is not, what the user has to decide. Don't replay the session or restate the request.
+- **Chat replies** — the change, and anything the user has to decide or act on. Mention verification only where it is informative: a routine `clippy`/`fmt`/`cargo check` pass is not, an unrun test suite or an unverified behaviour change is. Don't replay the session or restate the request.
 
 ### Before posting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ Never state a motive you do not have. A true fact about a dependency is not the 
 | Don't                                                                        | Do                                                             |
 | ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | `base64ct` was chosen because it is constant-time                              | Base64 is pulled in by each key-scheme feature                   |
-| Renames `content_digest` to `contents_digest` across the crate                 | The field now matches the type it holds, `CheckpointContentsDigest` |
+| Renames the field, its accessor, the FFI shim and the schema comment           | Renames `content_digest` to `contents_digest`, matching the type it holds, `CheckpointContentsDigest` |
 | Adds `to_base64`/`from_base64` to `Ed25519PrivateKey`, `Secp256k1PrivateKey`, … | Any key type with byte conversions gets base64 for free          |
 | "Review comments on the diff:" / "Here is what I changed:"                     | delete it and start with the first point                         |
 | "There is no length limit — a small change is a few sentences"                 | delete it; don't write about the rules                           |
@@ -138,7 +138,7 @@ Never state a motive you do not have. A true fact about a dependency is not the 
 ### Before posting
 
 1. Draft from the problem and the reasoning, not by reading back over the diff for material.
-2. Delete every sentence the reader could have got from the diff.
+2. Delete every sentence the reader could have got from the diff, except the one naming what the change is — every description needs that, however obvious, so the reasoning has something to attach to.
 3. Repeat step 2 until a pass cuts nothing.
 
 Being asked to make something shorter means step 2 was skipped.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ A PR description answers what a reviewer cannot get by reading the diff:
 - **Trade-offs and rejected alternatives**, where a real choice was made.
 - **What to look at hardest**, if some part of the change deserves more attention than the rest.
 
+State only reasoning you actually know — from the issue, the task you were given, or the code itself. Do not infer a plausible motivation and present it as the reason: an invented rationale is harder for a reviewer to catch than a verbose description, because it reads exactly like a real one. Where the reason is not recoverable, say what the change does and link the issue instead of filling the gap. The same applies to justifying a dependency or design choice you did not make.
+
 Leave out the mechanics of the diff: per-file walkthroughs, lists of renamed or added symbols, "moved X to Y" inventories, and summaries that restate the code in prose. The reviewer has the diff.
 
 Issue descriptions follow the same split: the problem and why it matters, not a proposed patch written out in prose.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,9 @@ These rules cover everything you write: function and variable names, code commen
 
 The rule they all follow: **write what the reader cannot get from the code or the diff.** Reasoning, constraints, trade-offs and the shape of a change are worth writing. Restating what the code already shows — which symbols were renamed, which files were touched, what each function now does — is not, no matter how well organised it is.
 
-There is no word limit anywhere in this section, and none should be added. Length follows scope: a one-concept change is a few sentences, a change spanning several concepts gets a paragraph or bullet per concept, and a genuinely large change is allowed to be long. What is never allowed is padding a description with material the reader can already see.
+Length follows scope, and there is no word limit — the rule constrains content, not size. A large change may need a long description; a small one is a few sentences.
+
+Filler counts as content the reader can't use, and is cut on the same grounds. Don't write sentences that state the absence of a rule, hedge about how long something should be, announce what you are about to say, or note that a section was skipped — leave it out instead.
 
 ### Code comments
 
@@ -141,7 +143,13 @@ Leave out the mechanics of the diff: per-file walkthroughs, lists of renamed or 
 
 Issue descriptions follow the same split: the problem and why it matters, not a proposed patch written out in prose.
 
-Self-check before submitting — this replaces any notion of a length limit: take each sentence and ask _could the reader have learned this from the diff?_ If yes, delete it. What survives is the description. If that leaves two sentences, the description is two sentences.
+How to write one:
+
+1. Write it from the problem and the reasoning, not by reading back over the diff for material. Consulting the diff to decide what to write produces an inventory.
+2. Then delete: take each sentence and ask _could the reader have learned this from the diff?_ If yes, cut it.
+3. Repeat step 2 until a pass cuts nothing. The first pass never catches everything.
+
+Do this before posting. Being asked to make a description shorter means step 2 was skipped.
 
 ### Chat replies and reports
 
@@ -151,8 +159,7 @@ The same rule applies when reporting work back in a session, not just on GitHub:
 - Don't replay the work: no narration of each file edited, no summary of code the user can read, no listing of steps already visible in the session.
 - Don't restate the request back before answering it, and don't close with a recap of what was just said.
 - Where a table or bullet list is only reformatting the diff, drop it entirely rather than tidying it.
-
-Length follows the same principle as above: as long as the content genuinely requires, and no longer.
+- Run the same delete pass before replying.
 
 ### Review comments
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ Never state a motive you do not have. A true fact about a dependency is not the 
 
 - **Code comments** — doc comments tell the caller what they need in order to call it correctly; inline comments give a non-obvious _why_, and default to none. No change history ("added for X", "as discussed", PR numbers).
 - **PR and issue descriptions** — why the change exists, what changes at the level of concepts, real trade-offs, and where to look hardest. For issues: the problem and why it matters, not a patch written out in prose.
-- **Review comments** — open with the problem, not a summary of the author's own code. One point per comment; if it contains "also", it is two.
+- **Review comments** — start with the first finding. No heading, no lead-in, and no "overall" paragraph describing the change back to the author; a verdict is allowed only if it is a judgement they don't already have. One point per comment; if it contains "also", it is two.
 - **Chat replies** — what changed, what is verified and what is not, what the user has to decide. Don't replay the session or restate the request.
 
 ### Before posting

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ cargo test --doc                 # Direct doc test invocation
 
 All prose — PR/issue descriptions, reviews, chat replies, comments, commit messages:
 
-- One sentence naming the change, then only what the reader can't get from the diff: the problem, the reasoning, real trade-offs. Usually that's a few sentences; long only when the change is genuinely large.
+- One sentence naming the change, then only what the reader can't get from the diff: the problem, the reasoning, real trade-offs. Default budget: 1–3 sentences per section — spend more only on a concern the reader would miss, never to cover the diff more completely.
 - No diff inventory — no per-file bullets, no symbol lists, no restating code in prose. Applies to reasons too: a "why" whose content is visible in the diff is inventory.
 - No invented motives — never "X because Y" unless Y came from the issue or task.
 - No filler — no lead-ins, headings-for-show, verdict paragraphs, or notes about these rules. Reviews: start with the first finding, one point per comment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,13 +120,19 @@ Covers everything you write: names, code comments, commit messages, PR and issue
 
 Never state a motive you do not have. A true fact about a dependency is not the reason it was picked: don't write "X because Y" unless Y came from the issue or the task. Where the reason isn't recoverable, say what the change does and link the issue.
 
-| Don't                                                                        | Do                                                             |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| `base64ct` was chosen because it is constant-time                              | Base64 is pulled in by each key-scheme feature                   |
-| Renames the field, its accessor, the FFI shim and the schema comment           | Renames `content_digest` to `contents_digest`, matching the type it holds, `CheckpointContentsDigest` |
-| Adds `to_base64`/`from_base64` to `Ed25519PrivateKey`, `Secp256k1PrivateKey`, … | Any key type with byte conversions gets base64 for free          |
-| "Review comments on the diff:" / "Here is what I changed:"                     | delete it and start with the first point                         |
-| "There is no length limit — a small change is a few sentences"                 | delete it; don't write about the rules                           |
+An example — the difference is not any single sentence, it is what the description is organised around. Not this, organised by file, where each bullet is true and the whole still restates the diff:
+
+> Extends the writing conventions beyond code comments to cover PR/issue descriptions, reviews, and reports.
+>
+> - `RUST_CONVENTIONS.md`: new "Plain Language, No Coined Terms" rule under Comments — applies to all prose; use vocabulary already in the codebase/domain, don't invent-and-reuse labels, self-check before submitting.
+> - `AGENTS.md`: promote "Comment style" to a "Writing style" section covering code comments, PR/issue descriptions (compact, bullet points over prose, still state why), and the plain-language rule.
+> - `REVIEW.md`: review-output guidance now points to the plain-language rule.
+
+This, organised around the problem:
+
+> AI-generated comments and PR/issue text tend to be too long and lean on invented terminology. This extends the writing conventions to push back on that: keep prose concise, use plain language, and stick to terms already used in the project.
+>
+> Applies to code comments (as before) plus PR/issue descriptions, reviews, and reports.
 
 ### Per surface
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,9 @@ A PR description answers what a reviewer cannot get by reading the diff:
 - **Trade-offs and rejected alternatives**, where a real choice was made.
 - **What to look at hardest**, if some part of the change deserves more attention than the rest.
 
-State only reasoning you actually know — from the issue, the task you were given, or the code itself. Do not infer a plausible motivation and present it as the reason: an invented rationale is harder for a reviewer to catch than a verbose description, because it reads exactly like a real one. Where the reason is not recoverable, say what the change does and link the issue instead of filling the gap. The same applies to justifying a dependency or design choice you did not make.
+State only reasoning you actually know — from the issue, the task you were given, or the code itself. Do not infer a plausible motivation and present it as the reason: an invented rationale is harder for a reviewer to catch than a verbose description, because it reads exactly like a real one. Where the reason is not recoverable, say what the change does and link the issue instead of filling the gap.
+
+Knowing a fact about a dependency or an approach is not the same as knowing it was the reason for the choice. That a crate is constant-time or already in the tree may be true and still not be why it was picked — do not write "X was used because Y" unless Y came from the issue or the task. Where a property matters to the reader on its own, state the property, not the motive.
 
 Leave out the mechanics of the diff: per-file walkthroughs, lists of renamed or added symbols, "moved X to Y" inventories, and summaries that restate the code in prose. The reviewer has the diff.
 
@@ -165,8 +167,9 @@ The same rule applies when reporting work back in a session, not just on GitHub:
 
 ### Review comments
 
-- Say what is wrong and why it matters. One point per comment.
-- Don't re-explain the author's own code back to them, and don't restate the same suggestion in several forms.
+- Say what is wrong and why it matters. Open with the problem, not with a summary of what the code does — the author knows what they wrote.
+- One point per comment. If a comment contains "also" or "additionally", it is two comments.
+- Don't restate the same suggestion in several forms, and don't introduce a set of comments with a line announcing that comments follow.
 
 ### Plain language, no coined terms
 


### PR DESCRIPTION
## Why

Asking for "concise" descriptions didn't work — agent output stayed organised as an inventory of the diff, and adjectives in the rules got ignored while checkable rules stuck.

## What changes

Replaces the writing-style section with five content rules plus a default per-section sentence budget, and adds a PR template so the rules are present when the description is written.

## Test plan

Subagents wrote descriptions, reviews and reports for merged PRs from this repo over several rounds; each rule fixed a failure observed in that output. `dprint fmt` not run (unavailable in the sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GhpErczNatMYNiMKmJ8uR