### PR TITLE
chore: exclude coveralls from the link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,2 @@
-https://.*cynic-rs.dev.*
+https://.*cynic-rs\.dev.*
+https://coveralls\.io/.*


### PR DESCRIPTION
Closes #1332.

Coveralls answers 403 to any non-browser request, so the badge URL is reported as broken on every link checker run. Excluding the host is preferable to accepting 403 globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)