### PR TITLE
chore: add node team as codeowners for gRPC crates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @iotaledger/dev-tools
+/crates/iota-sdk-grpc-*/ @iotaledger/node


### PR DESCRIPTION
Adds @iotaledger/node as codeowners for the gRPC crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)