### PR TITLE
feat: add transaction_deny_rules Move type mirrors

### DIFF
--- a/crates/iota-sdk-move-types/bcs-schema.abnf
+++ b/crates/iota-sdk-move-types/bcs-schema.abnf
@@ -283,6 +283,37 @@ token-allocation = address                 ; recipient-address
 token-distribution-schedule = u64                        ; pre-minted-supply
                               (size *token-allocation)   ; allocations
 
+transaction-deny-rules = uid         ; id
+                         versioned   ; inner
+
+transaction-deny-rules-inner-v1 = u64            ; version
+                                  linked-table   ; denied-addresses
+                                  linked-table   ; denied-objects
+                                  linked-table   ; denied-packages
+                                  bool           ; package-publish-disabled
+                                  bool           ; package-upgrade-disabled
+                                  bool           ; shared-object-disabled
+                                  bool           ; user-transaction-disabled
+                                  bool           ; receiving-objects-disabled
+                                  bool           ; move-authenticator-disabled
+
+transaction-deny-rules-updated = u64               ; epoch
+                                 (size *address)   ; added-addresses
+                                 (size *address)   ; removed-addresses
+                                 (size *id)        ; added-objects
+                                 (size *id)        ; removed-objects
+                                 (size *id)        ; added-packages
+                                 (size *id)        ; removed-packages
+                                 bool              ; package-publish-disabled
+                                 bool              ; package-upgrade-disabled
+                                 bool              ; shared-object-disabled
+                                 bool              ; user-transaction-disabled
+                                 bool              ; receiving-objects-disabled
+                                 bool              ; move-authenticator-disabled
+                                 u64               ; denied-addresses-len
+                                 u64               ; denied-objects-len
+                                 u64               ; denied-packages-len
+
 treasury-ownership-renounced = string   ; coin-name
 
 tx-context = address   ; sender

--- a/crates/iota-sdk-move-types/src/packages/iota_framework.rs
+++ b/crates/iota-sdk-move-types/src/packages/iota_framework.rs
@@ -1206,6 +1206,115 @@ pub mod linked_table {
 }
 
 /// Types from `0x2::object_table`.
+pub mod transaction_deny_rules {
+    use iota_types::Address;
+
+    use super::{
+        linked_table::LinkedTable,
+        object::{ID, UID},
+        versioned::Versioned,
+    };
+
+    /// Rust version of the Move
+    /// `iota::transaction_deny_rules::TransactionDenyRules` type.
+    ///
+    /// The shared singleton at the reserved ID `0xDE9` holding the
+    /// committee-governed transaction deny rules. The current state is a
+    /// `TransactionDenyRulesInnerV1` stored as a dynamic field of `inner`,
+    /// keyed by its version.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct TransactionDenyRules {
+        pub id: UID,
+        pub inner: Versioned,
+    }
+
+    /// Rust version of the Move
+    /// `iota::transaction_deny_rules::TransactionDenyRulesInnerV1` type.
+    ///
+    /// The deny lists are `LinkedTable` membership sets (the `bool` value is
+    /// always `true` and never read): each entry is its own child object, and
+    /// the linked keys let any reader enumerate the full set by walking
+    /// `head` → `next` with plain child-object reads.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct TransactionDenyRulesInnerV1 {
+        pub version: u64,
+        /// Addresses denied as transaction sender or gas sponsor.
+        pub denied_addresses: LinkedTable<Address, bool>,
+        /// Objects denied as transaction inputs or receiving objects.
+        pub denied_objects: LinkedTable<ID, bool>,
+        /// Packages denied as a (transitive) dependency of any command.
+        pub denied_packages: LinkedTable<ID, bool>,
+        /// Denies all package publishing.
+        pub package_publish_disabled: bool,
+        /// Denies all package upgrades.
+        pub package_upgrade_disabled: bool,
+        /// Denies transactions that use shared objects as inputs.
+        pub shared_object_disabled: bool,
+        /// Denies all user transactions (kill switch).
+        pub user_transaction_disabled: bool,
+        /// Denies transactions that contain receiving objects.
+        pub receiving_objects_disabled: bool,
+        /// Denies transactions signed with a Move authenticator.
+        pub move_authenticator_disabled: bool,
+    }
+
+    /// Rust version of the Move
+    /// `iota::transaction_deny_rules::TransactionDenyRulesUpdated` event.
+    ///
+    /// Emitted on every update; the event stream is the audit history of the
+    /// network's deny rules. Carries the delta the update requested
+    /// (tolerated no-ops included), the resulting switch states, and the
+    /// deny list sizes after applying the delta.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "bcs-schema", derive(iota_bcs_schema::BcsSchema))]
+    #[cfg_attr(
+        all(test, not(target_arch = "wasm32")),
+        derive(iota_bcs_schema::MoveShape)
+    )]
+    pub struct TransactionDenyRulesUpdated {
+        /// The epoch in which the update was executed.
+        pub epoch: u64,
+        /// Addresses added to / removed from the sender-or-sponsor deny list.
+        pub added_addresses: Vec<Address>,
+        pub removed_addresses: Vec<Address>,
+        /// Objects added to / removed from the input-or-receiving deny list.
+        pub added_objects: Vec<ID>,
+        pub removed_objects: Vec<ID>,
+        /// Packages added to / removed from the dependency deny list.
+        pub added_packages: Vec<ID>,
+        pub removed_packages: Vec<ID>,
+        /// Denies all package publishing.
+        pub package_publish_disabled: bool,
+        /// Denies all package upgrades.
+        pub package_upgrade_disabled: bool,
+        /// Denies transactions that use shared objects as inputs.
+        pub shared_object_disabled: bool,
+        /// Denies all user transactions (kill switch).
+        pub user_transaction_disabled: bool,
+        /// Denies transactions that contain receiving objects.
+        pub receiving_objects_disabled: bool,
+        /// Denies transactions signed with a Move authenticator.
+        pub move_authenticator_disabled: bool,
+        /// Deny list sizes after applying the delta.
+        pub denied_addresses_len: u64,
+        pub denied_objects_len: u64,
+        pub denied_packages_len: u64,
+    }
+}
+
 pub mod object_table {
     use core::marker::PhantomData;
 


### PR DESCRIPTION
## Why

Client-visible mirrors for the on-chain `TransactionDenyRules` object, needed before the governance flags flip. Tracked by iotaledger/iota#12613.

## What changes

Mirrors of `0x2::transaction_deny_rules`: the object, its inner state, and the update event. Shape-compare entries and the matching pin bump follow separately once the monorepo stack merges.

## Test plan

Crate tests pass. `shapes_match` verified manually with blobs fetched at iotaledger/iota#12517's tip and the entries temporarily registered.
