### PR TITLE
chore(move-types): bump pinned monorepo rev

### DIFF
--- a/crates/iota-sdk-move-types/Cargo.toml
+++ b/crates/iota-sdk-move-types/Cargo.toml
@@ -44,7 +44,7 @@ iota-bcs-schema = { workspace = true, features = ["move-shape"] }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 # `update_compiled_packages.sh` reads this rev via `cargo metadata` so the
 # parser matches the fetched blobs.
-move-binary-format = { git = "https://github.com/iotaledger/iota.git", rev = "2e0ad64996fc65d9eec2aa64732a09609f76c7cb" }
+move-binary-format = { git = "https://github.com/iotaledger/iota.git", rev = "4bbd71629225a04946ec6ff9a80080ecb6960641" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test.workspace = true


### PR DESCRIPTION
The nightly `drift-check` job is failing: the pinned monorepo rev (`2e0ad64`) is behind `iotaledger/iota@develop`, so the two `published_api.txt` manifests no longer match.

- Bumps the `move-binary-format` pin — the single source of truth for the rev — to `4bbd716`.
- No Rust mirrors needed changes: the only drift was `TimelockedStakedIota` shifting position in the manifest (upstream c37cbad dropped the timelocked delegation logic from the genesis builder), with no type added, removed, or reshaped. The drift check is a plain textual diff, so a pure reorder trips it too.

Test plan: `make update-compiled-packages` + `cargo test -p iota-sdk-move-types --all-features` — green, including `move_shape_compare::shapes_match` and `registry_matches_published_api`, which re-parse the bytecode at the new rev and check every mirror field-by-field.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfHRUSQqWakFGfSjrhCRTR)_