### PR TITLE
fix(grpc)!: give execute_transaction(s) its own read mask type

### DIFF
--- a/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
+++ b/crates/iota-sdk-grpc-client/src/api/execution/execute.rs
@@ -4,7 +4,7 @@
 //! High-level API for transaction execution.
 
 use iota_grpc_types::{
-    read_mask_fields::{IntoReadMask, TransactionReadMask},
+    read_mask_fields::{ExecuteTransactionReadMask, IntoReadMask},
     v1::{
         signatures::{UserSignature as ProtoUserSignature, UserSignatures},
         transaction::ExecutedTransaction,
@@ -36,7 +36,7 @@ impl Client {
     /// - `result.object_changes()` - Get object changes (if requested)
     ///
     /// The `read_mask` controls which fields the server returns; use
-    /// `TransactionReadMask::default()` for the default mask. Pass a
+    /// `ExecuteTransactionReadMask::default()` for the default mask. Pass a
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -51,14 +51,14 @@ impl Client {
     ///
     /// ```no_run
     /// # use iota_sdk_grpc_client::Client;
-    /// # use iota_sdk_grpc_client::read_mask_fields::TransactionReadMask;
+    /// # use iota_sdk_grpc_client::read_mask_fields::ExecuteTransactionReadMask;
     /// # use iota_types::SignedTransaction;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::new_localnet()?;
     ///
     /// let signed_tx: SignedTransaction = todo!();
     /// let result = client
-    ///     .execute_transaction(signed_tx, None, TransactionReadMask::default())
+    ///     .execute_transaction(signed_tx, None, ExecuteTransactionReadMask::default())
     ///     .await?;
     ///
     /// let effects = result.body().effects()?.effects()?;
@@ -75,7 +75,7 @@ impl Client {
         &self,
         signed_transaction: SignedTransaction,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
-        read_mask: impl IntoReadMask<TransactionReadMask>,
+        read_mask: impl IntoReadMask<ExecuteTransactionReadMask>,
     ) -> Result<MetadataEnvelope<ExecutedTransaction>> {
         self.execute_transactions(
             vec![signed_transaction],
@@ -96,8 +96,8 @@ impl Client {
     /// the per-item error returned by the server.
     ///
     /// The `read_mask` controls which fields the server returns for each
-    /// `ExecutedTransaction`; use `TransactionReadMask::default()` for the
-    /// default mask. Pass a
+    /// `ExecutedTransaction`; use `ExecuteTransactionReadMask::default()` for
+    /// the default mask. Pass a
     /// [`TransactionField`](iota_grpc_types::read_mask_fields::TransactionField)
     /// or any slice/array/vec of fields — conversion is automatic.
     ///
@@ -117,7 +117,7 @@ impl Client {
         &self,
         transactions: Vec<SignedTransaction>,
         checkpoint_inclusion_timeout_ms: impl Into<Option<u64>>,
-        read_mask: impl IntoReadMask<TransactionReadMask>,
+        read_mask: impl IntoReadMask<ExecuteTransactionReadMask>,
     ) -> Result<MetadataEnvelope<Vec<Result<ExecutedTransaction>>>> {
         let read_mask = read_mask.into_read_mask();
         let checkpoint_inclusion_timeout_ms = checkpoint_inclusion_timeout_ms.into();

--- a/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
+++ b/crates/iota-sdk-grpc-client/src/transaction_builder_client.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 
 use iota_grpc_types::{
     read_mask_fields::{
-        EpochField, EpochReadMask, ObjectReadMask, OwnedObjectReadMask, SimulateReadMask,
-        TransactionField, TransactionReadMask,
+        EpochField, EpochReadMask, ExecuteTransactionReadMask, ObjectReadMask, OwnedObjectReadMask,
+        SimulateReadMask, TransactionField, TransactionReadMask,
     },
     v1::transaction_execution_service::SimulatedTransaction,
 };
@@ -237,7 +237,11 @@ impl TransactionBuilderClient for Client {
         };
         // The default execute read mask includes `effects`.
         let result = self
-            .execute_transaction(signed_transaction, None, TransactionReadMask::default())
+            .execute_transaction(
+                signed_transaction,
+                None,
+                ExecuteTransactionReadMask::default(),
+            )
             .await?
             .into_inner();
         let effects = result.effects()?.effects()?;

--- a/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
+++ b/crates/iota-sdk-grpc-types/src/read_mask_fields.rs
@@ -32,9 +32,10 @@ use std::borrow::Cow;
 use crate::{
     field_mask_normalize,
     read_masks::{
-        GET_CHECKPOINT_READ_MASK, GET_EPOCH_READ_MASK, GET_OBJECTS_READ_MASK,
-        GET_SERVICE_INFO_READ_MASK, GET_TRANSACTIONS_READ_MASK, LIST_DYNAMIC_FIELDS_READ_MASK,
-        LIST_OWNED_OBJECTS_READ_MASK, SIMULATE_TRANSACTIONS_READ_MASK,
+        EXECUTE_TRANSACTIONS_READ_MASK, GET_CHECKPOINT_READ_MASK, GET_EPOCH_READ_MASK,
+        GET_OBJECTS_READ_MASK, GET_SERVICE_INFO_READ_MASK, GET_TRANSACTIONS_READ_MASK,
+        LIST_DYNAMIC_FIELDS_READ_MASK, LIST_OWNED_OBJECTS_READ_MASK,
+        SIMULATE_TRANSACTIONS_READ_MASK,
     },
 };
 
@@ -417,8 +418,17 @@ define_field_paths! {
 }
 
 define_scoped_read_mask! {
-    /// Scoped read mask for `get_transactions` and `execute_transaction(s)`.
+    /// Scoped read mask for `get_transactions`.
     pub struct TransactionReadMask from TransactionField default GET_TRANSACTIONS_READ_MASK;
+}
+
+define_scoped_read_mask! {
+    /// Scoped read mask for `execute_transaction(s)`.
+    ///
+    /// Its `default()` is [`EXECUTE_TRANSACTIONS_READ_MASK`], matching the
+    /// server-side fallback: the transaction digest, `effects`, `events` and
+    /// the input/output objects.
+    pub struct ExecuteTransactionReadMask from TransactionField default EXECUTE_TRANSACTIONS_READ_MASK;
 }
 
 // =============================================================================
@@ -926,5 +936,20 @@ mod tests {
         let fields = [ObjectField::REFERENCE, ObjectField::BCS];
         let mask: ObjectReadMask = (&fields).into();
         assert_eq!(mask, "bcs,reference");
+    }
+
+    #[test]
+    fn execute_default_mask_includes_effects() {
+        let mask = ExecuteTransactionReadMask::default();
+        assert_eq!(mask, EXECUTE_TRANSACTIONS_READ_MASK);
+        assert!(mask.as_str().split(',').any(|path| path == "effects"));
+        // The `get_transactions` default does not, so the two endpoints must
+        // not share a mask type.
+        assert!(
+            !TransactionReadMask::default()
+                .as_str()
+                .split(',')
+                .any(|path| path == "effects")
+        );
     }
 }

--- a/crates/iota-sdk-grpc-types/src/read_masks.rs
+++ b/crates/iota-sdk-grpc-types/src/read_masks.rs
@@ -14,7 +14,8 @@
 //!
 //! Constants like [`GET_CHECKPOINT_READ_MASK`] are the canonical defaults used
 //! by both the server (as fallback when no mask is provided) and the client
-//! (when `None` is passed as the mask).
+//! (as the `Default` of the endpoint's mask type in
+//! [`read_mask_fields`](crate::read_mask_fields)).
 //!
 //! ## Per-method field constants
 //!


### PR DESCRIPTION
## Problem

`TransactionReadMask::default()` is `GET_TRANSACTIONS_READ_MASK` — `transaction, signatures, checkpoint, timestamp` — which has no `effects`. That type was also the parameter type of `execute_transaction(s)`.

The client always sends the mask, so passing it to execute suppressed the server's `EXECUTE_TRANSACTIONS_READ_MASK` fallback and responses came back without effects: `result.effects()` failed with `FIELD_MISSING`. That broke `TransactionBuilderClient::execute_tx`, the documented example, and the gRPC execute simtests downstream (iotaledger/iota#12547).

## Fix

Add `ExecuteTransactionReadMask` (default `EXECUTE_TRANSACTIONS_READ_MASK`) and take it in `execute_transaction` / `execute_transactions`, so the get-transactions default no longer type-checks for execute.

Source-breaking only for call sites naming `TransactionReadMask` on an execute call — `TransactionField` constants and their slices/arrays still convert automatically.

## Verification

Crate tests (incl. a new `execute_default_mask_includes_effects` regression test), doctests, clippy, rustdoc, `cargo +nightly fmt --check` and `dprint check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)