### PR TITLE
refactor(transaction-builder): name the split client traits after read and write

### DIFF
--- a/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
+++ b/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
@@ -4,7 +4,7 @@
 use iota_sdk::{
     graphql_client::{Client, DryRunResult, WaitForTx},
     transaction_builder::{
-        ObjectsPage, ProtocolConfig, TransactionBuilderClient, TransactionBuilderResolveClient,
+        ObjectsPage, ProtocolConfig, TransactionBuilderRead, TransactionBuilderWrite,
     },
     types::{
         Address, Object, ObjectId, StructTag, Transaction, TransactionDigest, TransactionEffects,
@@ -14,15 +14,15 @@ use iota_sdk::{
 
 use crate::graphql::client::GraphQLClient;
 
-impl TransactionBuilderResolveClient for GraphQLClient {
-    type Error = <Client as TransactionBuilderResolveClient>::Error;
+impl TransactionBuilderRead for GraphQLClient {
+    type Error = <Client as TransactionBuilderRead>::Error;
 
     async fn object(
         &self,
         object_id: ObjectId,
         version: impl Into<Option<Version>>,
     ) -> Result<Option<Object>, Self::Error> {
-        TransactionBuilderResolveClient::object(&*self.0.read().await, object_id, version).await
+        TransactionBuilderRead::object(&*self.0.read().await, object_id, version).await
     }
 
     async fn objects(
@@ -32,55 +32,49 @@ impl TransactionBuilderResolveClient for GraphQLClient {
         cursor: Option<Vec<u8>>,
         limit: Option<usize>,
     ) -> Result<ObjectsPage, Self::Error> {
-        TransactionBuilderResolveClient::objects(
-            &*self.0.read().await,
-            struct_tag,
-            owner,
-            cursor,
-            limit,
-        )
-        .await
+        TransactionBuilderRead::objects(&*self.0.read().await, struct_tag, owner, cursor, limit)
+            .await
     }
-
-    async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
-        TransactionBuilderResolveClient::protocol_config(&*self.0.read().await).await
-    }
-
-    async fn reference_gas_price(
-        &self,
-        epoch: impl Into<Option<u64>>,
-    ) -> Result<Option<u64>, Self::Error> {
-        TransactionBuilderResolveClient::reference_gas_price(&*self.0.read().await, epoch).await
-    }
-
-    async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-        TransactionBuilderResolveClient::estimate_tx_budget(&*self.0.read().await, tx).await
-    }
-}
-
-impl TransactionBuilderClient for GraphQLClient {
-    type DryRunResult = DryRunResult;
 
     async fn transaction(
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<iota_sdk::types::SignedTransaction>, Self::Error> {
-        TransactionBuilderClient::transaction(&*self.0.read().await, digest).await
+        TransactionBuilderRead::transaction(&*self.0.read().await, digest).await
     }
 
     async fn transaction_effects(
         &self,
         digest: TransactionDigest,
     ) -> Result<Option<TransactionEffects>, Self::Error> {
-        TransactionBuilderClient::transaction_effects(&*self.0.read().await, digest).await
+        TransactionBuilderRead::transaction_effects(&*self.0.read().await, digest).await
     }
+
+    async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
+        TransactionBuilderRead::protocol_config(&*self.0.read().await).await
+    }
+
+    async fn reference_gas_price(
+        &self,
+        epoch: impl Into<Option<u64>>,
+    ) -> Result<Option<u64>, Self::Error> {
+        TransactionBuilderRead::reference_gas_price(&*self.0.read().await, epoch).await
+    }
+
+    async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
+        TransactionBuilderRead::estimate_tx_budget(&*self.0.read().await, tx).await
+    }
+}
+
+impl TransactionBuilderWrite for GraphQLClient {
+    type DryRunResult = DryRunResult;
 
     async fn dry_run_tx(
         &self,
         tx: &Transaction,
         skip_checks: bool,
     ) -> Result<Self::DryRunResult, Self::Error> {
-        TransactionBuilderClient::dry_run_tx(&*self.0.read().await, tx, skip_checks).await
+        TransactionBuilderWrite::dry_run_tx(&*self.0.read().await, tx, skip_checks).await
     }
 
     async fn execute_tx(
@@ -89,7 +83,7 @@ impl TransactionBuilderClient for GraphQLClient {
         tx: &Transaction,
         wait_for: impl Into<Option<WaitForTx>>,
     ) -> Result<TransactionEffects, Self::Error> {
-        TransactionBuilderClient::execute_tx(&*self.0.read().await, signatures, tx, wait_for).await
+        TransactionBuilderWrite::execute_tx(&*self.0.read().await, signatures, tx, wait_for).await
     }
 
     async fn wait_for_tx(
@@ -97,6 +91,6 @@ impl TransactionBuilderClient for GraphQLClient {
         digest: TransactionDigest,
         wait_for: WaitForTx,
     ) -> Result<(), Self::Error> {
-        TransactionBuilderClient::wait_for_tx(&*self.0.read().await, digest, wait_for).await
+        TransactionBuilderWrite::wait_for_tx(&*self.0.read().await, digest, wait_for).await
     }
 }

--- a/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
+++ b/crates/iota-sdk-ffi/src/graphql/transaction_builder_client.rs
@@ -36,13 +36,6 @@ impl TransactionBuilderRead for GraphQLClient {
             .await
     }
 
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<iota_sdk::types::SignedTransaction>, Self::Error> {
-        TransactionBuilderRead::transaction(&*self.0.read().await, digest).await
-    }
-
     async fn transaction_effects(
         &self,
         digest: TransactionDigest,

--- a/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
@@ -1,12 +1,11 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of [`TransactionBuilderResolveClient`] and
-//! [`TransactionBuilderClient`] for the GraphQL [`Client`].
+//! Implementation of [`TransactionBuilderRead`] and
+//! [`TransactionBuilderWrite`] for the GraphQL [`Client`].
 
 use iota_transaction_builder::{
-    ObjectsPage, ProtocolConfig, TransactionBuilderClient, TransactionBuilderResolveClient,
-    WaitForTx,
+    ObjectsPage, ProtocolConfig, TransactionBuilderRead, TransactionBuilderWrite, WaitForTx,
 };
 use iota_types::{
     Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
@@ -19,7 +18,7 @@ use crate::{
     query_types::ObjectFilter,
 };
 
-impl TransactionBuilderResolveClient for Client {
+impl TransactionBuilderRead for Client {
     type Error = crate::error::Error;
 
     async fn object(
@@ -68,6 +67,20 @@ impl TransactionBuilderResolveClient for Client {
         Ok(ObjectsPage { data, next_cursor })
     }
 
+    async fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<SignedTransaction>, Self::Error> {
+        self.transaction(digest).await
+    }
+
+    async fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<TransactionEffects>, Self::Error> {
+        self.transaction_effects(digest).await
+    }
+
     async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
         let cfg = crate::Client::protocol_config(self, None).await?;
         let attributes = cfg
@@ -96,22 +109,8 @@ impl TransactionBuilderResolveClient for Client {
     }
 }
 
-impl TransactionBuilderClient for Client {
+impl TransactionBuilderWrite for Client {
     type DryRunResult = DryRunResult;
-
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<SignedTransaction>, Self::Error> {
-        self.transaction(digest).await
-    }
-
-    async fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<TransactionEffects>, Self::Error> {
-        self.transaction_effects(digest).await
-    }
 
     async fn dry_run_tx(
         &self,

--- a/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-graphql-client/src/transaction_builder_client.rs
@@ -8,8 +8,8 @@ use iota_transaction_builder::{
     ObjectsPage, ProtocolConfig, TransactionBuilderRead, TransactionBuilderWrite, WaitForTx,
 };
 use iota_types::{
-    Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
-    TransactionEffects, UserSignature, Version,
+    Address, Object, ObjectId, StructTag, Transaction, TransactionDigest, TransactionEffects,
+    UserSignature, Version,
 };
 
 use crate::{
@@ -65,13 +65,6 @@ impl TransactionBuilderRead for Client {
             .flatten()
             .map(String::into_bytes);
         Ok(ObjectsPage { data, next_cursor })
-    }
-
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<SignedTransaction>, Self::Error> {
-        self.transaction(digest).await
     }
 
     async fn transaction_effects(

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -20,8 +20,7 @@ use iota_types::{
 use crate::{
     Client,
     api::{
-        EXECUTED_TRANSACTION_CHECKPOINT, EXECUTED_TRANSACTION_SIGNATURES,
-        EXECUTED_TRANSACTION_TRANSACTION, Error, MetadataEnvelope, ReadMask, TRANSACTION_DIGEST,
+        EXECUTED_TRANSACTION_CHECKPOINT, Error, MetadataEnvelope, ReadMask, TRANSACTION_DIGEST,
         TRANSACTION_EFFECTS_BCS, check_result_count, saturating_usize_to_u32,
     },
 };
@@ -118,33 +117,6 @@ impl TransactionBuilderRead for Client {
             .collect::<Result<Vec<_>, _>>()?;
         let next_cursor = page.next_page_token.map(|token| token.to_vec());
         Ok(ObjectsPage { data, next_cursor })
-    }
-
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<SignedTransaction>, Self::Error> {
-        let response = self
-            .get_transactions(
-                &[digest],
-                Some(ReadMask::from(&[
-                    EXECUTED_TRANSACTION_TRANSACTION,
-                    EXECUTED_TRANSACTION_SIGNATURES,
-                ])),
-            )
-            .await;
-
-        match single_item(response)? {
-            Some(tx) => {
-                let transaction = tx.transaction()?.transaction()?;
-                let signatures = Vec::<UserSignature>::try_from(tx.signatures()?)?;
-                Ok(Some(SignedTransaction {
-                    transaction,
-                    signatures,
-                }))
-            }
-            None => Ok(None),
-        }
     }
 
     async fn transaction_effects(

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-//! Implementation of [`TransactionBuilderResolveClient`] and
-//! [`TransactionBuilderClient`] for the GRPC [`Client`].
+//! Implementation of [`TransactionBuilderRead`] and
+//! [`TransactionBuilderWrite`] for the GRPC [`Client`].
 
 use std::time::Duration;
 
@@ -10,8 +10,7 @@ use iota_grpc_types::{
     read_mask_fields::EpochField, v1::transaction_execution_service::SimulatedTransaction,
 };
 use iota_transaction_builder::{
-    ObjectsPage, ProtocolConfig, TransactionBuilderClient, TransactionBuilderResolveClient,
-    WaitForTx,
+    ObjectsPage, ProtocolConfig, TransactionBuilderRead, TransactionBuilderWrite, WaitForTx,
 };
 use iota_types::{
     Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
@@ -27,9 +26,9 @@ use crate::{
     },
 };
 
-/// How long [`TransactionBuilderClient::wait_for_tx`] polls before giving up.
+/// How long [`TransactionBuilderWrite::wait_for_tx`] polls before giving up.
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
-/// Interval between polls in [`TransactionBuilderClient::wait_for_tx`].
+/// Interval between polls in [`TransactionBuilderWrite::wait_for_tx`].
 const WAIT_FOR_TX_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Extract the result for the single item of a one-item batch request.
@@ -55,7 +54,7 @@ fn single_item<T>(
     }
 }
 
-impl TransactionBuilderResolveClient for Client {
+impl TransactionBuilderRead for Client {
     type Error = crate::api::Error;
 
     async fn object(
@@ -121,6 +120,47 @@ impl TransactionBuilderResolveClient for Client {
         Ok(ObjectsPage { data, next_cursor })
     }
 
+    async fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<SignedTransaction>, Self::Error> {
+        let response = self
+            .get_transactions(
+                &[digest],
+                Some(ReadMask::from(&[
+                    EXECUTED_TRANSACTION_TRANSACTION,
+                    EXECUTED_TRANSACTION_SIGNATURES,
+                ])),
+            )
+            .await;
+
+        match single_item(response)? {
+            Some(tx) => {
+                let transaction = tx.transaction()?.transaction()?;
+                let signatures = Vec::<UserSignature>::try_from(tx.signatures()?)?;
+                Ok(Some(SignedTransaction {
+                    transaction,
+                    signatures,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> Result<Option<TransactionEffects>, Self::Error> {
+        let response = self
+            .get_transactions(&[digest], Some(ReadMask::from(TRANSACTION_EFFECTS_BCS)))
+            .await;
+
+        match single_item(response)? {
+            Some(tx) => Ok(Some(tx.effects()?.effects()?)),
+            None => Ok(None),
+        }
+    }
+
     async fn protocol_config(&self) -> Result<ProtocolConfig, Self::Error> {
         let epoch = self
             .get_epoch(
@@ -169,49 +209,8 @@ impl TransactionBuilderResolveClient for Client {
     }
 }
 
-impl TransactionBuilderClient for Client {
+impl TransactionBuilderWrite for Client {
     type DryRunResult = SimulatedTransaction;
-
-    async fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<SignedTransaction>, Self::Error> {
-        let response = self
-            .get_transactions(
-                &[digest],
-                Some(ReadMask::from(&[
-                    EXECUTED_TRANSACTION_TRANSACTION,
-                    EXECUTED_TRANSACTION_SIGNATURES,
-                ])),
-            )
-            .await;
-
-        match single_item(response)? {
-            Some(tx) => {
-                let transaction = tx.transaction()?.transaction()?;
-                let signatures = Vec::<UserSignature>::try_from(tx.signatures()?)?;
-                Ok(Some(SignedTransaction {
-                    transaction,
-                    signatures,
-                }))
-            }
-            None => Ok(None),
-        }
-    }
-
-    async fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> Result<Option<TransactionEffects>, Self::Error> {
-        let response = self
-            .get_transactions(&[digest], Some(ReadMask::from(TRANSACTION_EFFECTS_BCS)))
-            .await;
-
-        match single_item(response)? {
-            Some(tx) => Ok(Some(tx.effects()?.effects()?)),
-            None => Ok(None),
-        }
-    }
 
     async fn dry_run_tx(
         &self,

--- a/crates/iota-sdk-transaction-builder/src/builder/client.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client.rs
@@ -4,8 +4,8 @@
 use std::collections::BTreeMap;
 
 use iota_types::{
-    Address, Object, ObjectId, SignedTransaction, StructTag, Transaction, TransactionDigest,
-    TransactionEffects, UserSignature, Version,
+    Address, Object, ObjectId, StructTag, Transaction, TransactionDigest, TransactionEffects,
+    UserSignature, Version,
 };
 
 /// Determines what to wait for after executing a transaction.
@@ -104,12 +104,6 @@ pub trait TransactionBuilderRead {
         limit: Option<usize>,
     ) -> impl std::future::Future<Output = Result<ObjectsPage, Self::Error>>;
 
-    /// Fetch a transaction
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>>;
-
     /// Fetch transaction effects
     fn transaction_effects(
         &self,
@@ -203,13 +197,6 @@ impl<T: TransactionBuilderRead> TransactionBuilderRead for &T {
         (*self).objects(struct_tag, owner, cursor, limit)
     }
 
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
-        (*self).transaction(digest)
-    }
-
     fn transaction_effects(
         &self,
         digest: TransactionDigest,
@@ -295,13 +282,6 @@ impl<T: TransactionBuilderRead> TransactionBuilderRead for std::sync::Arc<T> {
         self.as_ref().objects(struct_tag, owner, cursor, limit)
     }
 
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
-        self.as_ref().transaction(digest)
-    }
-
     fn transaction_effects(
         &self,
         digest: TransactionDigest,
@@ -364,8 +344,8 @@ pub(crate) mod test_client {
     //! Test utilities for the transaction builder.
 
     use iota_types::{
-        Address, MoveStruct, Object, ObjectData, ObjectId, Owner, SignedTransaction, StructTag,
-        Transaction, TransactionDigest, TransactionEffects, UserSignature, Version,
+        Address, MoveStruct, Object, ObjectData, ObjectId, Owner, StructTag, Transaction,
+        TransactionDigest, TransactionEffects, UserSignature, Version,
     };
 
     use super::{TransactionBuilderRead, TransactionBuilderWrite, WaitForTx};
@@ -456,13 +436,6 @@ pub(crate) mod test_client {
                 data: vec![fabricated_coin(gas_coin_id, owner, FABRICATED_COIN_BALANCE)],
                 next_cursor: None,
             })
-        }
-
-        async fn transaction(
-            &self,
-            _digest: TransactionDigest,
-        ) -> Result<Option<SignedTransaction>, Self::Error> {
-            Ok(None)
         }
 
         async fn transaction_effects(
@@ -583,13 +556,6 @@ pub(crate) mod test_client {
             crate::TestClient
                 .objects(struct_tag, owner, cursor, limit)
                 .await
-        }
-
-        async fn transaction(
-            &self,
-            digest: iota_types::TransactionDigest,
-        ) -> Result<Option<iota_types::SignedTransaction>, Self::Error> {
-            crate::TestClient.transaction(digest).await
         }
 
         async fn transaction_effects(

--- a/crates/iota-sdk-transaction-builder/src/builder/client.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/client.rs
@@ -36,14 +36,14 @@ pub enum WaitForTx {
 }
 
 /// One page of objects plus an optional cursor for the next page. See
-/// [`TransactionBuilderResolveClient::objects`].
+/// [`TransactionBuilderRead::objects`].
 #[derive(Clone, Debug)]
 pub struct ObjectsPage {
     /// The objects in this page.
     pub data: Vec<Object>,
     /// Opaque continuation cursor for fetching the next page; `None` when no
     /// further pages exist. Pass it back as the `cursor` argument to
-    /// [`TransactionBuilderResolveClient::objects`] to advance.
+    /// [`TransactionBuilderRead::objects`] to advance.
     pub next_cursor: Option<Vec<u8>>,
 }
 
@@ -59,7 +59,7 @@ pub struct ProtocolConfig {
 /// A trait which defines read-only methods the Transaction Builder needs to
 /// resolve and build a transaction
 /// ([`finish`](crate::TransactionBuilder::finish)).
-pub trait TransactionBuilderResolveClient {
+pub trait TransactionBuilderRead {
     /// The error type for this client.
     type Error: 'static + std::error::Error + Send + Sync;
 
@@ -104,6 +104,18 @@ pub trait TransactionBuilderResolveClient {
         limit: Option<usize>,
     ) -> impl std::future::Future<Output = Result<ObjectsPage, Self::Error>>;
 
+    /// Fetch a transaction
+    fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>>;
+
+    /// Fetch transaction effects
+    fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>>;
+
     /// Fetch the chain's protocol configuration.
     ///
     /// The default impl returns a default [`ProtocolConfig`].
@@ -134,23 +146,11 @@ pub trait TransactionBuilderResolveClient {
 }
 
 /// A trait which defines methods needed from the client for the Transaction
-/// Builder, extending [`TransactionBuilderResolveClient`] with dry run and
+/// Builder, extending [`TransactionBuilderRead`] with dry run and
 /// execution.
-pub trait TransactionBuilderClient: TransactionBuilderResolveClient {
+pub trait TransactionBuilderWrite: TransactionBuilderRead {
     /// The result of a dry run.
     type DryRunResult;
-
-    /// Fetch a transaction
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>>;
-
-    /// Fetch transaction effects
-    fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>>;
 
     /// Dry run a transaction
     fn dry_run_tx(
@@ -175,7 +175,7 @@ pub trait TransactionBuilderClient: TransactionBuilderResolveClient {
     ) -> impl std::future::Future<Output = Result<(), Self::Error>>;
 }
 
-impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for &T {
+impl<T: TransactionBuilderRead> TransactionBuilderRead for &T {
     type Error = T::Error;
 
     fn object(
@@ -203,6 +203,20 @@ impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for &T 
         (*self).objects(struct_tag, owner, cursor, limit)
     }
 
+    fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
+        (*self).transaction(digest)
+    }
+
+    fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>> {
+        (*self).transaction_effects(digest)
+    }
+
     fn protocol_config(
         &self,
     ) -> impl std::future::Future<Output = Result<ProtocolConfig, Self::Error>> {
@@ -224,22 +238,8 @@ impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for &T 
     }
 }
 
-impl<T: TransactionBuilderClient> TransactionBuilderClient for &T {
+impl<T: TransactionBuilderWrite> TransactionBuilderWrite for &T {
     type DryRunResult = T::DryRunResult;
-
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
-        (*self).transaction(digest)
-    }
-
-    fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>> {
-        (*self).transaction_effects(digest)
-    }
 
     fn dry_run_tx(
         &self,
@@ -267,7 +267,7 @@ impl<T: TransactionBuilderClient> TransactionBuilderClient for &T {
     }
 }
 
-impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for std::sync::Arc<T> {
+impl<T: TransactionBuilderRead> TransactionBuilderRead for std::sync::Arc<T> {
     type Error = T::Error;
 
     fn object(
@@ -295,6 +295,20 @@ impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for std
         self.as_ref().objects(struct_tag, owner, cursor, limit)
     }
 
+    fn transaction(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
+        self.as_ref().transaction(digest)
+    }
+
+    fn transaction_effects(
+        &self,
+        digest: TransactionDigest,
+    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>> {
+        self.as_ref().transaction_effects(digest)
+    }
+
     fn protocol_config(
         &self,
     ) -> impl std::future::Future<Output = Result<ProtocolConfig, Self::Error>> {
@@ -316,22 +330,8 @@ impl<T: TransactionBuilderResolveClient> TransactionBuilderResolveClient for std
     }
 }
 
-impl<T: TransactionBuilderClient> TransactionBuilderClient for std::sync::Arc<T> {
+impl<T: TransactionBuilderWrite> TransactionBuilderWrite for std::sync::Arc<T> {
     type DryRunResult = T::DryRunResult;
-
-    fn transaction(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<SignedTransaction>, Self::Error>> {
-        self.as_ref().transaction(digest)
-    }
-
-    fn transaction_effects(
-        &self,
-        digest: TransactionDigest,
-    ) -> impl std::future::Future<Output = Result<Option<TransactionEffects>, Self::Error>> {
-        self.as_ref().transaction_effects(digest)
-    }
 
     fn dry_run_tx(
         &self,
@@ -368,7 +368,7 @@ pub(crate) mod test_client {
         Transaction, TransactionDigest, TransactionEffects, UserSignature, Version,
     };
 
-    use super::{TransactionBuilderClient, TransactionBuilderResolveClient, WaitForTx};
+    use super::{TransactionBuilderRead, TransactionBuilderWrite, WaitForTx};
     use crate::ObjectsPage;
 
     /// Balance, in NANOS, of every fabricated coin. Large enough to cover any
@@ -398,7 +398,7 @@ pub(crate) mod test_client {
         )
     }
 
-    /// A test client that implements [`TransactionBuilderClient`] by
+    /// A test client that implements [`TransactionBuilderWrite`] by
     /// fabricating objects on demand.
     ///
     /// It is useful for building transactions in tests, examples, and doc tests
@@ -408,7 +408,7 @@ pub(crate) mod test_client {
     /// selection always finds a single funded coin. This is enough to drive
     /// [`finish`](crate::TransactionBuilder::finish) to completion, but the
     /// resulting transaction references made-up objects and cannot be executed
-    /// — [`execute_tx`](TransactionBuilderClient::execute_tx) returns an error.
+    /// — [`execute_tx`](TransactionBuilderWrite::execute_tx) returns an error.
     #[derive(Clone, Copy, Debug, Default)]
     pub struct TestClient;
 
@@ -417,7 +417,7 @@ pub(crate) mod test_client {
     #[error("TestClientError: {0}")]
     pub struct TestClientError(pub String);
 
-    impl TransactionBuilderResolveClient for TestClient {
+    impl TransactionBuilderRead for TestClient {
         type Error = TestClientError;
 
         async fn object(
@@ -458,21 +458,6 @@ pub(crate) mod test_client {
             })
         }
 
-        async fn reference_gas_price(
-            &self,
-            _epoch: impl Into<Option<u64>>,
-        ) -> Result<Option<u64>, Self::Error> {
-            Ok(Some(1000))
-        }
-
-        async fn estimate_tx_budget(&self, _tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-            Ok(Some(50_000_000))
-        }
-    }
-
-    impl TransactionBuilderClient for TestClient {
-        type DryRunResult = ();
-
         async fn transaction(
             &self,
             _digest: TransactionDigest,
@@ -486,6 +471,21 @@ pub(crate) mod test_client {
         ) -> Result<Option<TransactionEffects>, Self::Error> {
             Ok(None)
         }
+
+        async fn reference_gas_price(
+            &self,
+            _epoch: impl Into<Option<u64>>,
+        ) -> Result<Option<u64>, Self::Error> {
+            Ok(Some(1000))
+        }
+
+        async fn estimate_tx_budget(&self, _tx: &Transaction) -> Result<Option<u64>, Self::Error> {
+            Ok(Some(50_000_000))
+        }
+    }
+
+    impl TransactionBuilderWrite for TestClient {
+        type DryRunResult = ();
 
         async fn dry_run_tx(
             &self,
@@ -539,7 +539,7 @@ pub(crate) mod test_client {
         }
     }
 
-    impl TransactionBuilderResolveClient for RecordingClient {
+    impl TransactionBuilderRead for RecordingClient {
         type Error = crate::TestClientError;
 
         async fn object(
@@ -585,21 +585,6 @@ pub(crate) mod test_client {
                 .await
         }
 
-        async fn reference_gas_price(
-            &self,
-            epoch: impl Into<Option<u64>>,
-        ) -> Result<Option<u64>, Self::Error> {
-            crate::TestClient.reference_gas_price(epoch).await
-        }
-
-        async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
-            crate::TestClient.estimate_tx_budget(tx).await
-        }
-    }
-
-    impl TransactionBuilderClient for RecordingClient {
-        type DryRunResult = ();
-
         async fn transaction(
             &self,
             digest: iota_types::TransactionDigest,
@@ -613,6 +598,21 @@ pub(crate) mod test_client {
         ) -> Result<Option<TransactionEffects>, Self::Error> {
             crate::TestClient.transaction_effects(digest).await
         }
+
+        async fn reference_gas_price(
+            &self,
+            epoch: impl Into<Option<u64>>,
+        ) -> Result<Option<u64>, Self::Error> {
+            crate::TestClient.reference_gas_price(epoch).await
+        }
+
+        async fn estimate_tx_budget(&self, tx: &Transaction) -> Result<Option<u64>, Self::Error> {
+            crate::TestClient.estimate_tx_budget(tx).await
+        }
+    }
+
+    impl TransactionBuilderWrite for RecordingClient {
+        type DryRunResult = ();
 
         async fn dry_run_tx(
             &self,

--- a/crates/iota-sdk-transaction-builder/src/builder/mod.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/mod.rs
@@ -18,7 +18,7 @@ use reqwest::Url;
 use serde::Serialize;
 
 use crate::{
-    PTBArgument, SharedMut, TransactionBuilderClient, TransactionBuilderResolveClient, WaitForTx,
+    PTBArgument, SharedMut, TransactionBuilderRead, TransactionBuilderWrite, WaitForTx,
     builder::{
         assigned_results::{AssignedResult, AssignedResults},
         gas_station::GasStationData,
@@ -50,7 +50,7 @@ const MAX_GAS_PAYMENT_OBJECTS_KEY: &str = "max_gas_payment_objects";
 /// Fallback cap on `gas_payment.objects.len()` used when the protocol-config
 /// value is unavailable (`max_gas_payment_objects` is 256 exclusive at the
 /// time of writing, so 255 inclusive). Auto gas selection fetches the live
-/// value via [`TransactionBuilderResolveClient::protocol_config`] and falls
+/// value via [`TransactionBuilderRead::protocol_config`] and falls
 /// back to this if the implementation does not expose protocol config or the
 /// value cannot be parsed.
 const DEFAULT_MAX_GAS_PAYMENT_OBJECTS: usize = 255;
@@ -1015,7 +1015,7 @@ impl<C, L> TransactionBuilder<C, L> {
     }
 }
 
-impl<C: TransactionBuilderResolveClient, L> TransactionBuilder<C, L> {
+impl<C: TransactionBuilderRead, L> TransactionBuilder<C, L> {
     /// Add gas coins that will be consumed. If no gas coins are provided, the
     /// client will set a default list owned by the sender.
     ///
@@ -1444,7 +1444,7 @@ impl<C: TransactionBuilderResolveClient, L> TransactionBuilder<C, L> {
     }
 }
 
-impl<C: TransactionBuilderClient, L> TransactionBuilder<C, L> {
+impl<C: TransactionBuilderWrite, L> TransactionBuilder<C, L> {
     /// Dry run the transaction.
     pub async fn dry_run(mut self, skip_checks: bool) -> Result<C::DryRunResult, Error> {
         let txn = self.resolve_ptb(false).await?;

--- a/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
+++ b/crates/iota-sdk-transaction-builder/src/builder/move_authenticator.rs
@@ -11,8 +11,7 @@ use iota_types::{
 };
 
 use crate::{
-    PTBArgumentList, TransactionBuilderResolveClient, error::Error, types::MoveTypes,
-    unresolved::InputKind,
+    PTBArgumentList, TransactionBuilderRead, error::Error, types::MoveTypes, unresolved::InputKind,
 };
 
 /// A function call to authorize a transaction via move.
@@ -59,7 +58,7 @@ impl MoveAuthenticatorBuilder {
     /// which can be used to execute the given transaction.
     pub async fn finish(
         self,
-        client: impl TransactionBuilderResolveClient,
+        client: impl TransactionBuilderRead,
     ) -> Result<MoveAuthenticator, Error> {
         let account = client
             .object(self.account_id, None)

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -354,13 +354,6 @@ mod tests {
                 self.0.objects(struct_tag, owner, cursor, limit).await
             }
 
-            async fn transaction(
-                &self,
-                digest: iota_types::TransactionDigest,
-            ) -> Result<Option<iota_types::SignedTransaction>, Self::Error> {
-                self.0.transaction(digest).await
-            }
-
             async fn transaction_effects(
                 &self,
                 digest: iota_types::TransactionDigest,

--- a/crates/iota-sdk-transaction-builder/src/lib.rs
+++ b/crates/iota-sdk-transaction-builder/src/lib.rs
@@ -15,10 +15,10 @@
 //! ## Online vs. Offline Builder
 //!
 //! The Transaction Builder can be used with or without a client implementing
-//! [TransactionBuilderResolveClient]. When one is provided via the
+//! [TransactionBuilderRead]. When one is provided via the
 //! [with_client](TransactionBuilder::with_client) method, the resulting builder
 //! will use it to find and validate provided IDs. Clients that also implement
-//! [TransactionBuilderClient] additionally enable
+//! [TransactionBuilderWrite] additionally enable
 //! [dry_run](TransactionBuilder::dry_run) and
 //! [execute](TransactionBuilder::execute).
 //!
@@ -301,8 +301,7 @@ pub use self::{
     builder::{
         TransactionBuilder,
         client::{
-            ObjectsPage, ProtocolConfig, TransactionBuilderClient, TransactionBuilderResolveClient,
-            WaitForTx,
+            ObjectsPage, ProtocolConfig, TransactionBuilderRead, TransactionBuilderWrite, WaitForTx,
         },
         move_authenticator::MoveAuthenticatorBuilder,
         ptb_arguments::{PTBArgument, PTBArgumentList, Receiving, Shared, SharedMut, assigned},
@@ -318,23 +317,23 @@ mod tests {
     use crate::TransactionBuilder;
 
     #[cfg(feature = "test-client")]
-    mod resolve_client {
+    mod read_client {
         use iota_types::{Object, ObjectId, StructTag, Version};
 
         use crate::{
-            ObjectsPage, TestClient, TestClientError, TransactionBuilder,
-            TransactionBuilderResolveClient, error::Error,
+            ObjectsPage, TestClient, TestClientError, TransactionBuilder, TransactionBuilderRead,
+            error::Error,
         };
 
-        /// Implements only [`TransactionBuilderResolveClient`] by forwarding to
+        /// Implements only [`TransactionBuilderRead`] by forwarding to
         /// [`TestClient`], to verify that building a transaction does not
         /// require the full
-        /// [`TransactionBuilderClient`](crate::TransactionBuilderClient).
+        /// [`TransactionBuilderWrite`](crate::TransactionBuilderWrite).
         /// It relies on the default `estimate_tx_budget`, so no transaction
         /// simulation is needed.
-        struct ResolveOnlyClient(TestClient);
+        struct ReadOnlyClient(TestClient);
 
-        impl TransactionBuilderResolveClient for ResolveOnlyClient {
+        impl TransactionBuilderRead for ReadOnlyClient {
             type Error = TestClientError;
 
             async fn object(
@@ -355,6 +354,20 @@ mod tests {
                 self.0.objects(struct_tag, owner, cursor, limit).await
             }
 
+            async fn transaction(
+                &self,
+                digest: iota_types::TransactionDigest,
+            ) -> Result<Option<iota_types::SignedTransaction>, Self::Error> {
+                self.0.transaction(digest).await
+            }
+
+            async fn transaction_effects(
+                &self,
+                digest: iota_types::TransactionDigest,
+            ) -> Result<Option<iota_types::TransactionEffects>, Self::Error> {
+                self.0.transaction_effects(digest).await
+            }
+
             async fn reference_gas_price(
                 &self,
                 epoch: impl Into<Option<u64>>,
@@ -364,7 +377,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn finish_requires_only_the_resolve_client() {
+        async fn finish_requires_only_the_read_client() {
             let sender = "0xc574ea804d9c1a27c886312e96c0e2c9cfd71923ebaeb3000d04b5e65fca2793"
                 .parse()
                 .unwrap();
@@ -379,7 +392,7 @@ mod tests {
             // Without simulation there is no budget estimation, so an explicit
             // gas budget is required.
             let mut builder =
-                TransactionBuilder::new(sender).with_client(ResolveOnlyClient(TestClient));
+                TransactionBuilder::new(sender).with_client(ReadOnlyClient(TestClient));
             builder.send_coins([coin], recipient, 1000u64);
             assert!(matches!(
                 builder.finish().await,
@@ -387,7 +400,7 @@ mod tests {
             ));
 
             let mut builder =
-                TransactionBuilder::new(sender).with_client(ResolveOnlyClient(TestClient));
+                TransactionBuilder::new(sender).with_client(ReadOnlyClient(TestClient));
             builder
                 .send_coins([coin], recipient, 1000u64)
                 .gas_budget(50_000_000);


### PR DESCRIPTION
Stacked on #1280.

## Why

`TransactionBuilderResolveClient` / `TransactionBuilderClient` reads as one trait and its variant, so which half a method belongs in isn't obvious from the name — and it left the two transaction reads on the execution side, where they only sit because `execute()` happens to use one of them.

## What changes

The split is now read vs. write: everything that only queries chain state is on the read trait, and the write trait is dry run plus execution. A read-only client therefore also has to supply the effects lookup; a plain read, and not called on the `finish()` path.

The `transaction` fn is removed entirely as it is unused.

## Test plan

`make test`, `make test-docs`, `make clippy`, `make check-fmt`, `make wasm32`.