### PR TITLE
feat: add to_bcs/from_bcs/to_base64/from_base64 to more types

### DIFF
--- a/crates/iota-sdk-types/src/hash.rs
+++ b/crates/iota-sdk-types/src/hash.rs
@@ -287,8 +287,6 @@ pub struct MissingSignatureError {
 #[cfg(feature = "serde")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
 mod type_digest {
-    use base64ct::Encoding;
-
     use super::Hasher;
     use crate::{
         CheckpointContentsDigest, CheckpointDigest, Digest, ObjectDigest, SenderSignedDataDigest,
@@ -325,56 +323,12 @@ mod type_digest {
             const SALT: &str = "TransactionData::";
             type_digest(SALT, &self).into()
         }
-
-        /// Serialize the transaction as a `Vec<u8>` of BCS bytes.
-        pub fn to_bcs(&self) -> Vec<u8> {
-            bcs::to_bytes(self).expect("bcs serialization failed")
-        }
-
-        /// Serialize the transaction as a base64-encoded string.
-        pub fn to_base64(&self) -> String {
-            base64ct::Base64::encode_string(&self.to_bcs())
-        }
-
-        /// Deserialize a transaction from a `Vec<u8>` of BCS bytes.
-        pub fn from_bcs(bytes: &[u8]) -> Result<Self, bcs::Error> {
-            bcs::from_bytes::<Self>(bytes)
-        }
-
-        /// Deserialize a transaction from a base64-encoded string.
-        pub fn from_base64(bytes: &str) -> Result<Self, bcs::Error> {
-            let decoded = base64ct::Base64::decode_vec(bytes)
-                .map_err(|e| bcs::Error::Custom(e.to_string()))?;
-            Self::from_bcs(&decoded)
-        }
     }
 
     impl crate::TransactionV1 {
         pub fn digest(&self) -> TransactionDigest {
             const SALT: &str = "TransactionData::";
             type_digest(SALT, &crate::Transaction::V1(self.clone())).into()
-        }
-
-        /// Serialize the transaction as a `Vec<u8>` of BCS bytes.
-        pub fn to_bcs(&self) -> Vec<u8> {
-            bcs::to_bytes(self).expect("bcs serialization failed")
-        }
-
-        /// Serialize the transaction as a base64-encoded string.
-        pub fn to_base64(&self) -> String {
-            base64ct::Base64::encode_string(&self.to_bcs())
-        }
-
-        /// Deserialize a transaction from a `Vec<u8>` of BCS bytes.
-        pub fn from_bcs(bytes: &[u8]) -> Result<Self, bcs::Error> {
-            bcs::from_bytes::<Self>(bytes)
-        }
-
-        /// Deserialize a transaction from a base64-encoded string.
-        pub fn from_base64(bytes: &str) -> Result<Self, bcs::Error> {
-            let decoded = base64ct::Base64::decode_vec(bytes)
-                .map_err(|e| bcs::Error::Custom(e.to_string()))?;
-            Self::from_bcs(&decoded)
         }
     }
 

--- a/crates/iota-sdk-types/src/lib.rs
+++ b/crates/iota-sdk-types/src/lib.rs
@@ -191,6 +191,53 @@ pub use version::Version;
 #[cfg(all(test, feature = "serde", feature = "proptest"))]
 mod serialization_proptests;
 
+#[cfg(feature = "serde")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "serde")))]
+mod bcs_base64 {
+    use base64ct::Encoding;
+
+    macro_rules! impl_bcs_base64 {
+        ($($type:ident),* $(,)?) => {
+            $(
+            impl crate::$type {
+                paste::paste! {
+                    #[doc = "Serialize this `" $type "` as a `Vec<u8>` of BCS bytes."]
+                    pub fn to_bcs(&self) -> Vec<u8> {
+                        bcs::to_bytes(self).expect("bcs serialization failed")
+                    }
+
+                    #[doc = "Serialize this `" $type "` as a base64-encoded string of its BCS bytes."]
+                    pub fn to_base64(&self) -> String {
+                        base64ct::Base64::encode_string(&self.to_bcs())
+                    }
+
+                    #[doc = "Deserialize a `" $type "` from BCS bytes."]
+                    pub fn from_bcs(bytes: &[u8]) -> Result<Self, bcs::Error> {
+                        bcs::from_bytes::<Self>(bytes)
+                    }
+
+                    #[doc = "Deserialize a `" $type "` from a base64-encoded string of its BCS bytes."]
+                    pub fn from_base64(bytes: &str) -> Result<Self, bcs::Error> {
+                        let decoded = base64ct::Base64::decode_vec(bytes)
+                            .map_err(|e| bcs::Error::Custom(e.to_string()))?;
+                        Self::from_bcs(&decoded)
+                    }
+                }
+            }
+            )*
+        };
+    }
+
+    impl_bcs_base64!(
+        Object,
+        SenderSignedTransaction,
+        Transaction,
+        TransactionEffects,
+        TransactionKind,
+        TransactionV1,
+    );
+}
+
 /// Returns the next array in byte-increasing order.
 pub const fn next_lexicographical_array<const N: usize>(array: &[u8; N]) -> [u8; N] {
     match next_lexicographical_array_opt(array) {

--- a/crates/iota-sdk-types/src/serialization_proptests.rs
+++ b/crates/iota-sdk-types/src/serialization_proptests.rs
@@ -156,3 +156,24 @@ serialization_test!(Identifier);
 serialization_test!(StructTag);
 serialization_test!(TypeTag);
 serialization_test!(Version);
+
+macro_rules! bcs_base64_test {
+    ($type:ident) => {
+        paste::item! {
+            #[cfg_attr(target_arch = "wasm32", proptest(cases = 50))]
+            #[cfg_attr(not(target_arch = "wasm32"), proptest)]
+            #[allow(non_snake_case)]
+            fn [< test_bcs_base64_roundtrip_ $type >] (instance: $type) {
+                assert_eq!(instance, $type::from_bcs(&instance.to_bcs()).unwrap());
+                assert_eq!(instance, $type::from_base64(&instance.to_base64()).unwrap());
+            }
+        }
+    };
+}
+
+bcs_base64_test!(Object);
+bcs_base64_test!(SenderSignedTransaction);
+bcs_base64_test!(Transaction);
+bcs_base64_test!(TransactionEffects);
+bcs_base64_test!(TransactionKind);
+bcs_base64_test!(TransactionV1);

--- a/crates/iota-sdk-types/src/serialization_proptests.rs
+++ b/crates/iota-sdk-types/src/serialization_proptests.rs
@@ -162,8 +162,7 @@ macro_rules! bcs_base64_test {
         paste::item! {
             #[cfg_attr(target_arch = "wasm32", proptest(cases = 50))]
             #[cfg_attr(not(target_arch = "wasm32"), proptest)]
-            #[allow(non_snake_case)]
-            fn [< test_bcs_base64_roundtrip_ $type >] (instance: $type) {
+            fn [< test_bcs_base64_roundtrip_ $type:snake >] (instance: $type) {
                 assert_eq!(instance, $type::from_bcs(&instance.to_bcs()).unwrap());
                 assert_eq!(instance, $type::from_base64(&instance.to_base64()).unwrap());
             }


### PR DESCRIPTION
## Why

Object, SenderSignedTransaction, TransactionEffects and TransactionKind travel as base64 of their BCS bytes throughout the node and the clients, and every consumer hand-rolls the base64 + `bcs::from_bytes` pair. iotaledger/iota#12587 counts about 30 such sites blocked on these four types alone; this is the prerequisite for cleaning them up.

## What changes

The four methods `Transaction`/`TransactionV1` already had now come from one shared definition covering all six types. That moves them off the `hash` feature onto `serde`, so they are available in more configurations than before — additive, no signature changes.

## Test plan

`cargo test -p iota-sdk-types --all-features` — the new proptests round-trip each of the six types through both BCS and base64. Workspace `cargo check --all-features` and clippy clean.

[run-ci]

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQt57NBVJweSsQZhLFvJZy)_