### PR TITLE
chore: use US English spellings in comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ the diff, delete it. Repeat until a pass deletes nothing.
 
 ## What changes
 
-<!-- The change at the level of concepts: behaviour that differs, invariants that now hold,
+<!-- The change at the level of concepts: behavior that differs, invariants that now hold,
      the new shape. Not the symbols that moved. -->
 
 ## Test plan

--- a/bindings/wasm/src/ts/index.web.ts
+++ b/bindings/wasm/src/ts/index.web.ts
@@ -8,7 +8,7 @@ import * as iota_sdk_ffi from "./iota_sdk_ffi";
 import * as bg from "./wasm-bindgen/index_bg.js";
 
 /**
- * Load and initialise the WASM module.
+ * Load and initialize the WASM module.
  *
  * @param input - One of:
  *   - `string` or `URL`: location of the `.wasm` binary to fetch (browser).

--- a/crates/iota-sdk-grpc-client/src/api/common.rs
+++ b/crates/iota-sdk-grpc-client/src/api/common.rs
@@ -943,7 +943,7 @@ mod tests {
     }
 
     #[test]
-    fn not_found_is_recognised_at_the_call_and_item_level() {
+    fn not_found_is_recognized_at_the_call_and_item_level() {
         let item_level = Error::Server(Status {
             code: tonic::Code::NotFound.into(),
             message: String::new(),

--- a/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/filter.proto
+++ b/crates/iota-sdk-grpc-types/proto/iota/grpc/v1/filter.proto
@@ -193,7 +193,7 @@ message CommandFilter {
 
 // Filter by transaction execution status.
 // Set `success` to `true` to match successful transactions,
-// or `false` to match failed transactions (cancelled, execution error, etc.).
+// or `false` to match failed transactions (canceled, execution error, etc.).
 message ExecutionStatusFilter {
   option (iota.grpc.message_accessors) = "with";
 

--- a/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.filter.rs
+++ b/crates/iota-sdk-grpc-types/src/proto/generated/iota.grpc.v1.filter.rs
@@ -195,7 +195,7 @@ pub mod command_filter {
 }
 /// Filter by transaction execution status.
 /// Set `success` to `true` to match successful transactions,
-/// or `false` to match failed transactions (cancelled, execution error, etc.).
+/// or `false` to match failed transactions (canceled, execution error, etc.).
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExecutionStatusFilter {

--- a/crates/iota-sdk-move-types/src/move_shape.rs
+++ b/crates/iota-sdk-move-types/src/move_shape.rs
@@ -56,7 +56,7 @@ pub enum Shape {
     Address,
     Vector(Box<Shape>),
     /// Move `option::Option<T>` is a one-field struct wrapping `vector<T>`;
-    /// the comparator normalises this match.
+    /// the comparator normalizes this match.
     Option(Box<Shape>),
     /// Produced for the type the derive was applied to. Compared against a
     /// `normalized::Struct.fields` of matching arity / names / per-field

--- a/crates/iota-sdk-move-types/src/move_shape_compare.rs
+++ b/crates/iota-sdk-move-types/src/move_shape_compare.rs
@@ -1145,7 +1145,7 @@ fn expected_entries() -> Vec<Entry> {
 // Package loading
 // ---------------------------------------------------------------------------
 
-/// Parse a `packages_compiled` blob into one normalised module per inner
+/// Parse a `packages_compiled` blob into one normalized module per inner
 /// bytecode payload, keyed by short module name.
 fn load_package(
     package: Package,
@@ -1296,7 +1296,7 @@ fn check_type(
 
     // Rust-side primitive-wrapper types (e.g. `ObjectId`, `Address`) come
     // through the derive as `Datatype { name, args: [] }` but represent a
-    // Move primitive on the wire. Normalise before the structural match.
+    // Move primitive on the wire. Normalize before the structural match.
     if let Shape::Datatype { name, args } = rust
         && args.is_empty()
         && matches!(*name, "ObjectId" | "Address")
@@ -1674,7 +1674,7 @@ fn rejects_option_inner_mismatch() {
     let mut fields =
         struct_fields(<iota_system::staking_pool::StakingPoolV1 as MoveShape>::move_shape());
     // `activation_epoch` is an `Option<u64>`; corrupt the inner type so the
-    // Option normalisation can't paper over it.
+    // Option normalization can't paper over it.
     let Shape::Option(inner) = &mut field_mut(&mut fields, "activation_epoch").shape else {
         panic!("activation_epoch should be an option");
     };


### PR DESCRIPTION
## Why

The codebase is US English throughout, with a handful of UK spellings scattered in comments.

## What changes

Comment-only spelling fixes, plus one internal test rename and a proto doc comment (`iota.grpc.v1.filter.rs` is the regenerated output of that proto change). Protocol identifiers that inherit the `Cancelled` spelling are handled separately in a follow-up PR.

## Test plan

`cargo check --workspace --all-features`; `make grpc` reproduces the generated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)