### PR TITLE
fix: derive Hash instead of hashing serialized bytes

### DIFF
--- a/crates/iota-sdk-types/src/crypto/move_authenticator.rs
+++ b/crates/iota-sdk-types/src/crypto/move_authenticator.rs
@@ -1,16 +1,13 @@
 // Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "serde")]
-use std::hash::{Hash, Hasher};
-
 use crate::{Address, Input, ObjectReference, TypeTag, transaction::SharedObjectReference};
 
 /// MoveAuthenticator is a signature variant that enables a method of
 /// authentication through Move code. This type represents the data received
 /// by the Move authenticate function during the Account Abstraction
 /// authentication flow.
-#[derive(Clone, Debug, derive_more::From, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::From, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
@@ -41,15 +38,8 @@ impl MoveAuthenticator {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Hash for MoveAuthenticator {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_bytes().hash(state);
-    }
-}
-
 /// Version 1 of the [`MoveAuthenticator`].
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]

--- a/crates/iota-sdk-types/src/crypto/multisig.rs
+++ b/crates/iota-sdk-types/src/crypto/multisig.rs
@@ -72,7 +72,7 @@ pub enum MultisigError {
 /// legacy-multisig-member = legacy-multisig-member-public-key
 ///                          u8     ; weight
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
@@ -124,7 +124,7 @@ impl MultisigMember {
 /// legacy-multisig-committee = (vector legacy-multisig-member)
 ///                             u16     ; threshold
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MultisigCommittee {
@@ -276,7 +276,7 @@ impl MultisigCommittee {
 ///
 /// See [here](https://github.com/RoaringBitmap/RoaringFormatSpec) for the specification for the
 /// serialized format of RoaringBitmaps.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
 pub struct MultisigAggregatedSignature {
     /// The plain signature encoded with signature scheme.
@@ -466,7 +466,7 @@ fn as_indices(bitmap: u16) -> Result<Vec<u8>, MultisigError> {
 /// secp256r1-multisig-member-signature             = %d02 secp256r1-signature
 /// passkey-multisig-member-signature               = %d04 passkey-authenticator
 /// ```
-#[derive(Clone, Debug, derive_more::From, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::From, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
 pub enum MultisigMemberSignature {
@@ -592,11 +592,7 @@ impl proptest::arbitrary::Arbitrary for MultisigAggregatedSignature {
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 pub(crate) mod serialization {
-    use std::{
-        borrow::Cow,
-        hash::{Hash, Hasher},
-        str::FromStr,
-    };
+    use std::{borrow::Cow, str::FromStr};
 
     use base64ct::{Base64, Encoding};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -846,12 +842,6 @@ pub(crate) mod serialization {
     impl From<&MultisigCommittee> for crate::Address {
         fn from(committee: &MultisigCommittee) -> Self {
             committee.derive_address()
-        }
-    }
-
-    impl Hash for MultisigAggregatedSignature {
-        fn hash<H: Hasher>(&self, state: &mut H) {
-            self.to_bytes().hash(state);
         }
     }
 

--- a/crates/iota-sdk-types/src/crypto/passkey.rs
+++ b/crates/iota-sdk-types/src/crypto/passkey.rs
@@ -2,9 +2,6 @@
 // Modifications Copyright (c) 2025 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "serde")]
-use std::hash::{Hash, Hasher};
-
 use super::{Secp256r1PublicKey, Secp256r1Signature, SimpleSignature};
 use crate::SigningDigest;
 
@@ -37,7 +34,7 @@ use crate::SigningDigest;
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, derive_more::Debug, Eq, PartialEq)]
+#[derive(Clone, derive_more::Debug, Eq, Hash, PartialEq)]
 pub struct PasskeyAuthenticator {
     /// Compact r1 public key for this passkey.
     pub(crate) public_key: Secp256r1PublicKey,
@@ -101,13 +98,6 @@ impl PasskeyAuthenticator {
     }
 }
 
-#[cfg(feature = "serde")]
-impl Hash for PasskeyAuthenticator {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.to_bytes().hash(state);
-    }
-}
-
 /// Public key of a `PasskeyAuthenticator`.
 ///
 /// This is used to derive the onchain `Address` for a `PasskeyAuthenticator`.
@@ -119,7 +109,7 @@ impl Hash for PasskeyAuthenticator {
 /// ```text
 /// passkey-public-key = passkey-flag secp256r1-public-key
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),

--- a/crates/iota-sdk-types/src/crypto/public_key.rs
+++ b/crates/iota-sdk-types/src/crypto/public_key.rs
@@ -50,7 +50,7 @@ pub enum PublicKeyError {
 ///                      (secp256r1-flag secp256r1-public-key) /
 ///                      (passkey-flag passkey-public-key)
 /// ```
-#[derive(Clone, Debug, derive_more::From, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::From, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[non_exhaustive]
 pub enum PublicKey {

--- a/crates/iota-sdk-types/src/crypto/signature.rs
+++ b/crates/iota-sdk-types/src/crypto/signature.rs
@@ -345,7 +345,7 @@ impl std::fmt::Display for InvalidSignatureScheme {
 /// signature is ever embedded in another structure it generally is serialized
 /// as `bytes` meaning it has a length prefix that defines the length of
 /// the completely serialized signature.
-#[derive(Clone, Debug, derive_more::From, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::From, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(
     feature = "bcs-schema",
@@ -400,13 +400,6 @@ impl UserSignature {
                 SignatureScheme::MoveAuthenticator.to_u8(),
             )),
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl std::hash::Hash for UserSignature {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.to_bytes().hash(state);
     }
 }
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -74,7 +74,7 @@ pub struct TransactionV1 {
 /// ```text
 /// sender-signed-transaction = %d01 intent-signed-transaction
 /// ```
-#[derive(Clone, Debug, derive_more::Deref, Eq, PartialEq)]
+#[derive(Clone, Debug, derive_more::Deref, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 pub struct SenderSignedTransaction(
@@ -100,14 +100,7 @@ impl From<SignedTransaction> for SenderSignedTransaction {
     }
 }
 
-#[cfg(feature = "serde")]
-impl std::hash::Hash for SenderSignedTransaction {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "proptest", derive(test_strategy::Arbitrary))]
 #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
@@ -167,14 +160,6 @@ impl SignedTransaction {
 impl From<SenderSignedTransaction> for SignedTransaction {
     fn from(transaction: SenderSignedTransaction) -> Self {
         transaction.0
-    }
-}
-
-#[cfg(feature = "serde")]
-impl std::hash::Hash for SignedTransaction {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.transaction.hash(state);
-        self.signatures.hash(state);
     }
 }
 


### PR DESCRIPTION
Replaces the manual `Hash` impls that serialized the value and hashed the bytes with `#[derive(Hash)]`. Each affected type derives `PartialEq`/`Eq` over the same fields, so the derived hash upholds the same `Hash`/`Eq` contract without the serialization round-trip.

Deriving needs no serialization, so these types now also implement `Hash` when the `serde` feature is off — the old impls were gated on it because they called `to_bytes()`.

The corresponding impl named in the issue is no longer in the `iota` repo; it moved here with iotaledger/iota#11929. The manual impls remaining there (`Committee`, `AuthoritySignInfo`, starfish's `BlockRef` and digest types) are deliberate partial hashes over a field subset or digest prefix, not this pattern.

Refs iotaledger/iota#11957

🤖 Generated with [Claude Code](https://claude.com/claude-code)