### PR TITLE
feat: impl From<T> for String for Address, Digest, and TypeTag

### DIFF
--- a/crates/iota-sdk-types/src/address.rs
+++ b/crates/iota-sdk-types/src/address.rs
@@ -326,6 +326,24 @@ impl From<Address> for Vec<u8> {
     }
 }
 
+impl From<&Address> for Vec<u8> {
+    fn from(value: &Address) -> Self {
+        value.0.to_vec()
+    }
+}
+
+impl From<Address> for String {
+    fn from(value: Address) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&Address> for String {
+    fn from(value: &Address) -> Self {
+        value.to_string()
+    }
+}
+
 impl From<super::ObjectId> for Address {
     fn from(value: super::ObjectId) -> Self {
         Self::from_object_id(value)

--- a/crates/iota-sdk-types/src/digest.rs
+++ b/crates/iota-sdk-types/src/digest.rs
@@ -197,6 +197,18 @@ impl std::fmt::Display for Digest {
     }
 }
 
+impl From<Digest> for String {
+    fn from(value: Digest) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&Digest> for String {
+    fn from(value: &Digest) -> Self {
+        value.to_string()
+    }
+}
+
 impl std::fmt::Debug for Digest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Digest")

--- a/crates/iota-sdk-types/src/move_core/identifier.rs
+++ b/crates/iota-sdk-types/src/move_core/identifier.rs
@@ -217,6 +217,18 @@ impl std::fmt::Display for Identifier {
     }
 }
 
+impl From<Identifier> for String {
+    fn from(value: Identifier) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&Identifier> for String {
+    fn from(value: &Identifier) -> Self {
+        value.to_string()
+    }
+}
+
 impl std::str::FromStr for Identifier {
     type Err = TypeParseError;
 

--- a/crates/iota-sdk-types/src/move_core/struct_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/struct_tag.rs
@@ -497,6 +497,18 @@ impl std::fmt::Display for StructTag {
     }
 }
 
+impl From<StructTag> for String {
+    fn from(value: StructTag) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&StructTag> for String {
+    fn from(value: &StructTag) -> Self {
+        value.to_string()
+    }
+}
+
 impl std::str::FromStr for StructTag {
     type Err = TypeParseError;
 

--- a/crates/iota-sdk-types/src/move_core/type_tag.rs
+++ b/crates/iota-sdk-types/src/move_core/type_tag.rs
@@ -192,6 +192,18 @@ impl std::fmt::Display for TypeTag {
     }
 }
 
+impl From<TypeTag> for String {
+    fn from(value: TypeTag) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&TypeTag> for String {
+    fn from(value: &TypeTag) -> Self {
+        value.to_string()
+    }
+}
+
 impl std::str::FromStr for TypeTag {
     type Err = TypeParseError;
 

--- a/crates/iota-sdk-types/src/object_id.rs
+++ b/crates/iota-sdk-types/src/object_id.rs
@@ -218,6 +218,24 @@ impl From<ObjectId> for Vec<u8> {
     }
 }
 
+impl From<&ObjectId> for Vec<u8> {
+    fn from(value: &ObjectId) -> Self {
+        (&value.0).into()
+    }
+}
+
+impl From<ObjectId> for String {
+    fn from(value: ObjectId) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<&ObjectId> for String {
+    fn from(value: &ObjectId) -> Self {
+        value.to_string()
+    }
+}
+
 impl std::str::FromStr for ObjectId {
     type Err = AddressParseError;
 


### PR DESCRIPTION
Replicates MystenLabs/sui-rust-sdk#150. Also covers `ObjectId`, which upstream merged into `Address` but is a separate type here, and `Identifier`/`StructTag` as in the upstream PR.

Closes #1320

🤖 Generated with [Claude Code](https://claude.com/claude-code)