### PR TITLE
feat: add ServiceConfig::supports_feature

### DIFF
--- a/crates/iota-sdk-graphql-client/src/query_types/service_config.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/service_config.rs
@@ -74,7 +74,14 @@ pub struct ServiceConfig {
     pub request_timeout_ms: i32,
 }
 
-#[derive(Clone, Copy, cynic::Enum, Debug)]
+impl ServiceConfig {
+    /// Whether `feature` is among the features this RPC service has enabled.
+    pub fn supports(&self, feature: Feature) -> bool {
+        self.enabled_features.contains(&feature)
+    }
+}
+
+#[derive(Clone, Copy, cynic::Enum, Debug, Eq, Hash, PartialEq)]
 #[cynic(
     schema = "rpc",
     graphql_type = "Feature",

--- a/crates/iota-sdk-graphql-client/src/query_types/service_config.rs
+++ b/crates/iota-sdk-graphql-client/src/query_types/service_config.rs
@@ -75,8 +75,8 @@ pub struct ServiceConfig {
 }
 
 impl ServiceConfig {
-    /// Whether `feature` is among the features this RPC service has enabled.
-    pub fn supports(&self, feature: Feature) -> bool {
+    /// Whether `feature` is among those this RPC service has enabled.
+    pub fn supports_feature(&self, feature: Feature) -> bool {
         self.enabled_features.contains(&feature)
     }
 }


### PR DESCRIPTION
Checking whether a node has a feature enabled meant iterating `enabled_features` and matching, since `Feature` carried no equality derives. A set-typed field isn't an option — cynic requires GraphQL list positions to be `Vec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)