### PR TITLE
feat(iota-sdk-types): add MoveVectorElemTooBig and MoveRawValueTooBig execution errors

### DIFF
--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -279,6 +279,19 @@ pub enum ExecutionError {
     /// wrapped error is the failure produced by the authenticator's
     /// execution.
     MoveAuthenticationError { error: Arc<ExecutionErrorWrapper> },
+    /// Move vector element (passed to MakeMoveVec) is larger than the maximum
+    /// size. The maximum is scaled based on the type of the vector element.
+    MoveVectorElemTooBig {
+        value_size: u64,
+        max_scaled_size: u64,
+    },
+    /// Move value (possibly an upgrade ticket or a dev-inspect value) is larger
+    /// than the maximum size. The maximum is scaled based on the type of the
+    /// value.
+    MoveRawValueTooBig {
+        value_size: u64,
+        max_scaled_size: u64,
+    },
 }
 
 /// Holds an [`ExecutionError`] so it can be nested inside another
@@ -438,6 +451,20 @@ impl From<iota_sdk::types::ExecutionError> for ExecutionError {
                     error: Arc::new(ExecutionErrorWrapper(*error)),
                 }
             }
+            iota_sdk::types::ExecutionError::MoveVectorElemTooBig {
+                value_size,
+                max_scaled_size,
+            } => Self::MoveVectorElemTooBig {
+                value_size,
+                max_scaled_size,
+            },
+            iota_sdk::types::ExecutionError::MoveRawValueTooBig {
+                value_size,
+                max_scaled_size,
+            } => Self::MoveRawValueTooBig {
+                value_size,
+                max_scaled_size,
+            },
             _ => unimplemented!("a new enum variant was added and needs to be handled"),
         }
     }
@@ -559,6 +586,20 @@ impl From<ExecutionError> for iota_sdk::types::ExecutionError {
             ExecutionError::InvalidLinkage => Self::InvalidLinkage,
             ExecutionError::MoveAuthenticationError { error } => Self::MoveAuthenticationError {
                 error: Box::new(error.0.clone()),
+            },
+            ExecutionError::MoveVectorElemTooBig {
+                value_size,
+                max_scaled_size,
+            } => Self::MoveVectorElemTooBig {
+                value_size,
+                max_scaled_size,
+            },
+            ExecutionError::MoveRawValueTooBig {
+                value_size,
+                max_scaled_size,
+            } => Self::MoveRawValueTooBig {
+                value_size,
+                max_scaled_size,
             },
         }
     }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -210,6 +210,8 @@ execution-error = %d00                               ; InsufficientGas
                 / %d37 (size *object-id) u64         ; ExecutionCancelledDueToSharedObjectCongestionV2
                 / %d38                               ; InvalidLinkage
                 / %d39 execution-error               ; MoveAuthenticationError
+                / %d40 u64 u64                       ; MoveVectorElemTooBig
+                / %d41 u64 u64                       ; MoveRawValueTooBig
 
 execution-status = %d00                                     ; Success
                  / %d01 execution-error (%d00 / %d01 u64)   ; Failure

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -202,6 +202,8 @@ fn display_congested_objects(objects: &[ObjectId]) -> impl core::fmt::Display + 
 /// execution-cancelled-due-to-shared-object-congestion-v2 = %d37 (vector object-id) u64
 /// invalid-linkage                                        = %d38
 /// move-authentication-error                              = %d39 execution-error
+/// move-vector-elem-too-big                               = %d40 u64 u64
+/// move-raw-value-too-big                                 = %d41 u64 u64
 /// ```
 // WARNING: The variant order of this enum is protocol-significant. Each variant's position
 // determines its BCS discriminant (the integer sent over the wire).
@@ -416,6 +418,29 @@ pub enum ExecutionError {
     #[error("Move authentication failed: {error}")]
     #[cfg_attr(feature = "proptest", weight(0))]
     MoveAuthenticationError { error: Box<ExecutionError> },
+    /// Move vector element (passed to MakeMoveVec) is larger than the maximum
+    /// size. The maximum is scaled based on the type of the vector element.
+    #[error(
+        "Move vector element (passed to MakeMoveVec) with size {value_size} is larger than the maximum size {max_scaled_size}. Note that this maximum is scaled based on the type of the vector element."
+    )]
+    MoveVectorElemTooBig {
+        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+        value_size: u64,
+        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+        max_scaled_size: u64,
+    },
+    /// Move value (possibly an upgrade ticket or a dev-inspect value) is larger
+    /// than the maximum size. The maximum is scaled based on the type of the
+    /// value.
+    #[error(
+        "Move value (possibly an upgrade ticket or a dev-inspect value) with size {value_size} is larger than the maximum size {max_scaled_size}. Note that this maximum is scaled based on the type of the value."
+    )]
+    MoveRawValueTooBig {
+        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+        value_size: u64,
+        #[cfg_attr(feature = "serde", serde(with = "crate::_serde::ReadableDisplay"))]
+        max_scaled_size: u64,
+    },
 }
 
 impl ExecutionError {
@@ -460,6 +485,8 @@ impl ExecutionError {
         ExecutionCancelledDueToSharedObjectCongestionV2,
         InvalidLinkage,
         MoveAuthenticationError,
+        MoveVectorElemTooBig,
+        MoveRawValueTooBig,
     );
 
     pub fn command_argument_error(kind: CommandArgumentError, argument: u16) -> Self {


### PR DESCRIPTION
# Description

Downstream support for porting Sui #21905 (relax MakeMoveVec size limits + better error messages). The node-side adapter constructs these variants, so they must exist in `ExecutionError` (which IOTA keeps in iota-sdk-types, not iota-types).

- Add both variants to `ExecutionError`, appended at the END (ExecutionFailureStatus) to preserve existing discriminants.
- Mirror them in `iota-sdk-ffi` (enum + both `From` conversions).

# Links to any relevant issues

Closes part of #[10831](https://github.com/orgs/iotaledger/projects/79/views/26?pane=issue&itemId=167511142&issue=iotaledger%7Ciota%7C10831). Upstream PR - №21905([6eeadd2f5a3e87b8a3bdd1927c23b435da8fbc55](https://github.com/iotaledger/iota/commit/6eeadd2f5a3e87b8a3bdd1927c23b435da8fbc55))

