### PR TITLE
feat: reshape TransactionDenyRulesUpdate to add/remove deltas

### DIFF
--- a/crates/iota-sdk-ffi/src/types/transaction/mod.rs
+++ b/crates/iota-sdk-ffi/src/types/transaction/mod.rs
@@ -1542,18 +1542,31 @@ impl From<iota_sdk::types::DenyRuleSet> for DenyRuleSet {
 
 /// Update of the on-chain transaction deny rules.
 ///
-/// Carries the full active set of deny rules, replacing the previous contents
-/// of the deny-rules object.
+/// Carries an add/remove delta for each deny list plus the absolute switch
+/// states. The added and removed sets of a list are disjoint by producer
+/// contract; converting into the underlying set-typed Rust representation
+/// sorts and deduplicates the lists.
 ///
 /// # BCS
 ///
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// transaction-deny-rules-update = u64             ; epoch
-///                                 u64             ; round
-///                                 deny-rule-set   ; deny rules
-///                                 version         ; initial shared version
+/// transaction-deny-rules-update = u64               ; epoch
+///                                 u64               ; round
+///                                 (vector address)  ; added addresses
+///                                 (vector address)  ; removed addresses
+///                                 (vector object-id) ; added objects
+///                                 (vector object-id) ; removed objects
+///                                 (vector object-id) ; added packages
+///                                 (vector object-id) ; removed packages
+///                                 bool              ; package publish disabled
+///                                 bool              ; package upgrade disabled
+///                                 bool              ; shared object disabled
+///                                 bool              ; user transaction disabled
+///                                 bool              ; receiving objects disabled
+///                                 bool              ; move authenticator disabled
+///                                 version           ; initial shared version
 /// ```
 #[derive(uniffi::Record)]
 pub struct TransactionDenyRulesUpdate {
@@ -1561,8 +1574,30 @@ pub struct TransactionDenyRulesUpdate {
     pub epoch: u64,
     /// Consensus round of the update
     pub round: u64,
-    /// The full active set of deny rules
-    pub deny_rules: DenyRuleSet,
+    /// Addresses added to the sender-or-sponsor deny list.
+    pub added_addresses: Vec<Arc<Address>>,
+    /// Addresses removed from the sender-or-sponsor deny list.
+    pub removed_addresses: Vec<Arc<Address>>,
+    /// Objects added to the input-or-receiving deny list.
+    pub added_objects: Vec<Arc<ObjectId>>,
+    /// Objects removed from the input-or-receiving deny list.
+    pub removed_objects: Vec<Arc<ObjectId>>,
+    /// Packages added to the dependency deny list.
+    pub added_packages: Vec<Arc<ObjectId>>,
+    /// Packages removed from the dependency deny list.
+    pub removed_packages: Vec<Arc<ObjectId>>,
+    /// Denies all package publishing.
+    pub package_publish_disabled: bool,
+    /// Denies all package upgrades.
+    pub package_upgrade_disabled: bool,
+    /// Denies transactions that use shared objects as inputs.
+    pub shared_object_disabled: bool,
+    /// Denies all user transactions (kill switch).
+    pub user_transaction_disabled: bool,
+    /// Denies transactions that contain receiving objects.
+    pub receiving_objects_disabled: bool,
+    /// Denies transactions signed with a Move authenticator.
+    pub move_authenticator_disabled: bool,
     /// The initial version of the deny-rules object that it was shared at
     pub deny_rules_obj_initial_shared_version: Arc<Version>,
 }
@@ -1572,7 +1607,18 @@ impl From<TransactionDenyRulesUpdate> for iota_sdk::types::TransactionDenyRulesU
         Self {
             epoch: value.epoch,
             round: value.round,
-            deny_rules: value.deny_rules.into(),
+            added_addresses: value.added_addresses.iter().map(|a| a.0).collect(),
+            removed_addresses: value.removed_addresses.iter().map(|a| a.0).collect(),
+            added_objects: value.added_objects.iter().map(|o| o.0).collect(),
+            removed_objects: value.removed_objects.iter().map(|o| o.0).collect(),
+            added_packages: value.added_packages.iter().map(|o| o.0).collect(),
+            removed_packages: value.removed_packages.iter().map(|o| o.0).collect(),
+            package_publish_disabled: value.package_publish_disabled,
+            package_upgrade_disabled: value.package_upgrade_disabled,
+            shared_object_disabled: value.shared_object_disabled,
+            user_transaction_disabled: value.user_transaction_disabled,
+            receiving_objects_disabled: value.receiving_objects_disabled,
+            move_authenticator_disabled: value.move_authenticator_disabled,
             deny_rules_obj_initial_shared_version: **value.deny_rules_obj_initial_shared_version,
         }
     }
@@ -1580,10 +1626,24 @@ impl From<TransactionDenyRulesUpdate> for iota_sdk::types::TransactionDenyRulesU
 
 impl From<iota_sdk::types::TransactionDenyRulesUpdate> for TransactionDenyRulesUpdate {
     fn from(value: iota_sdk::types::TransactionDenyRulesUpdate) -> Self {
+        fn arcs<T, U: From<T>>(items: impl IntoIterator<Item = T>) -> Vec<Arc<U>> {
+            items.into_iter().map(|x| Arc::new(x.into())).collect()
+        }
         Self {
             epoch: value.epoch,
             round: value.round,
-            deny_rules: value.deny_rules.into(),
+            added_addresses: arcs(value.added_addresses),
+            removed_addresses: arcs(value.removed_addresses),
+            added_objects: arcs(value.added_objects),
+            removed_objects: arcs(value.removed_objects),
+            added_packages: arcs(value.added_packages),
+            removed_packages: arcs(value.removed_packages),
+            package_publish_disabled: value.package_publish_disabled,
+            package_upgrade_disabled: value.package_upgrade_disabled,
+            shared_object_disabled: value.shared_object_disabled,
+            user_transaction_disabled: value.user_transaction_disabled,
+            receiving_objects_disabled: value.receiving_objects_disabled,
+            move_authenticator_disabled: value.move_authenticator_disabled,
             deny_rules_obj_initial_shared_version: Arc::new(
                 value.deny_rules_obj_initial_shared_version.into(),
             ),

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -431,10 +431,21 @@ system-package = version             ; version
 
 transaction = %d00 transaction-v1   ; V1
 
-transaction-deny-rules-update = u64             ; epoch
-                                u64             ; round
-                                deny-rule-set   ; deny-rules
-                                version         ; deny-rules-obj-initial-shared-version
+transaction-deny-rules-update = u64                 ; epoch
+                                u64                 ; round
+                                (size *address)     ; added-addresses
+                                (size *address)     ; removed-addresses
+                                (size *object-id)   ; added-objects
+                                (size *object-id)   ; removed-objects
+                                (size *object-id)   ; added-packages
+                                (size *object-id)   ; removed-packages
+                                bool                ; package-publish-disabled
+                                bool                ; package-upgrade-disabled
+                                bool                ; shared-object-disabled
+                                bool                ; user-transaction-disabled
+                                bool                ; receiving-objects-disabled
+                                bool                ; move-authenticator-disabled
+                                version             ; deny-rules-obj-initial-shared-version
 
 transaction-digest = digest
 

--- a/crates/iota-sdk-types/src/transaction/mod.rs
+++ b/crates/iota-sdk-types/src/transaction/mod.rs
@@ -327,18 +327,32 @@ pub struct DenyRuleSet {
 
 /// Update of the on-chain transaction deny rules.
 ///
-/// Carries the full active set of deny rules, replacing the previous contents
-/// of the deny-rules object.
+/// Carries an add/remove delta for each deny list plus the absolute switch
+/// states. The added and removed sets of a list are disjoint by producer
+/// contract (validators compute them as a diff); a delta too large for one
+/// transaction arrives split across several update transactions in the same
+/// commit. Set-typed fields decode normalizing, like [`DenyRuleSet`]'s.
 ///
 /// # BCS
 ///
 /// The BCS serialized form for this type is defined by the following ABNF:
 ///
 /// ```text
-/// transaction-deny-rules-update = u64             ; epoch
-///                                 u64             ; round
-///                                 deny-rule-set   ; deny rules
-///                                 version         ; initial shared version
+/// transaction-deny-rules-update = u64               ; epoch
+///                                 u64               ; round
+///                                 (vector address)  ; added addresses
+///                                 (vector address)  ; removed addresses
+///                                 (vector object-id) ; added objects
+///                                 (vector object-id) ; removed objects
+///                                 (vector object-id) ; added packages
+///                                 (vector object-id) ; removed packages
+///                                 bool              ; package publish disabled
+///                                 bool              ; package upgrade disabled
+///                                 bool              ; shared object disabled
+///                                 bool              ; user transaction disabled
+///                                 bool              ; receiving objects disabled
+///                                 bool              ; move authenticator disabled
+///                                 version           ; initial shared version
 /// ```
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -351,8 +365,30 @@ pub struct TransactionDenyRulesUpdate {
     /// Consensus round of the update
     #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
     pub round: u64,
-    /// The full active set of deny rules
-    pub deny_rules: DenyRuleSet,
+    /// Addresses added to the sender-or-sponsor deny list.
+    pub added_addresses: BTreeSet<Address>,
+    /// Addresses removed from the sender-or-sponsor deny list.
+    pub removed_addresses: BTreeSet<Address>,
+    /// Objects added to the input-or-receiving deny list.
+    pub added_objects: BTreeSet<ObjectId>,
+    /// Objects removed from the input-or-receiving deny list.
+    pub removed_objects: BTreeSet<ObjectId>,
+    /// Packages added to the dependency deny list.
+    pub added_packages: BTreeSet<ObjectId>,
+    /// Packages removed from the dependency deny list.
+    pub removed_packages: BTreeSet<ObjectId>,
+    /// Denies all package publishing.
+    pub package_publish_disabled: bool,
+    /// Denies all package upgrades.
+    pub package_upgrade_disabled: bool,
+    /// Denies transactions that use shared objects as inputs.
+    pub shared_object_disabled: bool,
+    /// Denies all user transactions (kill switch).
+    pub user_transaction_disabled: bool,
+    /// Denies transactions that contain receiving objects.
+    pub receiving_objects_disabled: bool,
+    /// Denies transactions signed with a Move authenticator.
+    pub move_authenticator_disabled: bool,
     /// The initial version of the deny-rules object that it was shared at.
     pub deny_rules_obj_initial_shared_version: Version,
 }

--- a/crates/iota-sdk-types/src/transaction/serialization.rs
+++ b/crates/iota-sdk-types/src/transaction/serialization.rs
@@ -276,8 +276,8 @@ mod tests {
     use crate::{
         Address, ObjectDigest, ObjectId, ObjectReference, Version,
         transaction::{
-            Argument, DenyRuleSet, EndOfEpochTransactionKind, Input, SharedObjectReference,
-            Transaction, TransactionDenyRulesUpdate, TransactionKind,
+            Argument, EndOfEpochTransactionKind, Input, SharedObjectReference, Transaction,
+            TransactionDenyRulesUpdate, TransactionKind,
         },
     };
 
@@ -380,7 +380,7 @@ mod tests {
     /// [`TransactionKind::TransactionDenyRulesUpdate`].
     ///
     /// Runs one sample per switch (one-hot) so swapping any two bool fields
-    /// changes some expected byte string; the three deny lists carry distinct
+    /// changes some expected byte string; the six delta lists carry distinct
     /// contents and lengths for the same reason.
     #[test]
     fn transaction_deny_rules_update_bcs_pin() {
@@ -404,37 +404,44 @@ mod tests {
             let kind = TransactionKind::TransactionDenyRulesUpdate(TransactionDenyRulesUpdate {
                 epoch: 7,
                 round: 11,
-                deny_rules: DenyRuleSet {
-                    denied_addresses: [Address::new([1; 32]), Address::new([2; 32])].into(),
-                    denied_objects: [ObjectId::new([3; 32])].into(),
-                    denied_packages: [
-                        ObjectId::new([4; 32]),
-                        ObjectId::new([5; 32]),
-                        ObjectId::new([6; 32]),
-                    ]
-                    .into(),
-                    package_publish_disabled,
-                    package_upgrade_disabled,
-                    shared_object_disabled,
-                    user_transaction_disabled,
-                    receiving_objects_disabled,
-                    move_authenticator_disabled,
-                },
+                added_addresses: [Address::new([1; 32]), Address::new([2; 32])].into(),
+                removed_addresses: [Address::new([3; 32])].into(),
+                added_objects: [ObjectId::new([4; 32])].into(),
+                removed_objects: [ObjectId::new([5; 32]), ObjectId::new([6; 32])].into(),
+                added_packages: [
+                    ObjectId::new([7; 32]),
+                    ObjectId::new([8; 32]),
+                    ObjectId::new([9; 32]),
+                ]
+                .into(),
+                removed_packages: [].into(),
+                package_publish_disabled,
+                package_upgrade_disabled,
+                shared_object_disabled,
+                user_transaction_disabled,
+                receiving_objects_disabled,
+                move_authenticator_disabled,
                 deny_rules_obj_initial_shared_version: Version::from_u64(42),
             });
 
             let mut expected = vec![6]; // TransactionKind variant tag
             expected.extend(7u64.to_le_bytes()); // epoch
             expected.extend(11u64.to_le_bytes()); // round
-            expected.push(2); // denied_addresses length
+            expected.push(2); // added_addresses length
             expected.extend([1; 32]);
             expected.extend([2; 32]);
-            expected.push(1); // denied_objects length
+            expected.push(1); // removed_addresses length
             expected.extend([3; 32]);
-            expected.push(3); // denied_packages length
+            expected.push(1); // added_objects length
             expected.extend([4; 32]);
+            expected.push(2); // removed_objects length
             expected.extend([5; 32]);
             expected.extend([6; 32]);
+            expected.push(3); // added_packages length
+            expected.extend([7; 32]);
+            expected.extend([8; 32]);
+            expected.extend([9; 32]);
+            expected.push(0); // removed_packages length
             expected.extend(switches.map(u8::from));
             expected.extend(42u64.to_le_bytes()); // deny_rules_obj_initial_shared_version
 

--- a/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
+++ b/crates/iota-sdk-types/tests/bcs_schema_fuzzing.rs
@@ -415,6 +415,10 @@ impl TestHarness {
         );
         overrides.insert("move-struct", Self::gen_move_struct);
         overrides.insert("deny-rule-set", Self::gen_deny_rule_set);
+        overrides.insert(
+            "transaction-deny-rules-update",
+            Self::gen_transaction_deny_rules_update,
+        );
 
         Self {
             grammar,
@@ -551,6 +555,23 @@ impl TestHarness {
         let value: iota_sdk_types::DenyRuleSet =
             bcs::from_bytes(&bytes).expect("grammar-conformant deny-rule-set must decode");
         bcs::to_bytes(&value).expect("serialize deny-rule-set")
+    }
+
+    /// Generate a canonical `transaction-deny-rules-update` in BCS wire form.
+    ///
+    /// Its six delta lists are set-typed like `deny-rule-set`'s, so the same
+    /// normalization applies: generate from the grammar, decode through the
+    /// type, re-encode.
+    fn gen_transaction_deny_rules_update(&mut self) -> Vec<u8> {
+        let expr = self
+            .grammar
+            .get("transaction-deny-rules-update")
+            .cloned()
+            .expect("transaction-deny-rules-update rule");
+        let bytes = self.gen_expr(expr, 0);
+        let value: iota_sdk_types::TransactionDenyRulesUpdate = bcs::from_bytes(&bytes)
+            .expect("grammar-conformant transaction-deny-rules-update must decode");
+        bcs::to_bytes(&value).expect("serialize transaction-deny-rules-update")
     }
 
     /// Generate a valid `validator-aggregated-signature` in BCS wire form.


### PR DESCRIPTION
## Why

iotaledger/iota#12498's update semantics changed (2026-08-04): the on-chain object applies add/remove deltas against `Table`-backed storage instead of full-state overwrites, so the payload must carry the delta. The kind is inert and has never been emitted on-chain, so the tag-6 payload changes in place, no compatibility machinery.

## What

`TransactionDenyRulesUpdate` now carries `added_*`/`removed_*` `BTreeSet` lists per deny list (disjoint by producer contract; decode normalizes), the six switch states (absolute), epoch/round, and the object's initial shared version. `DenyRuleSet` is unchanged — consensus proposals still announce full state. FFI mirrors updated; the grammar fuzzer gets the same normalization override the `deny-rule-set` rule already has.

## Test plan

Reworked BCS pin with hand-written expected bytes (one-hot over the six switches, distinct contents and lengths across the six delta lists), serde/proptest round-trips, grammar fuzzer with the new override. 