### PR TITLE
feat: add random() to the private key types

### DIFF
--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -31,6 +31,8 @@ secp256r1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 passkey = ["secp256r1", "dep:sha2"]
 secp256k1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 bech32 = ["dep:bech32", "signature/std"]
+# `random()` constructors backed by the operating system's RNG
+rand = ["dep:rand_core", "rand_core/getrandom"]
 # PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519, p256 and
 # k256 are pulled in purely as encoders/decoders here; the actual signing and
 # verification always go through fastcrypto.

--- a/crates/iota-sdk-crypto/Cargo.toml
+++ b/crates/iota-sdk-crypto/Cargo.toml
@@ -31,7 +31,6 @@ secp256r1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 passkey = ["secp256r1", "dep:sha2"]
 secp256k1 = ["dep:base64ct", "dep:fastcrypto", "dep:rand_core", "dep:zeroize"]
 bech32 = ["dep:bech32", "signature/std"]
-# `random()` constructors backed by the operating system's RNG
 rand = ["dep:rand_core", "rand_core/getrandom"]
 # PKCS#8/PEM support. fastcrypto has no PKCS#8 codec, so ed25519, p256 and
 # k256 are pulled in purely as encoders/decoders here; the actual signing and

--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -73,6 +73,14 @@ impl Ed25519PrivateKey {
         Self::new(buf)
     }
 
+    /// Generate a new private key using the operating system's random number
+    /// generator.
+    #[cfg(feature = "rand")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
+    pub fn random() -> Self {
+        Self::generate(rand_core::OsRng)
+    }
+
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
     #[cfg(feature = "pem")]
@@ -459,5 +467,22 @@ mod tests {
         Ed25519PrivateKey::from_base64("not-base64!").unwrap_err();
         // valid base64 but wrong length
         Ed25519PrivateKey::from_base64("aGVsbG8=").unwrap_err();
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn random_key_signing() {
+        let signer = Ed25519PrivateKey::random();
+        assert_ne!(
+            signer.public_key(),
+            Ed25519PrivateKey::random().public_key()
+        );
+
+        let message = PersonalMessage(b"hello".into());
+        let signature = signer.sign_personal_message(&message).unwrap();
+        signer
+            .verifying_key()
+            .verify_personal_message(&message, &signature)
+            .unwrap();
     }
 }

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -91,6 +91,14 @@ impl Secp256k1PrivateKey {
         }
     }
 
+    /// Generate a new private key using the operating system's random number
+    /// generator.
+    #[cfg(feature = "rand")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
+    pub fn random() -> Self {
+        Self::generate(rand_core::OsRng)
+    }
+
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
     #[cfg(feature = "pem")]
@@ -515,5 +523,22 @@ mod tests {
         let decoded = Secp256k1PrivateKey::from_base64(&b64).unwrap();
         assert_eq!(decoded.to_bytes(), signer.to_bytes());
         assert_eq!(decoded.to_base64(), b64);
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn random_key_signing() {
+        let signer = Secp256k1PrivateKey::random();
+        assert_ne!(
+            signer.public_key(),
+            Secp256k1PrivateKey::random().public_key()
+        );
+
+        let message = PersonalMessage(b"hello".into());
+        let signature = signer.sign_personal_message(&message).unwrap();
+        signer
+            .verifying_key()
+            .verify_personal_message(&message, &signature)
+            .unwrap();
     }
 }

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -91,6 +91,14 @@ impl Secp256r1PrivateKey {
         }
     }
 
+    /// Generate a new private key using the operating system's random number
+    /// generator.
+    #[cfg(feature = "rand")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "rand")))]
+    pub fn random() -> Self {
+        Self::generate(rand_core::OsRng)
+    }
+
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
     #[cfg(feature = "pem")]
@@ -468,5 +476,22 @@ mod tests {
         let decoded = Secp256r1PrivateKey::from_base64(&b64).unwrap();
         assert_eq!(decoded.to_bytes(), signer.to_bytes());
         assert_eq!(decoded.to_base64(), b64);
+    }
+
+    #[cfg(feature = "rand")]
+    #[test]
+    fn random_key_signing() {
+        let signer = Secp256r1PrivateKey::random();
+        assert_ne!(
+            signer.public_key(),
+            Secp256r1PrivateKey::random().public_key()
+        );
+
+        let message = PersonalMessage(b"hello".into());
+        let signature = signer.sign_personal_message(&message).unwrap();
+        signer
+            .verifying_key()
+            .verify_personal_message(&message, &signature)
+            .unwrap();
     }
 }

--- a/crates/iota-sdk/Cargo.toml
+++ b/crates/iota-sdk/Cargo.toml
@@ -58,7 +58,7 @@ txn-builder = ["dep:iota-transaction-builder"]
 # Types
 types = ["dep:iota-types"]
 serde = ["types", "iota-types/serde"]
-rand = ["types", "iota-types/rand"]
+rand = ["types", "iota-types/rand", "iota-crypto?/rand"]
 hash = ["types", "iota-types/hash"]
 proptest = ["types", "iota-types/proptest"]
 


### PR DESCRIPTION
# Description of change

Adds `random()` to `Ed25519PrivateKey`, `Secp256k1PrivateKey`, and `Secp256r1PrivateKey`, so callers can write `Ed25519PrivateKey::random()` instead of threading an rng into `generate` for the common case.

Mirrors the existing `iota-sdk-types` pattern (`Address::random()`): a `rand` feature enabling `rand_core/getrandom`, with `random()` delegating to `generate(rand_core::OsRng)`. The umbrella crate forwards the feature (weak dependency, in default features). No new dependencies, no breaking changes; `SimpleKeypair` is left out since it has no `generate`.

Motivation: the iota monorepo's test code now spells `AccountKeyPair::generate(rand::thread_rng())` at several hundred call sites (iotaledger/iota#12568); this shortens them to `::random()`.

## Links to any relevant issues

-

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [x] Patch-specific tests (correctness, functionality coverage)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Per-type tests (distinct random keys, sign/verify round-trip); clippy clean under `--all-features --all-targets`; feature combinations (none, each scheme, `rand` alone, `rand`+scheme) all compile; `wasm32-unknown-unknown` checked for `iota-sdk-crypto` and the umbrella.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8HDhvVEyBujVabtPaZtoe)_