### PR TITLE
chore: put doc comments before attributes

### DIFF
--- a/crates/iota-sdk-crypto/src/ed25519.rs
+++ b/crates/iota-sdk-crypto/src/ed25519.rs
@@ -73,19 +73,19 @@ impl Ed25519PrivateKey {
         Self::new(buf)
     }
 
-    #[cfg(feature = "pem")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
+    #[cfg(feature = "pem")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
             .map_err(SignatureError::from_source)
             .and_then(Self::from_pkcs8)
     }
 
+    /// Serialize this private key as DER-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as DER-encoded PKCS#8
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
@@ -95,18 +95,18 @@ impl Ed25519PrivateKey {
             .map(|der| der.as_bytes().to_owned())
     }
 
+    /// Deserialize PKCS#8-encoded private key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
             .map_err(SignatureError::from_source)
             .and_then(Self::from_pkcs8)
     }
 
+    /// Serialize this private key as PEM-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as PEM-encoded PKCS#8
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
@@ -270,18 +270,18 @@ impl Ed25519VerifyingKey {
         )
     }
 
+    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         pkcs8::DecodePublicKey::from_public_key_der(bytes)
             .map_err(SignatureError::from_source)
             .and_then(Self::from_pkcs8)
     }
 
+    /// Serialize this public key as DER-encoded data
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key as DER-encoded data
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
@@ -291,18 +291,18 @@ impl Ed25519VerifyingKey {
             .map(|der| der.into_vec())
     }
 
+    /// Deserialize public key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         pkcs8::DecodePublicKey::from_public_key_pem(s)
             .map_err(SignatureError::from_source)
             .and_then(Self::from_pkcs8)
     }
 
+    /// Serialize this public key into PEM format
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key into PEM format
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 

--- a/crates/iota-sdk-crypto/src/secp256k1.rs
+++ b/crates/iota-sdk-crypto/src/secp256k1.rs
@@ -91,19 +91,19 @@ impl Secp256k1PrivateKey {
         }
     }
 
-    #[cfg(feature = "pem")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
+    #[cfg(feature = "pem")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
             .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this private key as DER-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as DER-encoded PKCS#8
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use k256::pkcs8::EncodePrivateKey;
 
@@ -113,18 +113,18 @@ impl Secp256k1PrivateKey {
             .map(|der| der.as_bytes().to_owned())
     }
 
+    /// Deserialize PKCS#8-encoded private key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
             .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this private key as PEM-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as PEM-encoded PKCS#8
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
@@ -265,18 +265,18 @@ impl Secp256k1VerifyingKey {
         )
     }
 
+    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePublicKey::from_public_key_der(bytes)
             .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this public key as DER-encoded data
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key as DER-encoded data
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
@@ -286,18 +286,18 @@ impl Secp256k1VerifyingKey {
             .map(|der| der.into_vec())
     }
 
+    /// Deserialize public key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         k256::pkcs8::DecodePublicKey::from_public_key_pem(s)
             .map(Self::from_k256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this public key into PEM
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key into PEM
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 

--- a/crates/iota-sdk-crypto/src/secp256r1.rs
+++ b/crates/iota-sdk-crypto/src/secp256r1.rs
@@ -91,19 +91,19 @@ impl Secp256r1PrivateKey {
         }
     }
 
-    #[cfg(feature = "pem")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
     /// format).
+    #[cfg(feature = "pem")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePrivateKey::from_pkcs8_der(bytes)
             .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this private key as DER-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as DER-encoded PKCS#8
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use p256::pkcs8::EncodePrivateKey;
 
@@ -113,18 +113,18 @@ impl Secp256r1PrivateKey {
             .map(|der| der.as_bytes().to_owned())
     }
 
+    /// Deserialize PKCS#8-encoded private key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize PKCS#8-encoded private key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePrivateKey::from_pkcs8_pem(s)
             .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this private key as PEM-encoded PKCS#8
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this private key as PEM-encoded PKCS#8
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePrivateKey;
 
@@ -265,18 +265,18 @@ impl Secp256r1VerifyingKey {
         )
     }
 
+    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from ASN.1 DER-encoded data (binary format).
     pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePublicKey::from_public_key_der(bytes)
             .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this public key as DER-encoded data
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key as DER-encoded data
     pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
         use pkcs8::EncodePublicKey;
 
@@ -286,18 +286,18 @@ impl Secp256r1VerifyingKey {
             .map(|der| der.into_vec())
     }
 
+    /// Deserialize public key from PEM.
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Deserialize public key from PEM.
     pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
         p256::pkcs8::DecodePublicKey::from_public_key_pem(s)
             .map(Self::from_p256)
             .map_err(SignatureError::from_source)
     }
 
+    /// Serialize this public key into PEM
     #[cfg(feature = "pem")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-    /// Serialize this public key into PEM
     pub fn to_pem(&self) -> Result<String, SignatureError> {
         use pkcs8::EncodePublicKey;
 

--- a/crates/iota-sdk-crypto/src/simple.rs
+++ b/crates/iota-sdk-crypto/src/simple.rs
@@ -217,10 +217,10 @@ mod keypair {
             }
         }
 
-        #[cfg(feature = "pem")]
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
         /// Deserialize PKCS#8 private key from ASN.1 DER-encoded data (binary
         /// format).
+        #[cfg(feature = "pem")]
+        #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
         pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
             let private_key =
                 pkcs8::PrivateKeyInfo::try_from(bytes).map_err(SignatureError::from_source)?;
@@ -261,9 +261,9 @@ mod keypair {
             .map(|inner| Self { inner })
         }
 
+        /// Serialize this private key as DER-encoded PKCS#8
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Serialize this private key as DER-encoded PKCS#8
         pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
             match &self.inner {
                 #[cfg(feature = "ed25519")]
@@ -275,9 +275,9 @@ mod keypair {
             }
         }
 
+        /// Deserialize PKCS#8-encoded private key from PEM.
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Deserialize PKCS#8-encoded private key from PEM.
         pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
             use pkcs8::der::pem::PemLabel;
 
@@ -288,9 +288,9 @@ mod keypair {
             Self::from_der(doc.as_bytes())
         }
 
+        /// Serialize this private key as DER-encoded PKCS#8
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Serialize this private key as DER-encoded PKCS#8
         pub fn to_pem(&self) -> Result<String, SignatureError> {
             match &self.inner {
                 #[cfg(feature = "ed25519")]
@@ -401,9 +401,9 @@ mod keypair {
             }
         }
 
+        /// Deserialize public key from ASN.1 DER-encoded data (binary format).
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Deserialize public key from ASN.1 DER-encoded data (binary format).
         pub fn from_der(bytes: &[u8]) -> Result<Self, SignatureError> {
             let public_key = pkcs8::SubjectPublicKeyInfoRef::try_from(bytes)
                 .map_err(SignatureError::from_source)?;
@@ -444,9 +444,9 @@ mod keypair {
             .map(|inner| Self { inner })
         }
 
+        /// Serialize this public key as DER-encoded data
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Serialize this public key as DER-encoded data
         pub fn to_der(&self) -> Result<Vec<u8>, SignatureError> {
             match &self.inner {
                 #[cfg(feature = "ed25519")]
@@ -458,9 +458,9 @@ mod keypair {
             }
         }
 
+        /// Deserialize public key from PEM.
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Deserialize public key from PEM.
         pub fn from_pem(s: &str) -> Result<Self, SignatureError> {
             use pkcs8::der::pem::PemLabel;
 
@@ -470,9 +470,9 @@ mod keypair {
             Self::from_der(doc.as_bytes())
         }
 
+        /// Serialize this public key as PEM
         #[cfg(feature = "pem")]
         #[cfg_attr(doc_cfg, doc(cfg(feature = "pem")))]
-        /// Serialize this public key as PEM
         pub fn to_pem(&self) -> Result<String, SignatureError> {
             match &self.inner {
                 #[cfg(feature = "ed25519")]


### PR DESCRIPTION
# Description of change

Moves doc comments above `#[cfg]`/`#[cfg_attr]` attributes at the 32 pre-existing places in `iota-sdk-crypto` that had them the other way around (follow-up to the [#1310 discussion](https://github.com/iotaledger/iota-rust-sdk/pull/1310#discussion_r3727400127)). No code changes.

## Links to any relevant issues

-

## How the change has been tested

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that new and existing unit tests pass locally with my changes

Comment-only reorder; `cargo check --all-features` and formatting are clean.