### PR TITLE
fix(grpc-client): enable HTTP/2 adaptive flow-control window

### DIFF
--- a/crates/iota-sdk-grpc-client/src/client.rs
+++ b/crates/iota-sdk-grpc-client/src/client.rs
@@ -75,9 +75,15 @@ impl Client {
             .into());
         }
 
+        // Without this, h2's fixed 64KiB flow-control windows cap each
+        // stream's throughput at window/RTT (~130KB/s on a 500ms link),
+        // which starves high-volume streams such as checkpoint
+        // subscriptions. The adaptive window sizes both windows from a
+        // live bandwidth-delay-product estimate instead.
         let channel = endpoint
             .connect_timeout(Duration::from_secs(5))
             .http2_keep_alive_interval(Duration::from_secs(5))
+            .http2_adaptive_window(true)
             .connect_lazy();
 
         Ok(Self {


### PR DESCRIPTION
## Why

`Client::new` builds its tonic channel with h2's default flow-control windows (64KiB per stream and per connection). HTTP/2 flow control bounds a stream's throughput at `window_size / RTT`, so on a higher-latency link every stream from this client is capped at a few hundred KB/s no matter how much bandwidth is available — e.g. at 500ms RTT the cap is ~130KB/s.

We hit this in production with `iota-data-ingestion-core`, which consumes checkpoints through this client's `stream_checkpoints`: full checkpoint content at tens of KB per checkpoint exceeded the cap, so the indexer's consumption rate fell below checkpoint production and its lag grew without bound, while the process itself sat idle (per-checkpoint processing was ~5ms; the time went to the sender stalling on flow-control window updates).

## What changes

The channel enables `http2_adaptive_window`, so hyper sizes both windows from a live bandwidth-delay-product estimate instead of the fixed 64KiB default. Streams are no longer throughput-capped by latency; behaviour on low-latency links is unchanged. This mirrors what other gRPC implementations (e.g. grpc-go) do by default via BDP estimation.

## Test plan

`cargo check -p iota-sdk-grpc-client`. Verified the failure mode and the fix against a fullnode over a ~500ms link: with default windows the checkpoint stream sustains only single-digit checkpoints/sec; with the window fix it saturates the link and the indexer lag collapses to near zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)