### PR TITLE
fix(examples): avoid type-only object queries that time out

### DIFF
--- a/bindings/csharp/examples/DecodeStakedIota/Program.cs
+++ b/bindings/csharp/examples/DecodeStakedIota/Program.cs
@@ -15,29 +15,16 @@ class Program
     {
         var client = GraphQlClient.NewTestnet();
 
-        // Filtering objects by type alone scans every object on the network, which
-        // the GraphQL server rejects with a timeout. Pick a recent staker and filter
-        // by owner as well, so only that address' objects are looked at.
-        var stakers = await client.Transactions(
-            new TransactionsFilter(Function: "0x3::iota_system::request_add_stake"),
-            new PaginationFilter(Direction.Backward, Limit: 1));
-
-        if (stakers.Data.Length == 0)
-        {
-            Console.WriteLine("No staking transactions on testnet right now.");
-            return;
-        }
-
-        var staker = stakers.Data[^1].Transaction.Sender();
-        Console.WriteLine($"Latest staker: {staker.ToHex()}\n");
-
-        var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota", Owner: staker);
+        // Filtering by type alone scans every object on the network, which the
+        // GraphQL server rejects with a timeout, so filter by owner as well.
+        var owner = Address.FromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151");
+        var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota", Owner: owner);
 
         var page = await client.Objects(filter);
 
         if (page.Data.Length == 0)
         {
-            Console.WriteLine($"No StakedIota objects owned by {staker.ToHex()} right now.");
+            Console.WriteLine($"No StakedIota objects owned by {owner.ToHex()} right now.");
             return;
         }
 

--- a/bindings/csharp/examples/DecodeStakedIota/Program.cs
+++ b/bindings/csharp/examples/DecodeStakedIota/Program.cs
@@ -15,8 +15,6 @@ class Program
     {
         var client = GraphQlClient.NewTestnet();
 
-        // Filtering by type alone scans every object on the network, which the
-        // GraphQL server rejects with a timeout, so filter by owner as well.
         var owner = Address.FromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151");
         var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota", Owner: owner);
 

--- a/bindings/csharp/examples/DecodeStakedIota/Program.cs
+++ b/bindings/csharp/examples/DecodeStakedIota/Program.cs
@@ -14,13 +14,30 @@ class Program
     static async Task Main(string[] args)
     {
         var client = GraphQlClient.NewTestnet();
-        var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota");
+
+        // Filtering objects by type alone scans every object on the network, which
+        // the GraphQL server rejects with a timeout. Pick a recent staker and filter
+        // by owner as well, so only that address' objects are looked at.
+        var stakers = await client.Transactions(
+            new TransactionsFilter(Function: "0x3::iota_system::request_add_stake"),
+            new PaginationFilter(Direction.Backward, Limit: 1));
+
+        if (stakers.Data.Length == 0)
+        {
+            Console.WriteLine("No staking transactions on testnet right now.");
+            return;
+        }
+
+        var staker = stakers.Data[^1].Transaction.Sender();
+        Console.WriteLine($"Latest staker: {staker.ToHex()}\n");
+
+        var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota", Owner: staker);
 
         var page = await client.Objects(filter);
 
         if (page.Data.Length == 0)
         {
-            Console.WriteLine("No StakedIota objects on testnet right now.");
+            Console.WriteLine($"No StakedIota objects owned by {staker.ToHex()} right now.");
             return;
         }
 

--- a/bindings/csharp/examples/ObjectsByType/Program.cs
+++ b/bindings/csharp/examples/ObjectsByType/Program.cs
@@ -8,20 +8,20 @@ class Program
     static async Task Main(string[] args)
     {
         var client = GraphQlClient.NewTestnet();
-        var filter = new ObjectFilter(TypeTag: "0x3::staking_pool::StakedIota");
+        var filter = new ObjectFilter(TypeTag: "0x2::coin::Coin<0x2::iota::IOTA>");
 
-        var stakedIotas = await client.Objects(filter);
+        var coins = await client.Objects(filter);
 
-        if (stakedIotas.Data.Length == 0)
+        if (coins.Data.Length == 0)
         {
-            Console.WriteLine("No StakedIota objects found");
+            Console.WriteLine("No IOTA coin objects found");
         }
         else
         {
-            Console.WriteLine("StakedIota object IDs:");
-            foreach (var stakedIota in stakedIotas.Data)
+            Console.WriteLine("IOTA coin object IDs:");
+            foreach (var coin in coins.Data)
             {
-                Console.WriteLine(stakedIota.Id().ToHex());
+                Console.WriteLine(coin.Id().ToHex());
             }
         }
     }

--- a/bindings/csharp/examples/Unstake/Program.cs
+++ b/bindings/csharp/examples/Unstake/Program.cs
@@ -9,7 +9,11 @@ class Program
     {
         var client = GraphQlClient.NewTestnet();
 
-        var stakedIotas = await client.Objects(new ObjectFilter(TypeTag: StructTag.NewStakedIota().ToString()));
+        // Filtering by type alone scans every object on the network, which the
+        // GraphQL server rejects with a timeout, so filter by owner as well.
+        var owner = Address.FromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151");
+
+        var stakedIotas = await client.Objects(new ObjectFilter(TypeTag: StructTag.NewStakedIota().ToString(), Owner: owner));
         if (stakedIotas.Data.Length == 0)
         {
             throw new Exception("no staked iotas found");

--- a/bindings/csharp/examples/Unstake/Program.cs
+++ b/bindings/csharp/examples/Unstake/Program.cs
@@ -9,8 +9,6 @@ class Program
     {
         var client = GraphQlClient.NewTestnet();
 
-        // Filtering by type alone scans every object on the network, which the
-        // GraphQL server rejects with a timeout, so filter by owner as well.
         var owner = Address.FromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151");
 
         var stakedIotas = await client.Objects(new ObjectFilter(TypeTag: StructTag.NewStakedIota().ToString(), Owner: owner));

--- a/bindings/go/examples/decode_staked_iota/main.go
+++ b/bindings/go/examples/decode_staked_iota/main.go
@@ -19,35 +19,21 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
-	// Filtering objects by type alone scans every object on the network, which
-	// the GraphQL server rejects with a timeout. Pick a recent staker and filter
-	// by owner as well, so only that address' objects are looked at.
-	stakeFunction := "0x3::iota_system::request_add_stake"
-	limit := int32(1)
-	stakers, err := client.Transactions(
-		&iota_sdk.TransactionsFilter{Function: &stakeFunction},
-		&iota_sdk.PaginationFilter{Direction: iota_sdk.DirectionBackward, Limit: &limit},
-	)
+	// Filtering by type alone scans every object on the network, which the
+	// GraphQL server rejects with a timeout, so filter by owner as well.
+	owner, err := iota_sdk.AddressFromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 	if err != nil {
-		log.Fatalf("Failed to fetch staking transactions: %v", err)
+		log.Fatalf("Failed to parse address: %v", err)
 	}
-
-	if len(stakers.Data) == 0 {
-		fmt.Println("No staking transactions on testnet right now.")
-		return
-	}
-
-	staker := stakers.Data[len(stakers.Data)-1].Transaction.Sender()
-	fmt.Printf("Latest staker: %s\n\n", staker.ToHex())
 
 	stakedIotaType := "0x3::staking_pool::StakedIota"
-	page, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType, Owner: &staker}, nil)
+	page, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType, Owner: &owner}, nil)
 	if err != nil {
 		log.Fatalf("Failed to fetch StakedIota objects: %v", err)
 	}
 
 	if len(page.Data) == 0 {
-		fmt.Printf("No StakedIota objects owned by %s right now.\n", staker.ToHex())
+		fmt.Printf("No StakedIota objects owned by %s right now.\n", owner.ToHex())
 		return
 	}
 

--- a/bindings/go/examples/decode_staked_iota/main.go
+++ b/bindings/go/examples/decode_staked_iota/main.go
@@ -19,8 +19,6 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
-	// Filtering by type alone scans every object on the network, which the
-	// GraphQL server rejects with a timeout, so filter by owner as well.
 	owner, err := iota_sdk.AddressFromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 	if err != nil {
 		log.Fatalf("Failed to parse address: %v", err)

--- a/bindings/go/examples/decode_staked_iota/main.go
+++ b/bindings/go/examples/decode_staked_iota/main.go
@@ -19,14 +19,35 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
+	// Filtering objects by type alone scans every object on the network, which
+	// the GraphQL server rejects with a timeout. Pick a recent staker and filter
+	// by owner as well, so only that address' objects are looked at.
+	stakeFunction := "0x3::iota_system::request_add_stake"
+	limit := int32(1)
+	stakers, err := client.Transactions(
+		&iota_sdk.TransactionsFilter{Function: &stakeFunction},
+		&iota_sdk.PaginationFilter{Direction: iota_sdk.DirectionBackward, Limit: &limit},
+	)
+	if err != nil {
+		log.Fatalf("Failed to fetch staking transactions: %v", err)
+	}
+
+	if len(stakers.Data) == 0 {
+		fmt.Println("No staking transactions on testnet right now.")
+		return
+	}
+
+	staker := stakers.Data[len(stakers.Data)-1].Transaction.Sender()
+	fmt.Printf("Latest staker: %s\n\n", staker.ToHex())
+
 	stakedIotaType := "0x3::staking_pool::StakedIota"
-	page, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType}, nil)
+	page, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType, Owner: &staker}, nil)
 	if err != nil {
 		log.Fatalf("Failed to fetch StakedIota objects: %v", err)
 	}
 
 	if len(page.Data) == 0 {
-		fmt.Println("No StakedIota objects on testnet right now.")
+		fmt.Printf("No StakedIota objects owned by %s right now.\n", staker.ToHex())
 		return
 	}
 

--- a/bindings/go/examples/objects_by_type/main.go
+++ b/bindings/go/examples/objects_by_type/main.go
@@ -13,18 +13,18 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
-	stakedIotaType := "0x3::staking_pool::StakedIota"
-	stakedIotas, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType}, nil)
+	coinType := "0x2::coin::Coin<0x2::iota::IOTA>"
+	coins, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &coinType}, nil)
 	if err != nil {
 		log.Fatalf("Failed to get staked iota: %v", err)
 	}
 
-	if len(stakedIotas.Data) == 0 {
-		fmt.Println("No StakedIota objects found")
+	if len(coins.Data) == 0 {
+		fmt.Println("No IOTA coin objects found")
 	} else {
-		fmt.Println("StakedIota object IDs:")
-		for _, stakedIota := range stakedIotas.Data {
-			fmt.Printf("%s\n", stakedIota.Id().ToHex())
+		fmt.Println("IOTA coin object IDs:")
+		for _, coin := range coins.Data {
+			fmt.Printf("%s\n", coin.Id().ToHex())
 		}
 	}
 }

--- a/bindings/go/examples/unstake/main.go
+++ b/bindings/go/examples/unstake/main.go
@@ -12,8 +12,6 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
-	// Filtering by type alone scans every object on the network, which the
-	// GraphQL server rejects with a timeout, so filter by owner as well.
 	owner, err := iota_sdk.AddressFromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 	if err != nil {
 		log.Fatalf("Failed to parse address: %v", err)

--- a/bindings/go/examples/unstake/main.go
+++ b/bindings/go/examples/unstake/main.go
@@ -12,8 +12,15 @@ import (
 func main() {
 	client := iota_sdk.GraphQlClientNewTestnet()
 
+	// Filtering by type alone scans every object on the network, which the
+	// GraphQL server rejects with a timeout, so filter by owner as well.
+	owner, err := iota_sdk.AddressFromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
+	if err != nil {
+		log.Fatalf("Failed to parse address: %v", err)
+	}
+
 	stakedIotaType := iota_sdk.StructTagNewStakedIota().String()
-	stakedIotas, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType}, nil)
+	stakedIotas, err := client.Objects(&iota_sdk.ObjectFilter{TypeTag: &stakedIotaType, Owner: &owner}, nil)
 	if err != nil {
 		log.Fatalf("Failed to get staked iota: %v", err)
 	}

--- a/bindings/kotlin/examples/DecodeStakedIota.kt
+++ b/bindings/kotlin/examples/DecodeStakedIota.kt
@@ -7,40 +7,24 @@
 // `StakedIota.tryFromObject(obj)` call gives typed, named-field access to
 // id / poolId / stakeActivationEpoch / principal.
 
-import iota_sdk.Direction
+import iota_sdk.Address
 import iota_sdk.GraphQlClient
 import iota_sdk.ObjectFilter
-import iota_sdk.PaginationFilter
 import iota_sdk.StakedIota
-import iota_sdk.TransactionsFilter
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
-
-        // Filtering objects by type alone scans every object on the network, which the
-        // GraphQL server rejects with a timeout. Pick a recent staker and filter by owner
-        // as well, so only that address' objects are looked at.
-        val stakers =
-            client.transactions(
-                TransactionsFilter(function = "0x3::iota_system::request_add_stake"),
-                PaginationFilter(direction = Direction.BACKWARD, limit = 1),
-            )
-
-        val staker = stakers.data.lastOrNull()?.transaction?.sender()
-        if (staker == null) {
-            println("No staking transactions on testnet right now.")
-            return@runBlocking
-        }
-
-        println("Latest staker: ${staker.toHex()}\n")
-
+        // Filtering by type alone scans every object on the network, which the GraphQL
+        // server rejects with a timeout, so filter by owner as well.
+        val owner =
+            Address.fromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
         val page =
-            client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota", owner = staker))
+            client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota", owner = owner))
 
         if (page.data.isEmpty()) {
-            println("No StakedIota objects owned by ${staker.toHex()} right now.")
+            println("No StakedIota objects owned by ${owner.toHex()} right now.")
             return@runBlocking
         }
 

--- a/bindings/kotlin/examples/DecodeStakedIota.kt
+++ b/bindings/kotlin/examples/DecodeStakedIota.kt
@@ -7,18 +7,42 @@
 // `StakedIota.tryFromObject(obj)` call gives typed, named-field access to
 // id / poolId / stakeActivationEpoch / principal.
 
+import iota_sdk.Direction
 import iota_sdk.GraphQlClient
 import iota_sdk.ObjectFilter
+import iota_sdk.PaginationFilter
 import iota_sdk.StakedIota
+import iota_sdk.TransactionsFilter
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
-        val page = client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota"))
+
+        // Filtering objects by type alone scans every object on the network, which the
+        // GraphQL server rejects with a timeout. Pick a recent staker and filter by owner
+        // as well, so only that address' objects are looked at.
+        val stakers =
+            client.transactions(
+                TransactionsFilter(function = "0x3::iota_system::request_add_stake"),
+                PaginationFilter(direction = Direction.BACKWARD, limit = 1),
+            )
+
+        val staker = stakers.data.lastOrNull()?.transaction?.sender()
+        if (staker == null) {
+            println("No staking transactions on testnet right now.")
+            return@runBlocking
+        }
+
+        println("Latest staker: ${staker.toHex()}\n")
+
+        val page =
+            client.objects(
+                ObjectFilter(typeTag = "0x3::staking_pool::StakedIota", owner = staker)
+            )
 
         if (page.data.isEmpty()) {
-            println("No StakedIota objects on testnet right now.")
+            println("No StakedIota objects owned by ${staker.toHex()} right now.")
             return@runBlocking
         }
 

--- a/bindings/kotlin/examples/DecodeStakedIota.kt
+++ b/bindings/kotlin/examples/DecodeStakedIota.kt
@@ -37,9 +37,7 @@ fun main() = runBlocking {
         println("Latest staker: ${staker.toHex()}\n")
 
         val page =
-            client.objects(
-                ObjectFilter(typeTag = "0x3::staking_pool::StakedIota", owner = staker)
-            )
+            client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota", owner = staker))
 
         if (page.data.isEmpty()) {
             println("No StakedIota objects owned by ${staker.toHex()} right now.")

--- a/bindings/kotlin/examples/DecodeStakedIota.kt
+++ b/bindings/kotlin/examples/DecodeStakedIota.kt
@@ -16,8 +16,6 @@ import kotlinx.coroutines.runBlocking
 fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
-        // Filtering by type alone scans every object on the network, which the GraphQL
-        // server rejects with a timeout, so filter by owner as well.
         val owner =
             Address.fromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
         val page =

--- a/bindings/kotlin/examples/ObjectsByType.kt
+++ b/bindings/kotlin/examples/ObjectsByType.kt
@@ -9,14 +9,14 @@ fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
 
-        val stakedIotas = client.objects(ObjectFilter(typeTag = "0x3::staking_pool::StakedIota"))
+        val coins = client.objects(ObjectFilter(typeTag = "0x2::coin::Coin<0x2::iota::IOTA>"))
 
-        if (stakedIotas.data.isEmpty()) {
-            println("No StakedIota objects found")
+        if (coins.data.isEmpty()) {
+            println("No IOTA coin objects found")
         } else {
-            println("StakedIota object IDs:")
-            for (stakedIota in stakedIotas.data) {
-                println(stakedIota.id().toHex())
+            println("IOTA coin object IDs:")
+            for (coin in coins.data) {
+                println(coin.id().toHex())
             }
         }
     } catch (e: Exception) {

--- a/bindings/kotlin/examples/Unstake.kt
+++ b/bindings/kotlin/examples/Unstake.kt
@@ -8,8 +8,15 @@ fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
 
+        // Filtering by type alone scans every object on the network, which the GraphQL
+        // server rejects with a timeout, so filter by owner as well.
+        val owner =
+            Address.fromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
+
         val stakedIotas =
-            client.objects(ObjectFilter(typeTag = StructTag.newStakedIota().toString()))
+            client.objects(
+                ObjectFilter(typeTag = StructTag.newStakedIota().toString(), owner = owner)
+            )
         if (stakedIotas.data.isEmpty()) {
             throw Exception("no validators found")
         }

--- a/bindings/kotlin/examples/Unstake.kt
+++ b/bindings/kotlin/examples/Unstake.kt
@@ -8,8 +8,6 @@ fun main() = runBlocking {
     try {
         val client = GraphQlClient.newTestnet()
 
-        // Filtering by type alone scans every object on the network, which the GraphQL
-        // server rejects with a timeout, so filter by owner as well.
         val owner =
             Address.fromHex("0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 

--- a/bindings/python/examples/decode_staked_iota.py
+++ b/bindings/python/examples/decode_staked_iota.py
@@ -15,8 +15,6 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
-    # Filtering by type alone scans every object on the network, which the
-    # GraphQL server rejects with a timeout, so filter by owner as well.
     owner = Address.from_hex(
         "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 

--- a/bindings/python/examples/decode_staked_iota.py
+++ b/bindings/python/examples/decode_staked_iota.py
@@ -15,11 +15,27 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
+    # Filtering objects by type alone scans every object on the network, which
+    # the GraphQL server rejects with a timeout. Pick a recent staker and filter
+    # by owner as well, so only that address' objects are looked at.
+    stake_filter = TransactionsFilter(
+        function="0x3::iota_system::request_add_stake")
+    latest = PaginationFilter(direction=Direction.BACKWARD, limit=1)
+    stakers = await client.transactions(filter=stake_filter,
+                                        pagination_filter=latest)
+
+    if len(stakers.data) == 0:
+        print("No staking transactions on testnet right now.")
+        return
+
+    staker = stakers.data[-1].transaction.sender()
+    print(f"Latest staker: {staker.to_hex()}\n")
+
     page = await client.objects(filter=ObjectFilter(
-        type_tag="0x3::staking_pool::StakedIota"))
+        type_tag="0x3::staking_pool::StakedIota", owner=staker))
 
     if len(page.data) == 0:
-        print("No StakedIota objects on testnet right now.")
+        print(f"No StakedIota objects owned by {staker.to_hex()} right now.")
         return
 
     print(f"Decoded {len(page.data)} StakedIota object(s):\n")

--- a/bindings/python/examples/decode_staked_iota.py
+++ b/bindings/python/examples/decode_staked_iota.py
@@ -15,27 +15,16 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
-    # Filtering objects by type alone scans every object on the network, which
-    # the GraphQL server rejects with a timeout. Pick a recent staker and filter
-    # by owner as well, so only that address' objects are looked at.
-    stake_filter = TransactionsFilter(
-        function="0x3::iota_system::request_add_stake")
-    latest = PaginationFilter(direction=Direction.BACKWARD, limit=1)
-    stakers = await client.transactions(filter=stake_filter,
-                                        pagination_filter=latest)
-
-    if len(stakers.data) == 0:
-        print("No staking transactions on testnet right now.")
-        return
-
-    staker = stakers.data[-1].transaction.sender()
-    print(f"Latest staker: {staker.to_hex()}\n")
+    # Filtering by type alone scans every object on the network, which the
+    # GraphQL server rejects with a timeout, so filter by owner as well.
+    owner = Address.from_hex(
+        "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 
     page = await client.objects(filter=ObjectFilter(
-        type_tag="0x3::staking_pool::StakedIota", owner=staker))
+        type_tag="0x3::staking_pool::StakedIota", owner=owner))
 
     if len(page.data) == 0:
-        print(f"No StakedIota objects owned by {staker.to_hex()} right now.")
+        print(f"No StakedIota objects owned by {owner.to_hex()} right now.")
         return
 
     print(f"Decoded {len(page.data)} StakedIota object(s):\n")

--- a/bindings/python/examples/objects_by_type.py
+++ b/bindings/python/examples/objects_by_type.py
@@ -9,15 +9,15 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
-    staked_iotas = await client.objects(filter=ObjectFilter(
-        type_tag="0x3::staking_pool::StakedIota"))
+    coins = await client.objects(filter=ObjectFilter(
+        type_tag="0x2::coin::Coin<0x2::iota::IOTA>"))
 
-    if len(staked_iotas.data) == 0:
-        print("No StakedIota objects found")
+    if len(coins.data) == 0:
+        print("No IOTA coin objects found")
     else:
-        print("StakedIota object IDs:")
-        for staked_iota in staked_iotas.data:
-            print(staked_iota.id().to_hex())
+        print("IOTA coin object IDs:")
+        for coin in coins.data:
+            print(coin.id().to_hex())
 
 
 if __name__ == "__main__":

--- a/bindings/python/examples/unstake.py
+++ b/bindings/python/examples/unstake.py
@@ -9,8 +9,6 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
-    # Filtering by type alone scans every object on the network, which the
-    # GraphQL server rejects with a timeout, so filter by owner as well.
     owner = Address.from_hex(
         "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 

--- a/bindings/python/examples/unstake.py
+++ b/bindings/python/examples/unstake.py
@@ -9,8 +9,13 @@ import asyncio
 async def main():
     client = GraphQlClient.new_testnet()
 
+    # Filtering by type alone scans every object on the network, which the
+    # GraphQL server rejects with a timeout, so filter by owner as well.
+    owner = Address.from_hex(
+        "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
+
     staked_iotas = await client.objects(filter=ObjectFilter(
-        type_tag=str(StructTag.new_staked_iota())))
+        type_tag=str(StructTag.new_staked_iota()), owner=owner))
     if len(staked_iotas.data) == 0:
         raise Exception("no staked iotas found")
     staked_iota = staked_iotas.data[0]

--- a/bindings/swift/examples/DecodeStakedIota.swift
+++ b/bindings/swift/examples/DecodeStakedIota.swift
@@ -13,26 +13,16 @@ import IotaSDK
 struct DecodeStakedIotaExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
-
-    // Filtering objects by type alone scans every object on the network, which
-    // the GraphQL server rejects with a timeout. Pick a recent staker and filter
-    // by owner as well, so only that address' objects are looked at.
-    let stakers = try await client.transactions(
-      filter: TransactionsFilter(function: "0x3::iota_system::request_add_stake"),
-      paginationFilter: PaginationFilter(direction: .backward, limit: 1))
-
-    guard let staker = stakers.data.last?.transaction.sender() else {
-      print("No staking transactions on testnet right now.")
-      return
-    }
-
-    print("Latest staker: \(staker.toHex())\n")
+    // Filtering by type alone scans every object on the network, which the
+    // GraphQL server rejects with a timeout, so filter by owner as well.
+    let owner = try Address.fromHex(
+      hex: "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 
     let page = try await client.objects(
-      filter: ObjectFilter(typeTag: "0x3::staking_pool::StakedIota", owner: staker))
+      filter: ObjectFilter(typeTag: "0x3::staking_pool::StakedIota", owner: owner))
 
     if page.data.isEmpty {
-      print("No StakedIota objects owned by \(staker.toHex()) right now.")
+      print("No StakedIota objects owned by \(owner.toHex()) right now.")
       return
     }
 

--- a/bindings/swift/examples/DecodeStakedIota.swift
+++ b/bindings/swift/examples/DecodeStakedIota.swift
@@ -13,8 +13,6 @@ import IotaSDK
 struct DecodeStakedIotaExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
-    // Filtering by type alone scans every object on the network, which the
-    // GraphQL server rejects with a timeout, so filter by owner as well.
     let owner = try Address.fromHex(
       hex: "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 

--- a/bindings/swift/examples/DecodeStakedIota.swift
+++ b/bindings/swift/examples/DecodeStakedIota.swift
@@ -13,11 +13,26 @@ import IotaSDK
 struct DecodeStakedIotaExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
+
+    // Filtering objects by type alone scans every object on the network, which
+    // the GraphQL server rejects with a timeout. Pick a recent staker and filter
+    // by owner as well, so only that address' objects are looked at.
+    let stakers = try await client.transactions(
+      filter: TransactionsFilter(function: "0x3::iota_system::request_add_stake"),
+      paginationFilter: PaginationFilter(direction: .backward, limit: 1))
+
+    guard let staker = stakers.data.last?.transaction.sender() else {
+      print("No staking transactions on testnet right now.")
+      return
+    }
+
+    print("Latest staker: \(staker.toHex())\n")
+
     let page = try await client.objects(
-      filter: ObjectFilter(typeTag: "0x3::staking_pool::StakedIota"))
+      filter: ObjectFilter(typeTag: "0x3::staking_pool::StakedIota", owner: staker))
 
     if page.data.isEmpty {
-      print("No StakedIota objects on testnet right now.")
+      print("No StakedIota objects owned by \(staker.toHex()) right now.")
       return
     }
 

--- a/bindings/swift/examples/ObjectsByType.swift
+++ b/bindings/swift/examples/ObjectsByType.swift
@@ -8,15 +8,15 @@ struct ObjectsByTypeExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
 
-    let stakedIotas = try await client.objects(
-      filter: ObjectFilter(typeTag: "0x3::staking_pool::StakedIota"))
+    let coins = try await client.objects(
+      filter: ObjectFilter(typeTag: "0x2::coin::Coin<0x2::iota::IOTA>"))
 
-    if stakedIotas.data.isEmpty {
-      print("No StakedIota objects found")
+    if coins.data.isEmpty {
+      print("No IOTA coin objects found")
     } else {
-      print("StakedIota object IDs:")
-      for stakedIota in stakedIotas.data {
-        print(stakedIota.id().toHex())
+      print("IOTA coin object IDs:")
+      for coin in coins.data {
+        print(coin.id().toHex())
       }
     }
   }

--- a/bindings/swift/examples/Unstake.swift
+++ b/bindings/swift/examples/Unstake.swift
@@ -9,8 +9,14 @@ struct UnstakeExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
 
+    // Filtering by type alone scans every object on the network, which the
+    // GraphQL server rejects with a timeout, so filter by owner as well.
+    let owner = try Address.fromHex(
+      hex: "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
+
     let stakedIotas = try await client.objects(
-      filter: ObjectFilter(typeTag: String(describing: StructTag.newStakedIota())))
+      filter: ObjectFilter(
+        typeTag: String(describing: StructTag.newStakedIota()), owner: owner))
     if stakedIotas.data.isEmpty {
       throw NSError(
         domain: "Unstake", code: 1,

--- a/bindings/swift/examples/Unstake.swift
+++ b/bindings/swift/examples/Unstake.swift
@@ -9,8 +9,6 @@ struct UnstakeExample {
   static func main() async throws {
     let client = GraphQlClient.newTestnet()
 
-    // Filtering by type alone scans every object on the network, which the
-    // GraphQL server rejects with a timeout, so filter by owner as well.
     let owner = try Address.fromHex(
       hex: "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151")
 

--- a/bindings/wasm/examples/decode_staked_iota.mjs
+++ b/bindings/wasm/examples/decode_staked_iota.mjs
@@ -8,9 +8,12 @@
 // id / poolId / stakeActivationEpoch / principal.
 
 import {
+  Direction,
   GraphQlClient,
   ObjectFilter,
+  PaginationFilter,
   StakedIota,
+  TransactionsFilter,
   initAsync,
 } from "@iota/sdk-wasm";
 
@@ -18,24 +21,42 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
-const page = await client.objects(
-  ObjectFilter.new({ typeTag: "0x3::staking_pool::StakedIota" }),
+// Filtering objects by type alone scans every object on the network, which the
+// GraphQL server rejects with a timeout. Pick a recent staker and filter by
+// owner as well, so only that address' objects are looked at.
+const stakers = await client.transactions(
+  TransactionsFilter.new({ function: "0x3::iota_system::request_add_stake" }),
+  PaginationFilter.new({ direction: Direction.Backward, limit: 1 }),
 );
+const staker = stakers.data.at(-1)?.transaction.sender();
 
-if (page.data.length === 0) {
-  console.log("No StakedIota objects on testnet right now.");
+if (staker === undefined) {
+  console.log("No staking transactions on testnet right now.");
 } else {
-  console.log(`Decoded ${page.data.length} StakedIota object(s):\n`);
-  let totalPrincipal = 0n;
-  for (const obj of page.data) {
-    const staked = StakedIota.tryFromObject(obj);
-    totalPrincipal += staked.principal();
-    console.log(`- id:               ${staked.id().toHex()}`);
-    console.log(`  pool_id:          ${staked.poolId().toHex()}`);
-    console.log(`  stake_activation_epoch: ${staked.stakeActivationEpoch()}`);
-    console.log(`  principal (nanos): ${staked.principal()}`);
-    console.log();
-  }
+  console.log(`Latest staker: ${staker.toHex()}\n`);
 
-  console.log(`Total principal across page: ${totalPrincipal} nanos`);
+  const page = await client.objects(
+    ObjectFilter.new({
+      typeTag: "0x3::staking_pool::StakedIota",
+      owner: staker,
+    }),
+  );
+
+  if (page.data.length === 0) {
+    console.log(`No StakedIota objects owned by ${staker.toHex()} right now.`);
+  } else {
+    console.log(`Decoded ${page.data.length} StakedIota object(s):\n`);
+    let totalPrincipal = 0n;
+    for (const obj of page.data) {
+      const staked = StakedIota.tryFromObject(obj);
+      totalPrincipal += staked.principal();
+      console.log(`- id:               ${staked.id().toHex()}`);
+      console.log(`  pool_id:          ${staked.poolId().toHex()}`);
+      console.log(`  stake_activation_epoch: ${staked.stakeActivationEpoch()}`);
+      console.log(`  principal (nanos): ${staked.principal()}`);
+      console.log();
+    }
+
+    console.log(`Total principal across page: ${totalPrincipal} nanos`);
+  }
 }

--- a/bindings/wasm/examples/decode_staked_iota.mjs
+++ b/bindings/wasm/examples/decode_staked_iota.mjs
@@ -8,12 +8,10 @@
 // id / poolId / stakeActivationEpoch / principal.
 
 import {
-  Direction,
+  Address,
   GraphQlClient,
   ObjectFilter,
-  PaginationFilter,
   StakedIota,
-  TransactionsFilter,
   initAsync,
 } from "@iota/sdk-wasm";
 
@@ -21,42 +19,30 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
-// Filtering objects by type alone scans every object on the network, which the
-// GraphQL server rejects with a timeout. Pick a recent staker and filter by
-// owner as well, so only that address' objects are looked at.
-const stakers = await client.transactions(
-  TransactionsFilter.new({ function: "0x3::iota_system::request_add_stake" }),
-  PaginationFilter.new({ direction: Direction.Backward, limit: 1 }),
+// Filtering by type alone scans every object on the network, which the GraphQL
+// server rejects with a timeout, so filter by owner as well.
+const owner = Address.fromHex(
+  "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151",
 );
-const staker = stakers.data.at(-1)?.transaction.sender();
 
-if (staker === undefined) {
-  console.log("No staking transactions on testnet right now.");
+const page = await client.objects(
+  ObjectFilter.new({ typeTag: "0x3::staking_pool::StakedIota", owner }),
+);
+
+if (page.data.length === 0) {
+  console.log(`No StakedIota objects owned by ${owner.toHex()} right now.`);
 } else {
-  console.log(`Latest staker: ${staker.toHex()}\n`);
-
-  const page = await client.objects(
-    ObjectFilter.new({
-      typeTag: "0x3::staking_pool::StakedIota",
-      owner: staker,
-    }),
-  );
-
-  if (page.data.length === 0) {
-    console.log(`No StakedIota objects owned by ${staker.toHex()} right now.`);
-  } else {
-    console.log(`Decoded ${page.data.length} StakedIota object(s):\n`);
-    let totalPrincipal = 0n;
-    for (const obj of page.data) {
-      const staked = StakedIota.tryFromObject(obj);
-      totalPrincipal += staked.principal();
-      console.log(`- id:               ${staked.id().toHex()}`);
-      console.log(`  pool_id:          ${staked.poolId().toHex()}`);
-      console.log(`  stake_activation_epoch: ${staked.stakeActivationEpoch()}`);
-      console.log(`  principal (nanos): ${staked.principal()}`);
-      console.log();
-    }
-
-    console.log(`Total principal across page: ${totalPrincipal} nanos`);
+  console.log(`Decoded ${page.data.length} StakedIota object(s):\n`);
+  let totalPrincipal = 0n;
+  for (const obj of page.data) {
+    const staked = StakedIota.tryFromObject(obj);
+    totalPrincipal += staked.principal();
+    console.log(`- id:               ${staked.id().toHex()}`);
+    console.log(`  pool_id:          ${staked.poolId().toHex()}`);
+    console.log(`  stake_activation_epoch: ${staked.stakeActivationEpoch()}`);
+    console.log(`  principal (nanos): ${staked.principal()}`);
+    console.log();
   }
+
+  console.log(`Total principal across page: ${totalPrincipal} nanos`);
 }

--- a/bindings/wasm/examples/decode_staked_iota.mjs
+++ b/bindings/wasm/examples/decode_staked_iota.mjs
@@ -19,8 +19,6 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
-// Filtering by type alone scans every object on the network, which the GraphQL
-// server rejects with a timeout, so filter by owner as well.
 const owner = Address.fromHex(
   "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151",
 );

--- a/bindings/wasm/examples/objects_by_type.mjs
+++ b/bindings/wasm/examples/objects_by_type.mjs
@@ -7,15 +7,15 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
-const stakedIotas = await client.objects(
-  ObjectFilter.new({ typeTag: "0x3::staking_pool::StakedIota" }),
+const coins = await client.objects(
+  ObjectFilter.new({ typeTag: "0x2::coin::Coin<0x2::iota::IOTA>" }),
 );
 
-if (stakedIotas.data.length === 0) {
-  console.log("No StakedIota objects found");
+if (coins.data.length === 0) {
+  console.log("No IOTA coin objects found");
 } else {
-  console.log("StakedIota object IDs:");
-  for (const stakedIota of stakedIotas.data) {
-    console.log(stakedIota.id().toHex());
+  console.log("IOTA coin object IDs:");
+  for (const coin of coins.data) {
+    console.log(coin.id().toHex());
   }
 }

--- a/bindings/wasm/examples/unstake.mjs
+++ b/bindings/wasm/examples/unstake.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  Address,
   GraphQlClient,
   ObjectFilter,
   PtbArgument,
@@ -14,8 +15,14 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
+// Filtering by type alone scans every object on the network, which the GraphQL
+// server rejects with a timeout, so filter by owner as well.
+const owner = Address.fromHex(
+  "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151",
+);
+
 const stakedIotas = await client.objects(
-  ObjectFilter.new({ typeTag: String(StructTag.newStakedIota()) }),
+  ObjectFilter.new({ typeTag: String(StructTag.newStakedIota()), owner }),
 );
 if (stakedIotas.data.length === 0) {
   throw new Error("no staked iotas found");

--- a/bindings/wasm/examples/unstake.mjs
+++ b/bindings/wasm/examples/unstake.mjs
@@ -15,8 +15,6 @@ await initAsync();
 
 const client = GraphQlClient.newTestnet();
 
-// Filtering by type alone scans every object on the network, which the GraphQL
-// server rejects with a timeout, so filter by owner as well.
 const owner = Address.fromHex(
   "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151",
 );

--- a/crates/iota-sdk/examples/decode_staked_iota.rs
+++ b/crates/iota-sdk/examples/decode_staked_iota.rs
@@ -24,7 +24,11 @@
 
 use eyre::Result;
 use iota_sdk::{
-    graphql_client::{Client, query_types::ObjectFilter},
+    graphql_client::{
+        Client,
+        pagination::{Direction, PaginationFilter},
+        query_types::{ObjectFilter, TransactionsFilter},
+    },
     move_types::iota_system::staking_pool::StakedIota,
 };
 
@@ -32,10 +36,39 @@ use iota_sdk::{
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
+    // Filtering objects by type alone scans every object on the network, which
+    // the GraphQL server rejects with a timeout. Pick a recent staker and
+    // filter by owner as well, so only that address' objects are looked at.
+    let stakers = client
+        .transactions(
+            TransactionsFilter {
+                function: Some("0x3::iota_system::request_add_stake".to_owned()),
+                ..Default::default()
+            },
+            PaginationFilter {
+                direction: Direction::Backward,
+                limit: Some(1),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    let Some(staker) = stakers
+        .data()
+        .last()
+        .map(|tx| tx.transaction.as_v1().sender)
+    else {
+        println!("No staking transactions on testnet right now.");
+        return Ok(());
+    };
+
+    println!("Latest staker: {staker}\n");
+
     let page = client
         .objects(
             ObjectFilter {
                 type_: Some("0x3::staking_pool::StakedIota".to_owned()),
+                owner: Some(staker),
                 ..Default::default()
             },
             Default::default(),
@@ -43,7 +76,7 @@ async fn main() -> Result<()> {
         .await?;
 
     if page.data().is_empty() {
-        println!("No StakedIota objects on testnet right now.");
+        println!("No StakedIota objects owned by {staker} right now.");
         return Ok(());
     }
 

--- a/crates/iota-sdk/examples/decode_staked_iota.rs
+++ b/crates/iota-sdk/examples/decode_staked_iota.rs
@@ -33,8 +33,6 @@ use iota_sdk::{
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
-    // Filtering by type alone scans every object on the network, which the
-    // GraphQL server rejects with a timeout, so filter by owner as well.
     let owner: Address =
         "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151".parse()?;
 

--- a/crates/iota-sdk/examples/decode_staked_iota.rs
+++ b/crates/iota-sdk/examples/decode_staked_iota.rs
@@ -24,51 +24,25 @@
 
 use eyre::Result;
 use iota_sdk::{
-    graphql_client::{
-        Client,
-        pagination::{Direction, PaginationFilter},
-        query_types::{ObjectFilter, TransactionsFilter},
-    },
+    graphql_client::{Client, query_types::ObjectFilter},
     move_types::iota_system::staking_pool::StakedIota,
+    types::Address,
 };
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
-    // Filtering objects by type alone scans every object on the network, which
-    // the GraphQL server rejects with a timeout. Pick a recent staker and
-    // filter by owner as well, so only that address' objects are looked at.
-    let stakers = client
-        .transactions(
-            TransactionsFilter {
-                function: Some("0x3::iota_system::request_add_stake".to_owned()),
-                ..Default::default()
-            },
-            PaginationFilter {
-                direction: Direction::Backward,
-                limit: Some(1),
-                ..Default::default()
-            },
-        )
-        .await?;
-
-    let Some(staker) = stakers
-        .data()
-        .last()
-        .map(|tx| tx.transaction.as_v1().sender)
-    else {
-        println!("No staking transactions on testnet right now.");
-        return Ok(());
-    };
-
-    println!("Latest staker: {staker}\n");
+    // Filtering by type alone scans every object on the network, which the
+    // GraphQL server rejects with a timeout, so filter by owner as well.
+    let owner: Address =
+        "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151".parse()?;
 
     let page = client
         .objects(
             ObjectFilter {
                 type_: Some("0x3::staking_pool::StakedIota".to_owned()),
-                owner: Some(staker),
+                owner: Some(owner),
                 ..Default::default()
             },
             Default::default(),
@@ -76,7 +50,7 @@ async fn main() -> Result<()> {
         .await?;
 
     if page.data().is_empty() {
-        println!("No StakedIota objects owned by {staker} right now.");
+        println!("No StakedIota objects owned by {owner} right now.");
         return Ok(());
     }
 

--- a/crates/iota-sdk/examples/objects_by_type.rs
+++ b/crates/iota-sdk/examples/objects_by_type.rs
@@ -7,22 +7,22 @@ use iota_sdk::graphql_client::{Client, error::Result, query_types::ObjectFilter}
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
-    let staked_iotas = client
+    let coins = client
         .objects(
             ObjectFilter {
-                type_: "0x3::staking_pool::StakedIota".to_owned().into(),
+                type_: "0x2::coin::Coin<0x2::iota::IOTA>".to_owned().into(),
                 ..Default::default()
             },
             Default::default(),
         )
         .await?;
 
-    if staked_iotas.data.is_empty() {
-        println!("No StakedIota objects found");
+    if coins.data.is_empty() {
+        println!("No IOTA coin objects found");
     } else {
-        println!("StakedIota object IDs:");
-        for staked_iota in staked_iotas.data {
-            println!("{}", staked_iota.id());
+        println!("IOTA coin object IDs:");
+        for coin in coins.data {
+            println!("{}", coin.id());
         }
     }
 

--- a/crates/iota-sdk/examples/unstake.rs
+++ b/crates/iota-sdk/examples/unstake.rs
@@ -5,17 +5,23 @@ use eyre::{OptionExt, Result};
 use iota_sdk::{
     graphql_client::{Client, query_types::ObjectFilter},
     transaction_builder::TransactionBuilder,
-    types::StructTag,
+    types::{Address, StructTag},
 };
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
+    // Filtering by type alone scans every object on the network, which the
+    // GraphQL server rejects with a timeout, so filter by owner as well.
+    let owner: Address =
+        "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151".parse()?;
+
     let staked_iota = client
         .objects(
             ObjectFilter {
                 type_: Some(StructTag::new_staked_iota().to_string()),
+                owner: Some(owner),
                 ..Default::default()
             },
             Default::default(),

--- a/crates/iota-sdk/examples/unstake.rs
+++ b/crates/iota-sdk/examples/unstake.rs
@@ -12,8 +12,6 @@ use iota_sdk::{
 async fn main() -> Result<()> {
     let client = Client::new_testnet();
 
-    // Filtering by type alone scans every object on the network, which the
-    // GraphQL server rejects with a timeout, so filter by owner as well.
     let owner: Address =
         "0xda1820edf693ee32b5729907b9b2ec8e64980ee8c008c17e89cfb4e5ecd72151".parse()?;
 


### PR DESCRIPTION
Three examples filtered objects by type alone. Testnet holds too many `StakedIota` objects for that, so the GraphQL server answers with `Query request timed out. Limit: 8s` and the examples jobs fail. Reported upstream as iotaledger/iota#12536.

- `decode_staked_iota` and `unstake`: also filter by owner, using the address the other examples already use — it owns a `StakedIota`.
- `objects_by_type`: query IOTA coins instead, so a type-only filter stays the point of the example without hitting the timeout.

All three changed in every language: Rust, Go, Kotlin, Python, C#, Swift, WASM.

Verified locally against testnet — the Rust and Python variants of all three return in about a second.

[run-ci]
