### PR TITLE
fix!: rename ExecutionError::MoveAuthenticationError to MoveAuthentication

### DIFF
--- a/crates/iota-sdk-ffi/src/types/execution_status.rs
+++ b/crates/iota-sdk-ffi/src/types/execution_status.rs
@@ -278,7 +278,7 @@ pub enum ExecutionError {
     /// authenticator, before the programmable transaction was run. The
     /// wrapped error is the failure produced by the authenticator's
     /// execution.
-    MoveAuthenticationError { error: Arc<ExecutionErrorWrapper> },
+    MoveAuthentication { error: Arc<ExecutionErrorWrapper> },
 }
 
 /// Holds an [`ExecutionError`] so it can be nested inside another
@@ -433,8 +433,8 @@ impl From<iota_sdk::types::ExecutionError> for ExecutionError {
                 Self::ExecutionCancelledDueToRandomnessUnavailable
             }
             iota_sdk::types::ExecutionError::InvalidLinkage => Self::InvalidLinkage,
-            iota_sdk::types::ExecutionError::MoveAuthenticationError { error } => {
-                Self::MoveAuthenticationError {
+            iota_sdk::types::ExecutionError::MoveAuthentication { error } => {
+                Self::MoveAuthentication {
                     error: Arc::new(ExecutionErrorWrapper(*error)),
                 }
             }
@@ -557,7 +557,7 @@ impl From<ExecutionError> for iota_sdk::types::ExecutionError {
                 Self::ExecutionCancelledDueToRandomnessUnavailable
             }
             ExecutionError::InvalidLinkage => Self::InvalidLinkage,
-            ExecutionError::MoveAuthenticationError { error } => Self::MoveAuthenticationError {
+            ExecutionError::MoveAuthentication { error } => Self::MoveAuthentication {
                 error: Box::new(error.0.clone()),
             },
         }

--- a/crates/iota-sdk-types/bcs-schema.abnf
+++ b/crates/iota-sdk-types/bcs-schema.abnf
@@ -220,7 +220,7 @@ execution-error = %d00                               ; InsufficientGas
                 / %d36                               ; ExecutionCancelledDueToRandomnessUnavailable
                 / %d37 (size *object-id) u64         ; ExecutionCancelledDueToSharedObjectCongestionV2
                 / %d38                               ; InvalidLinkage
-                / %d39 execution-error               ; MoveAuthenticationError
+                / %d39 execution-error               ; MoveAuthentication
 
 execution-status = %d00                                     ; Success
                  / %d01 execution-error (%d00 / %d01 u64)   ; Failure

--- a/crates/iota-sdk-types/src/execution_status.rs
+++ b/crates/iota-sdk-types/src/execution_status.rs
@@ -415,7 +415,7 @@ pub enum ExecutionError {
     /// execution.
     #[error("Move authentication failed: {error}")]
     #[cfg_attr(feature = "proptest", weight(0))]
-    MoveAuthenticationError { error: Box<ExecutionError> },
+    MoveAuthentication { error: Box<ExecutionError> },
 }
 
 impl ExecutionError {
@@ -459,7 +459,7 @@ impl ExecutionError {
         ExecutionCancelledDueToRandomnessUnavailable,
         ExecutionCancelledDueToSharedObjectCongestionV2,
         InvalidLinkage,
-        MoveAuthenticationError,
+        MoveAuthentication,
     );
 
     pub fn command_argument_error(kind: CommandArgumentError, argument: u16) -> Self {


### PR DESCRIPTION
Drops the redundant `Error` suffix from the variant, matching the other `ExecutionError` variants. BCS encoding is unchanged (index-based); the JSON tag changes with the variant name.

Closes #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)